### PR TITLE
Remove title from translation comment & printf

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -35,10 +35,9 @@ if ( post_password_required() ) {
 				esc_html_e( '1 Reply', 'twentytwentyone' );
 			} else {
 				printf(
-					/* Translators: 1: comment count number, 2: title. */
-					esc_html( _nx( '%1$s Reply', '%1$s Replies', $twenty_twenty_one_comment_count, 'comments title', 'twentytwentyone' ) ),
-					esc_html( number_format_i18n( $twenty_twenty_one_comment_count ) ),
-					'<span>' . get_the_title() . '</span>' // phpcs:ignore WordPress.Security.EscapeOutput
+					/* Translators: %s: comment count number. */
+					esc_html( _nx( '%s Reply', '%s Replies', $twenty_twenty_one_comment_count, 'comments title', 'twentytwentyone' ) ),
+					esc_html( number_format_i18n( $twenty_twenty_one_comment_count ) )
 				);
 			}
 			?>


### PR DESCRIPTION
The comments title only displays the comment count, but the translators note & `printf` both use the post title. It's not causing any issue (except maybe translator confusion), but should be removed — assuming not showing the title is intentional.

(FYI, this seems to be true for Seedlet as well)