### PR TITLE
Revert "Add href to the site-title element"

### DIFF
--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -18,7 +18,7 @@
 	if ( ! empty( $blog_info ) ) {
 		if ( is_front_page() || ( is_front_page() && is_home() ) ) {
 			?>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
 			<?php
 		} else {
 			?>


### PR DESCRIPTION

Reverts WordPress/twentytwentyone#130

@metodiew I am reverting this only because the intention to was to add the link on the paged blog archives, and not on the home page.
-I meant paged as in when you click on the "newer posts" link and your url is something like http://localhost:8888/page/2/.
For this, you can use https://developer.wordpress.org/reference/functions/is_paged/ and I think it would be an easy fix for you.

The home page should not link to itself, you can find background information about why the link was removed here:
https://core.trac.wordpress.org/ticket/37011
