### PR TITLE
The scrollbar always visible for menu on small devices.

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4525,7 +4525,7 @@ h2.page-title {
 	padding: 80px 20px 25px;
 	background-color: #d1e4dd;
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(30px);
 }

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -109,7 +109,7 @@
 		padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
 		overflow-x: hidden;
-		overflow-y: scroll;
+		overflow-y: auto;
 		transition: all .15s ease-in-out;
 		transform: translateY(var(--global--spacing-vertical));
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3388,7 +3388,7 @@ h2.page-title {
 	padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }

--- a/style.css
+++ b/style.css
@@ -3401,7 +3401,7 @@ h2.page-title {
 	padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }


### PR DESCRIPTION
The scrollbar is always visible for the menu on small devices because of `overflow-y: scroll;`. It should be `overflow-y: auto;`.

### Testing

Tested manually. See the short [test video](https://videos.files.wordpress.com/0v822PYD/twentytwentyone-fix-always-visible-scrollbar-test-video_hd.mp4).

### Before

![Before](https://maheshwaghmare.com/wp-content/uploads/2020/09/twentytwentyone-fix-always-visible-scrollbar-before.png)

### After

![After](https://maheshwaghmare.com/wp-content/uploads/2020/09/twentytwentyone-fix-always-visible-scrollbar-after.png)

