### PR TITLE
Add readable text color script for the customizer.

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -43,6 +43,8 @@
                 textColor = 127 < lum ? '#222' : '#fff';
 
             document.documentElement.style.setProperty( '--global--color-primary', textColor );
-		} );
+            document.documentElement.style.setProperty( '--global--color-secondary', textColor );
+            document.documentElement.style.setProperty( '--global--color-foreground', textColor );
+        } );
 	} );
 }( wp.customize, _ ) );

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -1,0 +1,48 @@
+( function( api, _ ) {
+
+    /**
+     * Get luminance from a HEX color.
+     * 
+     * @param {string} hex - The hex color.
+     * 
+     * @return {number}
+     */
+    function twentytwentyoneGetHexLum( hex ) {
+        var rgb = twentytwentyoneGetRgbFromHex( hex );
+        return Math.round( ( 0.2126 * rgb.r ) + ( 0.7152 * rgb.g ) + ( 0.0722 * rgb.b ) );
+    }
+
+    /**
+     * Get RGB from HEX.
+     * 
+     * @param {string} hex - The hex color.
+     * 
+     * @return {Object} - Returns an object {r, g, b}
+     */
+    function twentytwentyoneGetRgbFromHex( hex ) {
+        var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
+            result;
+
+        // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF").
+        hex = hex.replace( shorthandRegex, function( m, r, g, b ) {
+            return `${r}${r}${g}${g}${b}${b}`;
+        } );
+
+        result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec( hex );
+        return result ? {
+            r: parseInt( result[1], 16 ),
+            g: parseInt( result[2], 16 ),
+            b: parseInt( result[3], 16 )
+        } : null;
+    }
+
+    // Add listener for the "background_color" control.
+	api( 'background_color', function( value ) {
+		value.bind( function( to ) {
+            var lum = twentytwentyoneGetHexLum( to ),
+                textColor = 127 < lum ? '#222' : '#fff';
+
+            document.documentElement.style.setProperty( '--global--color-primary', textColor );
+		} );
+	} );
+}( wp.customize, _ ) );

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -44,7 +44,6 @@
 
             document.documentElement.style.setProperty( '--global--color-primary', textColor );
             document.documentElement.style.setProperty( '--global--color-secondary', textColor );
-            document.documentElement.style.setProperty( '--global--color-foreground', textColor );
         } );
 	} );
 }( wp.customize, _ ) );

--- a/functions.php
+++ b/functions.php
@@ -383,3 +383,21 @@ require get_template_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_template_directory() . '/inc/block-styles.php';
+
+/**
+ * Enqueue scripts for the customizer preview.
+ *
+ * @since Twenty Twenty 1.0
+ *
+ * @return void
+ */
+function twentytwentyone_customize_preview_init() {
+	wp_enqueue_script(
+		'twentytwentyone-customize-preview',
+		get_theme_file_uri( '/assets/js/customize-preview.js' ),
+		array( 'customize-preview', 'customize-selective-refresh', 'jquery' ),
+		get_theme_file_path( 'assets/js/customize-preview.js' ),
+		true
+	);
+}
+add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' );

--- a/functions.php
+++ b/functions.php
@@ -387,7 +387,7 @@ require get_template_directory() . '/inc/block-styles.php';
 /**
  * Enqueue scripts for the customizer preview.
  *
- * @since Twenty Twenty 1.0
+ * @since Twenty Twenty One 1.0
  *
  * @return void
  */


### PR DESCRIPTION
* Adds a `customize-preview.js` script
* Calculates the relative luminance of the background color
* Changes the value of the `--global--color-primary` and `--global--color--secondary` CSS variables just like the PHP logic does.