### PR TITLE
Simplify the implementation of octed hex colors for borders a bit

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -41,11 +41,7 @@
 		value.bind( function( to ) {
 			var lum = twentytwentyoneGetHexLum( to ),
 				textColor = 127 < lum ? '#000' : '#fff';
-				borderColor = 127 < lum ? '#000' : '#fff';
-
-			if ( lum <= 40 ) {
-				borderColor = '#ffffff80';
-			}
+				borderColor = 127 < lum ? '#00000080' : '#ffffff80';
 
 			document.documentElement.style.setProperty( '--global--color-primary', textColor );
 			document.documentElement.style.setProperty( '--global--color-secondary', textColor );

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -66,11 +66,9 @@ class Twenty_Twenty_One_Custom_Colors {
 			$theme_css .= '--global--color-secondary: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
 		}
 
-		if ( $this->get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) ) <= 40 ) {
-			$theme_css .= '--global--color-border: #ffffff80';
-		} else {
-			$theme_css .= '--global--color-border: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
-		}
+		$theme_css .= ( 127 < $this->get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) ) )
+			? '--global--color-border: #00000080'
+			: '--global--color-border: #ffffff80';
 
 		$theme_css .= '}';
 


### PR DESCRIPTION
Simplify and make the use of octet hex colors consistent for border-color.
This is an addition to https://github.com/WordPress/twentytwentyone/pull/155
`#RRGGBBAA` colors are [supported by all browsers that can use css-variables](https://caniuse.com/css-rrggbbaa) so there is no problem in using them consistently. 