### PR TITLE
Unlink the homepage logo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -84,10 +84,11 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 240, // TODO: Is this the correct logo size?
-				'width'       => 240,
-				'flex-width'  => false,
-				'flex-height' => false,
+				'height'               => 240,
+				'width'                => 240,
+				'flex-width'           => false,
+				'flex-height'          => false,
+				'unlink-homepage-logo' => true,
 			)
 		);
 


### PR DESCRIPTION
Step one of https://github.com/WordPress/twentytwentyone/issues/57
See https://make.wordpress.org/core/2020/07/28/themes-changes-related-to-get_custom_logo-in-wordpress-5-5/