### PR TITLE
Try a "narrow title" template

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3559,6 +3559,11 @@ nav a {
 	margin-bottom: 90px;
 }
 
+.post-template-template-narrow-title .entry-header {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
 .single .has-post-thumbnail .entry-header {
 	border-bottom: none;
 	padding-bottom: 39px;

--- a/assets/sass/06-components/single.scss
+++ b/assets/sass/06-components/single.scss
@@ -4,6 +4,11 @@
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.post-template-template-narrow-title .entry-header {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
 .single .has-post-thumbnail .entry-header {
 	border-bottom: none;
 	padding-bottom: calc(1.3 * var(--global--spacing-vertical));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2683,6 +2683,11 @@ nav a {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.post-template-template-narrow-title .entry-header {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
 .single .has-post-thumbnail .entry-header {
 	border-bottom: none;
 	padding-bottom: calc(1.3 * var(--global--spacing-vertical));

--- a/style.css
+++ b/style.css
@@ -2696,6 +2696,11 @@ nav a {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.post-template-template-narrow-title .entry-header {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
 .single .has-post-thumbnail .entry-header {
 	border-bottom: none;
 	padding-bottom: calc(1.3 * var(--global--spacing-vertical));

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -13,7 +13,13 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-	<header class="entry-header alignwide">
+	<header class="entry-header <?php 
+		if ( is_page_template( 'templates/template-narrow-title.php' ) ) { 
+			echo esc_attr( 'default-max-width' ); } 
+		else { 
+			echo esc_attr( 'alignwide' );
+		} 
+	?>">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header>
 

--- a/templates/template-narrow-title.php
+++ b/templates/template-narrow-title.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Template Name: Narrow Title
+ * Template Post Type: post, page
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_One
+ * @since 1.0.0
+ */
+
+get_template_part( 'single' );


### PR DESCRIPTION
Tries out having a separate page template for a narrower page title. As brought up in https://github.com/WordPress/twentytwentyone/issues/37#issuecomment-696235187. 

Just an idea to see how we think it's working. 

---

![Screen Shot 2020-09-21 at 4 09 40 PM](https://user-images.githubusercontent.com/1202812/93816605-c0642700-fc25-11ea-8b93-91aeaf750f68.png)

Standard Post/Page Header: 

![gutenberg test__p=1637](https://user-images.githubusercontent.com/1202812/93816631-cbb75280-fc25-11ea-8053-db0424684e97.png)

With "Narrow Title" template active: 

![gutenberg test__p=1637 (1)](https://user-images.githubusercontent.com/1202812/93816664-d70a7e00-fc25-11ea-8cd7-a49639c0f993.png)
