### PR TITLE
Add spacing for tablet device range

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -107,7 +107,12 @@ Example:
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.default-max-width {
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px) {
 	.default-max-width {
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -119,7 +124,13 @@ Example:
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.wide-max-width {
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.wide-max-width {
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -1257,7 +1268,13 @@ p.has-background {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.wp-block-search {
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.wp-block-search {
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -1522,7 +1539,12 @@ pre.wp-block-verse {
 .wp-block {
 	max-width: calc(100vw - 30px);
 }
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.wp-block {
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px) {
 	.wp-block {
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -1532,7 +1554,13 @@ pre.wp-block-verse {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.wp-block[data-align="wide"] {
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.wp-block[data-align="wide"] {
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -1542,7 +1570,13 @@ pre.wp-block-verse {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.wp-block.alignwide {
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.wp-block.alignwide {
 	max-width: min(calc(100vw - 200px), 1240px);
 	}

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -671,7 +671,12 @@ template {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.default-max-width{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	.default-max-width{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -681,7 +686,12 @@ hr.wp-block-separator.is-style-wide {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	hr.wp-block-separator.is-style-wide{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	hr.wp-block-separator.is-style-wide{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -691,7 +701,12 @@ hr.wp-block-separator.is-style-wide {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce){
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	.entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce){
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -701,7 +716,12 @@ hr.wp-block-separator.is-style-wide {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	*[class*="inner-container"] > *:not(.entry-content):not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce){
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	*[class*="inner-container"] > *:not(.entry-content):not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce){
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -711,7 +731,12 @@ hr.wp-block-separator.is-style-wide {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.entry-content .wp-audio-shortcode{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	.entry-content .wp-audio-shortcode{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -721,7 +746,12 @@ hr.wp-block-separator.is-style-wide {
 	margin-left: auto;
 	margin-right: auto;
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.post-thumbnail{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	.post-thumbnail{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -733,7 +763,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.wide-max-width{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.wide-max-width{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -745,7 +781,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.alignwide{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.alignwide{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -757,7 +799,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.site-header{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.site-header{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -769,7 +817,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.site-footer{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.site-footer{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -781,7 +835,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.post-navigation{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.post-navigation{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -793,7 +853,13 @@ hr.wp-block-separator.is-style-wide {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.pagination{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.pagination{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -842,7 +908,13 @@ hr.wp-block-separator.is-style-wide {
 	max-width: 100%;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.alignwide [class*="inner-container"] > .alignwide{
+	width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.alignwide [class*="inner-container"] > .alignwide{
 	width: min(calc(100vw - 200px), 1240px);
 	}
@@ -855,7 +927,13 @@ hr.wp-block-separator.is-style-wide {
 	max-width: 100%;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.alignfull [class*="inner-container"] > .alignwide{
+	width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.alignfull [class*="inner-container"] > .alignwide{
 	width: min(calc(100vw - 200px), 1240px);
 	}
@@ -868,7 +946,13 @@ hr.wp-block-separator.is-style-wide {
 	max-width: 100%;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.entry-header .post-thumbnail{
+	width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.entry-header .post-thumbnail{
 	width: min(calc(100vw - 200px), 1240px);
 	}
@@ -881,7 +965,13 @@ hr.wp-block-separator.is-style-wide {
 	max-width: 100%;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.singular .post-thumbnail{
+	width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.singular .post-thumbnail{
 	width: min(calc(100vw - 200px), 1240px);
 	}
@@ -897,18 +987,23 @@ hr.wp-block-separator.is-style-wide {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: 15px;
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: 15px;
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
-	@media only screen and (min-width: 652px){
+	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: 15px;
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 822px){
+		.entry-content > .alignleft{
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -925,16 +1020,21 @@ hr.wp-block-separator.is-style-wide {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: 15px;
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: 15px;
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
-	@media only screen and (min-width: 652px){
+	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: 15px;
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 822px){
+		.entry-content > .alignright{
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2848,7 +2948,13 @@ p.has-text-color a {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.wp-block-pullquote.alignwide > p{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.wp-block-pullquote.alignwide > p{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -2858,7 +2964,13 @@ p.has-text-color a {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.wp-block-pullquote.alignwide blockquote{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.wp-block-pullquote.alignwide blockquote{
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
@@ -3050,7 +3162,13 @@ p.has-text-color a {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.wp-block-search{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.wp-block-search{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -3207,7 +3325,13 @@ table th {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.entry-content > .alignleft{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.entry-content > .alignleft{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -3241,7 +3365,13 @@ table th {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.entry-content > .alignright{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.entry-content > .alignright{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -3378,7 +3508,13 @@ table th {
 	padding-top: 30px;
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: 40px;
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.site-header {
 		padding-top: 72px;
 	}
@@ -3811,7 +3947,13 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.post-thumbnail .wp-post-image{
+	min-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.post-thumbnail .wp-post-image{
 	min-width: min(calc(100vw - 200px), 610px);
 	}
@@ -3825,7 +3967,12 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	font-size: 1rem;
 	max-width: calc(100vw - 30px);
 }
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.author-bio{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+@media only screen and (min-width: 822px){
 	.author-bio{
 	max-width: min(calc(100vw - 200px), 610px);
 	}
@@ -3847,7 +3994,13 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	max-width: calc(100vw - 120px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.author-bio.show-avatars .author-bio-content{
+	max-width: calc(min(calc(100vw - 4 * 25px), 610px) - 90px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.author-bio.show-avatars .author-bio-content{
 	max-width: calc(min(calc(100vw - 8 * 25px), 610px) - 90px);
 	}
@@ -4815,7 +4968,13 @@ h2.page-title {
 	max-width: calc(100vw - 30px);
 }
 
-@media only screen and (min-width: 652px){
+@media only screen and (min-width: 482px){
+	.search-form{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
 	.search-form{
 	max-width: min(calc(100vw - 200px), 610px);
 	}

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -267,12 +267,14 @@ Example:
 
 @media only screen and (min-width: 482px) {
 	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 4 * var(--global--spacing-horizontal)), 610px);
+		--responsive--alignwide-width: calc(100vw - 4 * var(--global--spacing-horizontal));
 		--responsive--alignright-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 822px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
 		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);

--- a/assets/sass/03-generic/breakpoints.scss
+++ b/assets/sass/03-generic/breakpoints.scss
@@ -92,12 +92,14 @@ $breakpoint_xxl: 1024px;
 
 @include media(mobile) {
 	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 4 * var(--global--spacing-horizontal)), #{$default_width});
+		--responsive--alignwide-width: calc(100vw - 4 * var(--global--spacing-horizontal));
 		--responsive--alignright-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@include media(laptop) {
+@include media(desktop) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), #{$default_width});
 		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), #{$max_content_width});

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -6,7 +6,11 @@
 	display: flex;
 	padding-top: var(--global--spacing-vertical);
 
-	@include media(laptop) {
+	@include media(mobile) {
+		padding-top: calc( var(--global--spacing-vertical) / 0.75); // 40px
+	}
+
+	@include media(desktop) {
 		padding-top: calc( 2.4 * var(--global--spacing-vertical)); // 60px
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -688,12 +688,14 @@ template {
 
 @media only screen and (min-width: 482px) {
 	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 4 * var(--global--spacing-horizontal)), 610px);
+		--responsive--alignwide-width: calc(100vw - 4 * var(--global--spacing-horizontal));
 		--responsive--alignright-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 822px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
 		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
@@ -2477,7 +2479,13 @@ table th,
 	padding-top: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc( var(--global--spacing-vertical) / 0.75);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.site-header {
 		padding-top: calc( 2.4 * var(--global--spacing-vertical));
 	}

--- a/style.css
+++ b/style.css
@@ -688,12 +688,14 @@ template {
 
 @media only screen and (min-width: 482px) {
 	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 4 * var(--global--spacing-horizontal)), 610px);
+		--responsive--alignwide-width: calc(100vw - 4 * var(--global--spacing-horizontal));
 		--responsive--alignright-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 822px) {
 	:root {
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
 		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
@@ -2490,7 +2492,13 @@ table th,
 	padding-top: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc( var(--global--spacing-vertical) / 0.75);
+	}
+}
+
+@media only screen and (min-width: 822px) {
 	.site-header {
 		padding-top: calc( 2.4 * var(--global--spacing-vertical));
 	}


### PR DESCRIPTION
This PR adds support for different spacing between 482px (`$breakpoint_sm`) and 822px (`$breakpoint_xl`). 

Before | After
----- | -----
<img width="607" alt="Screen Shot 2020-09-22 at 9 55 24 AM" src="https://user-images.githubusercontent.com/5375500/93891774-c572b600-fcb9-11ea-8983-190d84e6dc15.png"> | <img width="624" alt="Screen Shot 2020-09-22 at 9 52 40 AM" src="https://user-images.githubusercontent.com/5375500/93891787-c9063d00-fcb9-11ea-9560-eca5801dcbdd.png">
