### PR TITLE
Add stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,9 @@
+{
+	"extends": [
+		"stylelint-config-wordpress/scss"
+	],
+	"rules": {
+		"no-descending-specificity": null
+	}
+}
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
 		"postcss-custom-media": "^7.0.8",
 		"postcss-focus-within": "^3.0.0",
 		"postcss-nested": "^4.2.1",
-		"rtlcss": "^2.4.0"
+		"rtlcss": "^2.4.0",
+		"stylelint": "^13.7.1",
+		"stylelint-config-recommended-scss": "^4.2.0",
+		"stylelint-config-wordpress": "^17.0.0"
 	},
 	"rtlcssConfig": {
 		"options": {
@@ -52,6 +55,8 @@
 		"build:ie": "postcss style.css -o assets/css/ie.css",
 		"build:ie-editor": "postcss assets/css/style-editor.css -o assets/css/ie-editor.css",
 		"build": "run-s \"build:*\"",
-		"watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"
+		"watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
+		"lint:scss": "stylelint assets/sass/*.scss",
+		"lint:css": "stylelint **/*.css"
 	}
 }


### PR DESCRIPTION
Adds new dev dependencies:
"stylelint": "^13.7.1",
"stylelint-config-recommended-scss": "^4.2.0",
"stylelint-config-wordpress": "^17.0.0"

config
```
{
	"extends": [
		"stylelint-config-wordpress/scss"
	],
	"rules": {
		"no-descending-specificity": null
	}
}
```

scripts:
```
"lint:scss": "stylelint assets/sass/*.scss",
"lint:css": "stylelint **/*.css"
```
