### PR TITLE
Give wide content a max width of 1240px

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -121,7 +121,7 @@ Example:
 
 @media only screen and (min-width: 652px) {
 	.wide-max-width {
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -1534,7 +1534,7 @@ pre.wp-block-verse {
 
 @media only screen and (min-width: 652px) {
 	.wp-block[data-align="wide"] {
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -1544,7 +1544,7 @@ pre.wp-block-verse {
 
 @media only screen and (min-width: 652px) {
 	.wp-block.alignwide {
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -735,7 +735,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.wide-max-width{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -747,7 +747,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.alignwide{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -759,7 +759,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.site-header{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -771,7 +771,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.site-footer{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -833,7 +833,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.alignwide [class*="inner-container"] > .alignwide{
-	width: calc(100vw - 200px);
+	width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -846,7 +846,7 @@ hr.wp-block-separator.is-style-wide {
 
 @media only screen and (min-width: 652px){
 	.alignfull [class*="inner-container"] > .alignwide{
-	width: calc(100vw - 200px);
+	width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -2819,7 +2819,7 @@ p.has-text-color a {
 
 @media only screen and (min-width: 652px){
 	.wp-block-pullquote.alignwide > p{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 
@@ -2829,7 +2829,7 @@ p.has-text-color a {
 
 @media only screen and (min-width: 652px){
 	.wp-block-pullquote.alignwide blockquote{
-	max-width: calc(100vw - 200px);
+	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -275,7 +275,7 @@ Example:
 @media only screen and (min-width: 652px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
-		--responsive--alignwide-width: calc(100vw - 8 * var(--global--spacing-horizontal));
+		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
 	}
 }
 

--- a/assets/sass/03-generic/breakpoints.scss
+++ b/assets/sass/03-generic/breakpoints.scss
@@ -7,6 +7,7 @@
  */
 
 $default_width: 610px;
+$max_content_width: 1240px;
 $breakpoint_sm: 482px;
 $breakpoint_md: 592px;
 $breakpoint_lg: 652px;
@@ -99,7 +100,7 @@ $breakpoint_xxl: 1024px;
 @include media(laptop) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), #{$default_width});
-		--responsive--alignwide-width: calc(100vw - 8 * var(--global--spacing-horizontal));
+		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), #{$max_content_width});
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -696,7 +696,7 @@ template {
 @media only screen and (min-width: 652px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
-		--responsive--alignwide-width: calc(100vw - 8 * var(--global--spacing-horizontal));
+		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -696,7 +696,7 @@ template {
 @media only screen and (min-width: 652px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
-		--responsive--alignwide-width: calc(100vw - 8 * var(--global--spacing-horizontal));
+		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
 	}
 }
 


### PR DESCRIPTION
This PR sets the max width of elements with `alignwide` to 1240px. Previously the `alignwide` class allowed wide width content to expand indefinitely. 

**Before (2560px wide screen)**
<img width="2672" alt="Screen Shot 2020-09-21 at 4 56 22 PM" src="https://user-images.githubusercontent.com/5375500/93820661-7e3de400-fc2b-11ea-8883-e220778808f3.png">

**After (2560px wide screen)**
<img width="2672" alt="Screen Shot 2020-09-21 at 4 56 09 PM" src="https://user-images.githubusercontent.com/5375500/93820672-81d16b00-fc2b-11ea-94d6-79190a7bc1fb.png">
