### PR TITLE
Remove unused foreground color

### DIFF
--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -64,7 +64,6 @@ class Twenty_Twenty_One_Custom_Colors {
 			$theme_css .= '--global--color-background: #' . get_theme_mod( 'background_color', 'D1E4DD' ) . ';';
 			$theme_css .= '--global--color-primary: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
 			$theme_css .= '--global--color-secondary: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
-			$theme_css .= '--global--color-foreground: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
 		}
 
 		$theme_css .= '}';


### PR DESCRIPTION
Removes the last trace of the old `foreground-color` variable, as found by @carolinan in https://github.com/WordPress/twentytwentyone/issues/44#issuecomment-694878429. 

