### PR TITLE
Display full width and wide content on the blog

### DIFF
--- a/template-parts/content/blog.php
+++ b/template-parts/content/blog.php
@@ -11,8 +11,8 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class( 'default-max-width' ); ?>>
-	<header class="entry-header">
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header default-max-width">
 		<?php
 		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		twenty_twenty_one_post_thumbnail();


### PR DESCRIPTION
Attempts to fix a bug where full width and wide content on the blog listing was not showing correctly.