### PR TITLE
Prevent duplicate ID's in the search form

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -66,7 +66,6 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) :
 		add_theme_support(
 			'html5',
 			array(
-				'search-form',
 				'comment-form',
 				'comment-list',
 				'gallery',

--- a/searchform.php
+++ b/searchform.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The searchform.php template.
+ *
+ * Used any time that get_search_form() is called.
+ *
+ * @link https://developer.wordpress.org/reference/functions/wp_unique_id/
+ * @link https://developer.wordpress.org/reference/functions/get_search_form/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_One
+ * @since 1.0.0
+ */
+
+/*
+ * Generate a unique ID for each form and a string containing an aria-label
+ * if one was passed to get_search_form() in the args array.
+ */
+$twentytwentyone_unique_id = wp_unique_id( 'search-form-' );
+
+$twentytwentyone_aria_label = ! empty( $args['label'] ) ? 'aria-label="' . esc_attr( $args['label'] ) . '"' : '';
+?>
+<form role="search" <?php echo $twentytwentyone_aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<label for="<?php echo esc_attr( $twentytwentyone_unique_id ); ?>">
+		<span class="screen-reader-text"><?php _e( 'Search for:', 'twentytwentyone' ); // phpcs:ignore: WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+		<input type="search" id="<?php echo esc_attr( $twentytwentyone_unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwentyone' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
+	</label>
+	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwentyone' ); ?>" />
+</form>


### PR DESCRIPTION
Adds searchform.php, including wp_unique_id().
Removes theme_support for the HTML5 search form since it will be overwritten.

Closes #12