### PR TITLE
Specify grid column start value for tags links.

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4040,6 +4040,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: right;
 }
 
+.single .site-main > article > .entry-footer .tags-links {
+	grid-column-start: 2;
+}
+
 /**
  * Post Thumbnails
  */

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -192,6 +192,11 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: right;
 }
 
+// Place tag links in last grid column space
+.single .site-main > article > .entry-footer .tags-links {
+	grid-column-start: 2;
+}
+
 /**
  * Post Thumbnails
  */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2898,6 +2898,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: left;
 }
 
+.single .site-main > article > .entry-footer .tags-links {
+	grid-column-start: 2;
+}
+
 /**
  * Post Thumbnails
  */

--- a/style.css
+++ b/style.css
@@ -2911,6 +2911,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: right;
 }
 
+.single .site-main > article > .entry-footer .tags-links {
+	grid-column-start: 2;
+}
+
 /**
  * Post Thumbnails
  */


### PR DESCRIPTION
This should place the tags links container in the last grid column when an edit link isn't being output.

An alternative idea might be to always output a `<span>` or `<div>` where the edit link would go (even if a link wasn't actually output), so the tags links would automatically be pushed into the last grid column/row.

WordPress.org username is [kellylawrence](https://profiles.wordpress.org/kellylawrence/).