### PR TITLE
Update URL of php.net date format table

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -33,7 +33,7 @@
 			</div>
 			<div class="copyright">
 				<?php
-				/* translators: 1: Copyright date format, see https://www.php.net/date, 2: Site name */
+				/* translators: 1: Copyright date format, see https://www.php.net/manual/datetime.format.php, 2: Site name */
 				printf(
 					/* Translators: %1$s: Copyright date. %2$s: Site name. */
 					esc_html__( '&copy; %1$s %2$s', 'twentytwentyone' ),


### PR DESCRIPTION
As per core https://core.trac.wordpress.org/ticket/51332 core ticket.

We have to update the URL for PHP date formats table in translator comments.

WordPress Username: mukesh27