### PR TITLE
Fix search block styling

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1253,7 +1253,6 @@ p.has-background {
 }
 
 .wp-block-search {
-	display: flex;
 	max-width: calc(100vw - 30px);
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3015,7 +3015,6 @@ p.has-text-color a {
 }
 
 .wp-block-search {
-	display: flex;
 	max-width: calc(100vw - 30px);
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1004,7 +1004,6 @@ p.has-background {
 }
 
 .wp-block-search {
-	display: flex;
 	max-width: var(--responsive--aligndefault-width);
 }
 

--- a/assets/sass/05-blocks/search/_editor.scss
+++ b/assets/sass/05-blocks/search/_editor.scss
@@ -1,5 +1,4 @@
 .wp-block-search {
-	display: flex;
 	max-width: var(--responsive--aligndefault-width);
 
 	.wp-block-search__label {

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -1,5 +1,4 @@
 .wp-block-search {
-	display: flex;
 	max-width: var(--responsive--aligndefault-width);
 
 	.wp-block-search__label {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2222,7 +2222,6 @@ p.has-text-color a {
 }
 
 .wp-block-search {
-	display: flex;
 	max-width: var(--responsive--aligndefault-width);
 }
 

--- a/style.css
+++ b/style.css
@@ -2230,7 +2230,6 @@ p.has-text-color a {
 }
 
 .wp-block-search {
-	display: flex;
 	max-width: var(--responsive--aligndefault-width);
 }
 


### PR DESCRIPTION
This PR addresses a small bug in the way the search block was displayed on the front-end and in the editor.

**Before**
<img width="645" alt="Screen Shot 2020-09-21 at 4 37 41 PM" src="https://user-images.githubusercontent.com/5375500/93818770-cb6c8680-fc28-11ea-871d-470962f53ff6.png">

**After**
<img width="649" alt="Screen Shot 2020-09-21 at 4 37 16 PM" src="https://user-images.githubusercontent.com/5375500/93818779-ce677700-fc28-11ea-9935-f9d6218989c6.png">
