### PR TITLE
fix: Gallery item's link showing bottom border in Classic Editor case for Post Format Gallery

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2733,6 +2733,7 @@ img {
 
 .gallery-item a {
 	display: block;
+	border-bottom: transparent;
 }
 
 .gallery-columns-2 .gallery-item {

--- a/assets/sass/05-blocks/legacy/_style.scss
+++ b/assets/sass/05-blocks/legacy/_style.scss
@@ -6,6 +6,7 @@
 
 	a {
 		display: block;
+		border-bottom: transparent;
 	}
 
 	.gallery-columns-2 & {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1858,6 +1858,7 @@ img {
 
 .gallery-item a {
 	display: block;
+	border-bottom: transparent;
 }
 
 .gallery-columns-2 .gallery-item {

--- a/style.css
+++ b/style.css
@@ -1866,6 +1866,7 @@ img {
 
 .gallery-item a {
 	display: block;
+	border-bottom: transparent;
 }
 
 .gallery-columns-2 .gallery-item {


### PR DESCRIPTION
Issue Fix: #157 
- Added initial border style `transparent` for Gallery item.