### PR TITLE
Add color palette

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -65,12 +65,10 @@ Twenty Twenty One is distributed under the terms of the GNU GPL.
 	/* Headings */
 	/* Block: Latest posts */
 	/* Colors */
-	/* Naming? */
+	/* white 50% opacity used in form fields.*/
 	/* Body text color, site title, footer text color. */
 	/* Headings */
 	/* Mint, default body background */
-	/* Used for borders (separators) */
-	/* white 50% opacity used in form fields.*/
 	/* Used for borders (separators) */
 	/* Spacing */
 	/* Elevation */
@@ -1714,7 +1712,7 @@ blockquote.alignright footer {
 }
 
 input[type="text"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1722,7 +1720,7 @@ input[type="text"] {
 }
 
 input[type="email"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1730,7 +1728,7 @@ input[type="email"] {
 }
 
 input[type="url"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1738,7 +1736,7 @@ input[type="url"] {
 }
 
 input[type="password"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1746,7 +1744,7 @@ input[type="password"] {
 }
 
 input[type="search"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1754,7 +1752,7 @@ input[type="search"] {
 }
 
 input[type="number"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1762,7 +1760,7 @@ input[type="number"] {
 }
 
 input[type="tel"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1770,7 +1768,7 @@ input[type="tel"] {
 }
 
 input[type="range"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1778,7 +1776,7 @@ input[type="range"] {
 }
 
 input[type="date"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1786,7 +1784,7 @@ input[type="date"] {
 }
 
 input[type="month"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1794,7 +1792,7 @@ input[type="month"] {
 }
 
 input[type="week"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1802,7 +1800,7 @@ input[type="week"] {
 }
 
 input[type="time"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1810,7 +1808,7 @@ input[type="time"] {
 }
 
 input[type="datetime"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1818,7 +1816,7 @@ input[type="datetime"] {
 }
 
 input[type="datetime-local"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1826,7 +1824,7 @@ input[type="datetime-local"] {
 }
 
 input[type="color"] {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1834,7 +1832,7 @@ input[type="color"] {
 }
 
 textarea {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -1843,86 +1841,86 @@ textarea {
 
 input[type="text"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="email"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="url"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="password"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="search"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="number"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="tel"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="range"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="date"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="month"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="week"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="time"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="datetime"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="datetime-local"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 input[type="color"]:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 textarea:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 select {
-	border: 3px solid black;
+	border: 3px solid #000000;
 }
 
 textarea {
@@ -2089,7 +2087,7 @@ i {
 	color: #28303D;
 	font-size: 16px;
 	padding: 20px;
-	border-color: black;
+	border-color: #000000;
 }
 
 .wp-block-code pre {
@@ -2149,7 +2147,7 @@ i {
 }
 
 .wp-block-cover {
-	background-color: white;
+	background-color: #FFFFFF;
 	min-height: 450px;
 	margin-top: inherit;
 	margin-bottom: inherit;
@@ -2158,7 +2156,7 @@ i {
 }
 
 .wp-block-cover-image {
-	background-color: white;
+	background-color: #FFFFFF;
 	min-height: 450px;
 	margin-top: inherit;
 	margin-bottom: inherit;
@@ -2236,27 +2234,27 @@ i {
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover-text {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text {
-	color: black;
+	color: #000000;
 }
 
 .wp-block-cover h2 {
@@ -2406,13 +2404,13 @@ i {
 
 .wp-block-gallery .blocks-gallery-image figcaption {
 	margin: 0;
-	color: white;
+	color: #FFFFFF;
 	font: 16px;
 }
 
 .wp-block-gallery .blocks-gallery-item figcaption {
 	margin: 0;
-	color: white;
+	color: #FFFFFF;
 	font: 16px;
 }
 
@@ -3425,7 +3423,7 @@ p.has-text-color a {
 }
 
 .wp-block-search .wp-block-search__input {
-	border: 3px solid black;
+	border: 3px solid #000000;
 	border-radius: 0;
 	color: #28303D;
 	line-height: 1.7;
@@ -3436,19 +3434,19 @@ p.has-text-color a {
 
 .wp-block-search .wp-block-search__input:focus {
 	color: #28303D;
-	border-color: black;
+	border-color: #000000;
 }
 
 hr {
 	border-style: none;
-	border-bottom: 1px solid black;
+	border-bottom: 1px solid #000000;
 	clear: both;
 	margin-left: auto;
 	margin-right: auto;
 }
 
 hr.wp-block-separator {
-	border-bottom: 1px solid black;
+	border-bottom: 1px solid #000000;
 	/**
 		 * Block Options
 		 */
@@ -3467,7 +3465,7 @@ hr.wp-block-separator.is-style-dots.has-background:before, hr.wp-block-separator
 }
 
 hr.wp-block-separator.is-style-dots:before {
-	color: black;
+	color: #000000;
 	font-size: 28px;
 	letter-spacing: 16px;
 	padding-left: 16px;
@@ -3693,47 +3691,6 @@ table th {
 
 .has-parallax {
 	background-attachment: fixed;
-}
-
-.has-primary-color[class] {
-	color: #28303D;
-}
-
-.has-secondary-color[class] {
-	color: #39414D;
-}
-
-.has-white-color[class] {
-	color: white;
-}
-
-.has-black-color[class] {
-	color: black;
-}
-
-.has-background:not(.has-background-background-color) a,
-.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
-	color: currentColor;
-}
-
-.has-primary-background-color[class] {
-	background-color: #28303D;
-	color: #D1E4DD;
-}
-
-.has-secondary-background-color[class] {
-	background-color: #39414D;
-	color: #D1E4DD;
-}
-
-.has-white-background-color[class] {
-	background-color: white;
-	color: #39414D;
-}
-
-.has-black-background-color[class] {
-	background-color: black;
-	color: #28303D;
 }
 
 :root .is-tiny-text {
@@ -4055,7 +4012,7 @@ nav a {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 16px;
 	line-height: 1.7;
-	border-top: 3px solid black;
+	border-top: 3px solid #000000;
 	padding-top: 30px;
 	margin-top: 60px;
 }
@@ -4328,7 +4285,7 @@ h1.entry-title {
 	margin-top: 30px;
 	padding-top: 20px;
 	padding-bottom: 90px;
-	border-bottom: 1px solid black;
+	border-bottom: 1px solid #000000;
 }
 
 body:not(.single) .site-main > article:last-of-type .entry-footer {
@@ -4340,7 +4297,7 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	margin-bottom: 102px;
 	padding-bottom: 0;
 	padding-top: 24px;
-	border-top: 3px solid black;
+	border-top: 3px solid #000000;
 	border-bottom: 1px solid transparent;
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
@@ -4432,7 +4389,7 @@ h2.page-title {
 }
 
 .page-header {
-	border-bottom: 3px solid black;
+	border-bottom: 3px solid #000000;
 	padding-bottom: 60px;
 }
 
@@ -4509,7 +4466,7 @@ h2.page-title {
 }
 
 .comment-list > li:not(first-child) {
-	border-bottom: 1px solid black;
+	border-bottom: 1px solid #000000;
 }
 
 .comment-list .children {
@@ -4518,7 +4475,7 @@ h2.page-title {
 }
 
 .comment-list .children > li {
-	border-top: 1px solid black;
+	border-top: 1px solid #000000;
 	margin-top: 30px;
 	margin-bottom: 30px;
 }
@@ -5310,7 +5267,7 @@ h2.page-title {
 }
 
 .pagination {
-	border-top: 3px solid black;
+	border-top: 3px solid #000000;
 	padding-top: 30px;
 	margin: 30px 25px;
 }
@@ -5450,24 +5407,102 @@ h2.page-title {
 	outline: 0;
 }
 
-/*
-See assets\sass\05-blocks\utilities\_style.scss
-*/
-/* examples 
-.has-blue-color {
-    color: var(--color-blue);
+.has-black-color[class] {
+	color: #000000;
 }
 
-.has-blue-background-color {
-    background-color: var(--color-blue);
+.has-gray-color[class] {
+	color: #39414D;
 }
-*/
+
+.has-dark-gray-color[class] {
+	color: #28303D;
+}
+
+.has-green-color[class] {
+	color: #D1E4DD;
+}
+
+.has-blue-color[class] {
+	color: #D1DFE4;
+}
+
+.has-purple-color[class] {
+	color: #D1D1E4;
+}
+
+.has-red-color[class] {
+	color: #E4D1D1;
+}
+
+.has-orange-color[class] {
+	color: #E4DAD1;
+}
+
+.has-yellow-color[class] {
+	color: #EEEADD;
+}
+
+.has-white-color[class] {
+	color: #FFFFFF;
+}
+
+.has-background:not(.has-background-background-color) a,
+.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
+	color: currentColor;
+}
+
+.has-black-background-color[class] {
+	background-color: #000000;
+	color: #FFFFFF;
+}
+
+.has-gray-background-color[class] {
+	background-color: #39414D;
+	color: #FFFFFF;
+}
+
+.has-dark-gray-background-color[class] {
+	background-color: #28303D;
+	color: #FFFFFF;
+}
+
+.has-green-background-color[class] {
+	background-color: #D1E4DD;
+}
+
+.has-blue-background-color[class] {
+	background-color: #D1DFE4;
+}
+
+.has-purple-background-color[class] {
+	background-color: #D1D1E4;
+}
+
+.has-red-background-color[class] {
+	background-color: #E4D1D1;
+}
+
+.has-orange-background-color[class] {
+	background-color: #E4DAD1;
+}
+
+.has-yellow-background-color[class] {
+	background-color: #EEEADD;
+}
+
+.has-white-background-color[class] {
+	background-color: #FFFFFF;
+}
+
 header * {
 	max-width: unset;
 }
+
 main * {
 	max-width: unset;
 }
+
 footer * {
 	max-width: unset;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -58,20 +58,26 @@
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	/* Colors */
-	/* Naming? */
-	--global--color-primary: #28303D;
+	--global--color-black: #000000;
+	--global--color-dark-gray: #28303D;
+	--global--color-gray: #39414D;
+	--global--color-green: #D1E4DD;
+	--global--color-blue: #D1DFE4;
+	--global--color-purple: #D1D1E4;
+	--global--color-red: #E4D1D1;
+	--global--color-orange: #E4DAD1;
+	--global--color-yellow: #EEEADD;
+	--global--color-white: #FFFFFF;
+	--global--color-white-50: rgba(255, 255, 255, 0.5);
+	/* white 50% opacity used in form fields.*/
+	--global--color-primary: var(--global--color-dark-gray);
 	/* Body text color, site title, footer text color. */
-	--global--color-secondary: #39414D;
+	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var( --global--color-primary );
 	--global--color-secondary-hover: var( --global--color-secondary );
-	--global--color-background: #D1E4DD;
+	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
-	--global--color-black: black;
-	/* Used for borders (separators) */
-	--global--color-white: white;
-	--global--color-white-50: rgba(255, 255, 255, 0.5);
-	/* white 50% opacity used in form fields.*/
 	--global--color-border: var( --global--color-black );
 	/* Used for borders (separators) */
 	/* Spacing */
@@ -1393,4 +1399,92 @@ body {
 button,
 a {
 	cursor: pointer;
+}
+
+.has-black-color[class] {
+	color: var(--global--color-black);
+}
+
+.has-gray-color[class] {
+	color: var(--global--color-gray);
+}
+
+.has-dark-gray-color[class] {
+	color: var(--global--color-dark-gray);
+}
+
+.has-green-color[class] {
+	color: var(--global--color-green);
+}
+
+.has-blue-color[class] {
+	color: var(--global--color-blue);
+}
+
+.has-purple-color[class] {
+	color: var(--global--color-purple);
+}
+
+.has-red-color[class] {
+	color: var(--global--color-red);
+}
+
+.has-orange-color[class] {
+	color: var(--global--color-orange);
+}
+
+.has-yellow-color[class] {
+	color: var(--global--color-yellow);
+}
+
+.has-white-color[class] {
+	color: var(--global--color-white);
+}
+
+.has-background:not(.has-background-background-color) a,
+.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
+	color: currentColor;
+}
+
+.has-black-background-color[class] {
+	background-color: var(--global--color-black);
+	color: var(--global--color-white);
+}
+
+.has-gray-background-color[class] {
+	background-color: var(--global--color-gray);
+	color: var(--global--color-white);
+}
+
+.has-dark-gray-background-color[class] {
+	background-color: var(--global--color-dark-gray);
+	color: var(--global--color-white);
+}
+
+.has-green-background-color[class] {
+	background-color: var(--global--color-green);
+}
+
+.has-blue-background-color[class] {
+	background-color: var(--global--color-blue);
+}
+
+.has-purple-background-color[class] {
+	background-color: var(--global--color-purple);
+}
+
+.has-red-background-color[class] {
+	background-color: var(--global--color-red);
+}
+
+.has-orange-background-color[class] {
+	background-color: var(--global--color-orange);
+}
+
+.has-yellow-background-color[class] {
+	background-color: var(--global--color-yellow);
+}
+
+.has-white-background-color[class] {
+	background-color: var(--global--color-white);
 }

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -74,19 +74,23 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--definition-term--font-family: var(--global--font-primary);
 
 	/* Colors */
-	/* Naming? */
-	--global--color-primary: #28303D; /* Body text color, site title, footer text color. */
-	--global--color-secondary: #39414D; /* Headings */
-
-	--global--color-primary-hover: var( --global--color-primary );
-	--global--color-secondary-hover: var( --global--color-secondary );
-
-	--global--color-background: #D1E4DD; /* Mint, default body background */
-
-	--global--color-black: black; /* Used for borders (separators) */
-	--global--color-white: white;
+	--global--color-black: #000000;
+	--global--color-dark-gray: #28303D;
+	--global--color-gray: #39414D;
+	--global--color-green: #D1E4DD;
+	--global--color-blue: #D1DFE4;
+	--global--color-purple: #D1D1E4;
+	--global--color-red: #E4D1D1;
+	--global--color-orange: #E4DAD1;
+	--global--color-yellow: #EEEADD;
+	--global--color-white: #FFFFFF;
 	--global--color-white-50: rgba(255, 255, 255, 0.5); /* white 50% opacity used in form fields.*/
 
+	--global--color-primary: var(--global--color-dark-gray); /* Body text color, site title, footer text color. */
+	--global--color-secondary: var(--global--color-gray); /* Headings */
+	--global--color-primary-hover: var( --global--color-primary );
+	--global--color-secondary-hover: var( --global--color-secondary );
+	--global--color-background: var(--global--color-green); /* Mint, default body background */
 	--global--color-border: var( --global--color-black ); /* Used for borders (separators) */
 
 	/* Spacing */

--- a/assets/sass/05-blocks/utilities/_style.scss
+++ b/assets/sass/05-blocks/utilities/_style.scss
@@ -112,53 +112,6 @@
 	background-attachment: fixed;
 }
 
-// Gutenberg text color options
-.has-text-color {}
-
-.has-primary-color[class] {
-	color: var(--global--color-primary);
-}
-
-.has-secondary-color[class] {
-	color: var(--global--color-secondary);
-}
-
-.has-white-color[class] {
-	color: var(--global--color-white);
-}
-
-.has-black-color[class] {
-	color: var(--global--color-black);
-}
-
-// Gutenberg background-color options
-.has-background {
-	&:not(.has-background-background-color) a,
-	p, h1, h2, h3, h4, h5, h6 {
-		color: currentColor;
-	}
-}
-
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-secondary-background-color[class] {
-	background-color: var(--global--color-secondary);
-	color: var(--global--color-background);
-}
-
-.has-white-background-color[class] {
-	background-color: var(--global--color-white);
-	color: var(--global--color-secondary);
-}
-
-.has-black-background-color[class] {
-	background-color: var(--global--color-black);
-	color: var(--global--color-primary);
-}
-
 // Gutenberg Font-size options
 :root {
 	.is-tiny-text,

--- a/assets/sass/07-utilities/color-palette.scss
+++ b/assets/sass/07-utilities/color-palette.scss
@@ -1,14 +1,94 @@
-/*
-See assets\sass\05-blocks\utilities\_style.scss
-*/
+// Gutenberg text color options
 
-/* examples 
-.has-blue-color {
-    color: var(--color-blue);
+.has-text-color {}
+
+.has-black-color[class] {
+	color: var(--global--color-black);
 }
 
-.has-blue-background-color {
-    background-color: var(--color-blue);
+.has-gray-color[class] {
+	color: var(--global--color-gray);
 }
-*/
 
+.has-dark-gray-color[class] {
+	color: var(--global--color-dark-gray);
+}
+
+.has-green-color[class] {
+	color: var(--global--color-green);
+}
+
+.has-blue-color[class] {
+	color: var(--global--color-blue);
+}
+
+.has-purple-color[class] {
+	color: var(--global--color-purple);
+}
+
+.has-red-color[class] {
+	color: var(--global--color-red);
+}
+
+.has-orange-color[class] {
+	color: var(--global--color-orange);
+}
+
+.has-yellow-color[class] {
+	color: var(--global--color-yellow);
+}
+
+.has-white-color[class] {
+	color: var(--global--color-white);
+}
+
+// Gutenberg background-color options
+.has-background {
+	&:not(.has-background-background-color) a,
+	p, h1, h2, h3, h4, h5, h6 {
+		color: currentColor;
+	}
+}
+
+.has-black-background-color[class] {
+	background-color: var(--global--color-black);
+	color: var(--global--color-white);
+}
+
+.has-gray-background-color[class] {
+	background-color: var(--global--color-gray);
+	color: var(--global--color-white);
+}
+
+.has-dark-gray-background-color[class] {
+	background-color: var(--global--color-dark-gray);
+	color: var(--global--color-white);
+}
+
+.has-green-background-color[class] {
+	background-color: var(--global--color-green);
+}
+
+.has-blue-background-color[class] {
+	background-color: var(--global--color-blue);
+}
+
+.has-purple-background-color[class] {
+	background-color: var(--global--color-purple);
+}
+
+.has-red-background-color[class] {
+	background-color: var(--global--color-red);
+}
+
+.has-orange-background-color[class] {
+	background-color: var(--global--color-orange);
+}
+
+.has-yellow-background-color[class] {
+	background-color: var(--global--color-yellow);
+}
+
+.has-white-background-color[class] {
+	background-color: var(--global--color-white);
+}

--- a/assets/sass/style-editor.scss
+++ b/assets/sass/style-editor.scss
@@ -16,3 +16,5 @@
 @import "05-blocks/blocks-editor";
 
 @import "06-components/editor";
+
+@import "07-utilities/color-palette";

--- a/functions.php
+++ b/functions.php
@@ -160,28 +160,70 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) :
 		);
 
 		// Editor color palette.
-		$primary   = '#28303D';
-		$secondary = '#39414D';
-		$mint      = '#D1E4DD';
+		$black      = '#000000';
+		$dark_gray  = '#28303D';
+		$gray       = '#39414D';
+		$green      = '#D1E4DD';
+		$blue       = '#D1DFE4';
+		$purple     = '#D1D1E4';
+		$red        = '#E4D1D1';
+		$orange     = '#E4DAD1';
+		$yellow     = '#EEEADD';
+		$white      = '#FFFFFF';
 
 		add_theme_support(
 			'editor-color-palette',
 			array(
 				array(
-					'name'  => __( 'Primary', 'twentytwentyone' ),
-					'slug'  => 'primary',
-					'color' => $primary,
+					'name'  => __( 'Black', 'twentytwentyone' ),
+					'slug'  => 'black',
+					'color' => $black,
 				),
 				array(
-					'name'  => __( 'Secondary', 'twentytwentyone' ),
-					'slug'  => 'secondary',
-					'color' => $secondary,
+					'name'  => __( 'Dark Gray', 'twentytwentyone' ),
+					'slug'  => 'dark-gray',
+					'color' => $dark_gray,
 				),
 				array(
-					'name'  => __( 'Mint', 'twentytwentyone' ),
-					'slug'  => 'mint',
-					'color' => $mint,
+					'name'  => __( 'Gray', 'twentytwentyone' ),
+					'slug'  => 'gray',
+					'color' => $gray,
 				),
+				array(
+					'name'  => __( 'Green', 'twentytwentyone' ),
+					'slug'  => 'green',
+					'color' => $green,
+				),
+				array(
+					'name'  => __( 'Blue', 'twentytwentyone' ),
+					'slug'  => 'blue',
+					'color' => $blue,
+				),
+				array(
+					'name'  => __( 'Purple', 'twentytwentyone' ),
+					'slug'  => 'purple',
+					'color' => $purple,
+				),
+				array(
+					'name'  => __( 'Red', 'twentytwentyone' ),
+					'slug'  => 'red',
+					'color' => $red,
+				),
+				array(
+					'name'  => __( 'Orange', 'twentytwentyone' ),
+					'slug'  => 'orange',
+					'color' => $orange,
+				),
+				array(
+					'name'  => __( 'Yellow', 'twentytwentyone' ),
+					'slug'  => 'yellow',
+					'color' => $yellow,
+				),
+				array(
+					'name'  => __( 'White', 'twentytwentyone' ),
+					'slug'  => 'white',
+					'color' => $white,
+				)
 			)
 		);
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -113,20 +113,26 @@ Twenty Twenty One is distributed under the terms of the GNU GPL.
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	/* Colors */
-	/* Naming? */
-	--global--color-primary: #28303D;
+	--global--color-black: #000000;
+	--global--color-dark-gray: #28303D;
+	--global--color-gray: #39414D;
+	--global--color-green: #D1E4DD;
+	--global--color-blue: #D1DFE4;
+	--global--color-purple: #D1D1E4;
+	--global--color-red: #E4D1D1;
+	--global--color-orange: #E4DAD1;
+	--global--color-yellow: #EEEADD;
+	--global--color-white: #FFFFFF;
+	--global--color-white-50: rgba(255, 255, 255, 0.5);
+	/* white 50% opacity used in form fields.*/
+	--global--color-primary: var(--global--color-dark-gray);
 	/* Body text color, site title, footer text color. */
-	--global--color-secondary: #39414D;
+	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var( --global--color-primary );
 	--global--color-secondary-hover: var( --global--color-secondary );
-	--global--color-background: #D1E4DD;
+	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
-	--global--color-black: black;
-	/* Used for borders (separators) */
-	--global--color-white: white;
-	--global--color-white-50: rgba(255, 255, 255, 0.5);
-	/* white 50% opacity used in form fields.*/
 	--global--color-border: var( --global--color-black );
 	/* Used for borders (separators) */
 	/* Spacing */
@@ -2483,47 +2489,6 @@ table th,
 	background-attachment: fixed;
 }
 
-.has-primary-color[class] {
-	color: var(--global--color-primary);
-}
-
-.has-secondary-color[class] {
-	color: var(--global--color-secondary);
-}
-
-.has-white-color[class] {
-	color: var(--global--color-white);
-}
-
-.has-black-color[class] {
-	color: var(--global--color-black);
-}
-
-.has-background:not(.has-background-background-color) a,
-.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
-	color: currentColor;
-}
-
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-secondary-background-color[class] {
-	background-color: var(--global--color-secondary);
-	color: var(--global--color-background);
-}
-
-.has-white-background-color[class] {
-	background-color: var(--global--color-white);
-	color: var(--global--color-secondary);
-}
-
-.has-black-background-color[class] {
-	background-color: var(--global--color-black);
-	color: var(--global--color-primary);
-}
-
 :root .is-tiny-text,
 :root .has-tiny-font-size {
 	font-size: var(--global--font-size-xs);
@@ -4041,18 +4006,94 @@ h2.page-title {
 	outline: 0;
 }
 
-/*
-See assets\sass\05-blocks\utilities\_style.scss
-*/
-/* examples 
-.has-blue-color {
-    color: var(--color-blue);
+.has-black-color[class] {
+	color: var(--global--color-black);
 }
 
-.has-blue-background-color {
-    background-color: var(--color-blue);
+.has-gray-color[class] {
+	color: var(--global--color-gray);
 }
-*/
+
+.has-dark-gray-color[class] {
+	color: var(--global--color-dark-gray);
+}
+
+.has-green-color[class] {
+	color: var(--global--color-green);
+}
+
+.has-blue-color[class] {
+	color: var(--global--color-blue);
+}
+
+.has-purple-color[class] {
+	color: var(--global--color-purple);
+}
+
+.has-red-color[class] {
+	color: var(--global--color-red);
+}
+
+.has-orange-color[class] {
+	color: var(--global--color-orange);
+}
+
+.has-yellow-color[class] {
+	color: var(--global--color-yellow);
+}
+
+.has-white-color[class] {
+	color: var(--global--color-white);
+}
+
+.has-background:not(.has-background-background-color) a,
+.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
+	color: currentColor;
+}
+
+.has-black-background-color[class] {
+	background-color: var(--global--color-black);
+	color: var(--global--color-white);
+}
+
+.has-gray-background-color[class] {
+	background-color: var(--global--color-gray);
+	color: var(--global--color-white);
+}
+
+.has-dark-background-gray-color[class] {
+	background-color: var(--global--color-dark-gray);
+	color: var(--global--color-white);
+}
+
+.has-green-background-color[class] {
+	background-color: var(--global--color-green);
+}
+
+.has-blue-background-color[class] {
+	background-color: var(--global--color-blue);
+}
+
+.has-purple-background-color[class] {
+	background-color: var(--global--color-purple);
+}
+
+.has-red-background-color[class] {
+	background-color: var(--global--color-red);
+}
+
+.has-orange-background-color[class] {
+	background-color: var(--global--color-orange);
+}
+
+.has-yellow-background-color[class] {
+	background-color: var(--global--color-yellow);
+}
+
+.has-white-background-color[class] {
+	background-color: var(--global--color-white);
+}
+
 header *,
 main *,
 footer * {

--- a/style.css
+++ b/style.css
@@ -113,20 +113,26 @@ Twenty Twenty One is distributed under the terms of the GNU GPL.
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	/* Colors */
-	/* Naming? */
-	--global--color-primary: #28303D;
+	--global--color-black: #000000;
+	--global--color-dark-gray: #28303D;
+	--global--color-gray: #39414D;
+	--global--color-green: #D1E4DD;
+	--global--color-blue: #D1DFE4;
+	--global--color-purple: #D1D1E4;
+	--global--color-red: #E4D1D1;
+	--global--color-orange: #E4DAD1;
+	--global--color-yellow: #EEEADD;
+	--global--color-white: #FFFFFF;
+	--global--color-white-50: rgba(255, 255, 255, 0.5);
+	/* white 50% opacity used in form fields.*/
+	--global--color-primary: var(--global--color-dark-gray);
 	/* Body text color, site title, footer text color. */
-	--global--color-secondary: #39414D;
+	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var( --global--color-primary );
 	--global--color-secondary-hover: var( --global--color-secondary );
-	--global--color-background: #D1E4DD;
+	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
-	--global--color-black: black;
-	/* Used for borders (separators) */
-	--global--color-white: white;
-	--global--color-white-50: rgba(255, 255, 255, 0.5);
-	/* white 50% opacity used in form fields.*/
 	--global--color-border: var( --global--color-black );
 	/* Used for borders (separators) */
 	/* Spacing */
@@ -2496,47 +2502,6 @@ table th,
 	background-attachment: fixed;
 }
 
-.has-primary-color[class] {
-	color: var(--global--color-primary);
-}
-
-.has-secondary-color[class] {
-	color: var(--global--color-secondary);
-}
-
-.has-white-color[class] {
-	color: var(--global--color-white);
-}
-
-.has-black-color[class] {
-	color: var(--global--color-black);
-}
-
-.has-background:not(.has-background-background-color) a,
-.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
-	color: currentColor;
-}
-
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-secondary-background-color[class] {
-	background-color: var(--global--color-secondary);
-	color: var(--global--color-background);
-}
-
-.has-white-background-color[class] {
-	background-color: var(--global--color-white);
-	color: var(--global--color-secondary);
-}
-
-.has-black-background-color[class] {
-	background-color: var(--global--color-black);
-	color: var(--global--color-primary);
-}
-
 :root .is-tiny-text,
 :root .has-tiny-font-size {
 	font-size: var(--global--font-size-xs);
@@ -4066,18 +4031,94 @@ h2.page-title {
 	outline: 0;
 }
 
-/*
-See assets\sass\05-blocks\utilities\_style.scss
-*/
-/* examples 
-.has-blue-color {
-    color: var(--color-blue);
+.has-black-color[class] {
+	color: var(--global--color-black);
 }
 
-.has-blue-background-color {
-    background-color: var(--color-blue);
+.has-gray-color[class] {
+	color: var(--global--color-gray);
 }
-*/
+
+.has-dark-gray-color[class] {
+	color: var(--global--color-dark-gray);
+}
+
+.has-green-color[class] {
+	color: var(--global--color-green);
+}
+
+.has-blue-color[class] {
+	color: var(--global--color-blue);
+}
+
+.has-purple-color[class] {
+	color: var(--global--color-purple);
+}
+
+.has-red-color[class] {
+	color: var(--global--color-red);
+}
+
+.has-orange-color[class] {
+	color: var(--global--color-orange);
+}
+
+.has-yellow-color[class] {
+	color: var(--global--color-yellow);
+}
+
+.has-white-color[class] {
+	color: var(--global--color-white);
+}
+
+.has-background:not(.has-background-background-color) a,
+.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
+	color: currentColor;
+}
+
+.has-black-background-color[class] {
+	background-color: var(--global--color-black);
+	color: var(--global--color-white);
+}
+
+.has-gray-background-color[class] {
+	background-color: var(--global--color-gray);
+	color: var(--global--color-white);
+}
+
+.has-dark-gray-background-color[class] {
+	background-color: var(--global--color-dark-gray);
+	color: var(--global--color-white);
+}
+
+.has-green-background-color[class] {
+	background-color: var(--global--color-green);
+}
+
+.has-blue-background-color[class] {
+	background-color: var(--global--color-blue);
+}
+
+.has-purple-background-color[class] {
+	background-color: var(--global--color-purple);
+}
+
+.has-red-background-color[class] {
+	background-color: var(--global--color-red);
+}
+
+.has-orange-background-color[class] {
+	background-color: var(--global--color-orange);
+}
+
+.has-yellow-background-color[class] {
+	background-color: var(--global--color-yellow);
+}
+
+.has-white-background-color[class] {
+	background-color: var(--global--color-white);
+}
+
 header *,
 main *,
 footer * {


### PR DESCRIPTION
Closes #49.

This PR adds the custom color palette as described in #49. A few notes: 

- I opted to call `#28303D` "Dark Gray" instead of "Black" since we already have a pure black color variable (this also led to me renaming `#39414D` to just "Gray"). 
- I also added a true black to the palette while I was in here since this seemed like something folks might want (@melchoyce does that seem alright on your end?)
- I separated these out from their "Primary", "Secondary" color names, so that they're more descriptive.

Editor: 

![Screen Shot 2020-09-17 at 3 32 33 PM](https://user-images.githubusercontent.com/1202812/93518969-947e3400-f8fb-11ea-838b-79a49d86c3df.png)

Front end: 

![Screen Shot 2020-09-17 at 3 32 47 PM](https://user-images.githubusercontent.com/1202812/93518980-9942e800-f8fb-11ea-8519-92283a7b232a.png)
