### PR TITLE
image.php: fix warning due to improper use of printf placeholders

### DIFF
--- a/image.php
+++ b/image.php
@@ -63,7 +63,7 @@ while ( have_posts() ) :
 			$metadata = wp_get_attachment_metadata();
 			if ( $metadata ) {
 				printf(
-					'<span class="full-size-link"><span class="screen-reader-text">%1$s</span><a href="%2$s">%2$s &times; %5$s</a></span>',
+					'<span class="full-size-link"><span class="screen-reader-text">%1$s</span><a href="%2$s">%3$s &times; %4$s</a></span>',
 					_x( 'Full size', 'Used before full size attachment link.', 'twentytwentyone' ), // phpcs:ignore WordPress.Security.EscapeOutput
 					esc_url( wp_get_attachment_url() ),
 					absint( $metadata['width'] ),


### PR DESCRIPTION
See #74, comment by @carolinan: `image.php` has a warning due to an improper use of placeholders in `printf` function.

