### PR TITLE
Change calculated color to black from dark-gray

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -2,9 +2,9 @@
 
     /**
      * Get luminance from a HEX color.
-     * 
+     *
      * @param {string} hex - The hex color.
-     * 
+     *
      * @return {number}
      */
     function twentytwentyoneGetHexLum( hex ) {
@@ -14,9 +14,9 @@
 
     /**
      * Get RGB from HEX.
-     * 
+     *
      * @param {string} hex - The hex color.
-     * 
+     *
      * @return {Object} - Returns an object {r, g, b}
      */
     function twentytwentyoneGetRgbFromHex( hex ) {
@@ -40,7 +40,7 @@
 	api( 'background_color', function( value ) {
 		value.bind( function( to ) {
             var lum = twentytwentyoneGetHexLum( to ),
-                textColor = 127 < lum ? '#222' : '#fff';
+                textColor = 127 < lum ? '#000' : '#fff';
 
             document.documentElement.style.setProperty( '--global--color-primary', textColor );
             document.documentElement.style.setProperty( '--global--color-secondary', textColor );

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -31,7 +31,7 @@ class Twenty_Twenty_One_Custom_Colors {
 	}
 
 	/**
-	 * Determine the luminance of the given color and then return #FFFFFF or #222222 so that our text is always readable.
+	 * Determine the luminance of the given color and then return #fff or #000 so that our text is always readable.
 	 *
 	 * @access public
 	 *
@@ -40,7 +40,7 @@ class Twenty_Twenty_One_Custom_Colors {
 	 * @return string (hex color)
 	 */
 	public function custom_get_readable_color( $background_color ) {
-		return ( 127 < $this->get_relative_luminance_from_hex( $background_color ) ) ? '#222222' : '#FFFFFF';
+		return ( 127 < $this->get_relative_luminance_from_hex( $background_color ) ) ? '#000' : '#fff';
 	}
 
 	/**


### PR DESCRIPTION
When the user changes their background-color we auto-calculate the text-color for maximum contrast.
The calculated text-color should be `#000` instead of `#222` as that will ensure maximum contrast and be closer to AAA than what `#222` would be.