### PR TITLE
🐛 FIX: Align classic editor images correctly (#160)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -226,6 +226,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1749,6 +1749,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,
@@ -5262,10 +5267,6 @@ main * {
 
 footer * {
 	max-width: unset;
-}
-
-main img {
-	max-width: 100%;
 }
 
 html,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5264,6 +5264,10 @@ footer * {
 	max-width: unset;
 }
 
+main img {
+	max-width: 100%;
+}
+
 html,
 body,
 div,

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -375,6 +375,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,

--- a/assets/sass/04-elements/media.scss
+++ b/assets/sass/04-elements/media.scss
@@ -4,6 +4,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,

--- a/assets/sass/07-utilities/measure.scss
+++ b/assets/sass/07-utilities/measure.scss
@@ -7,10 +7,6 @@ footer * {
 	max-width: var(--global--spacing-measure);
 }
 
-main img {
-	max-width: 100%;
-}
-
 html,
 body,
 div,

--- a/assets/sass/07-utilities/measure.scss
+++ b/assets/sass/07-utilities/measure.scss
@@ -7,6 +7,10 @@ footer * {
 	max-width: var(--global--spacing-measure);
 }
 
+main img {
+	max-width: 100%;
+}
+
 html,
 body,
 div,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1217,6 +1217,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,
@@ -3969,10 +3974,6 @@ header *,
 main *,
 footer * {
 	max-width: var(--global--spacing-measure);
-}
-
-main img {
-	max-width: 100%;
 }
 
 html,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3971,6 +3971,10 @@ footer * {
 	max-width: var(--global--spacing-measure);
 }
 
+main img {
+	max-width: 100%;
+}
+
 html,
 body,
 div,

--- a/style.css
+++ b/style.css
@@ -1225,6 +1225,11 @@ img {
 	max-width: 100%;
 }
 
+/* Classic editor images */
+.entry-content img {
+	max-width: 100%;
+}
+
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,
@@ -3982,10 +3987,6 @@ header *,
 main *,
 footer * {
 	max-width: var(--global--spacing-measure);
-}
-
-main img {
-	max-width: 100%;
 }
 
 html,

--- a/style.css
+++ b/style.css
@@ -3984,6 +3984,10 @@ footer * {
 	max-width: var(--global--spacing-measure);
 }
 
+main img {
+	max-width: 100%;
+}
+
 html,
 body,
 div,


### PR DESCRIPTION
Fixes #160 

<table>
<tr>
<td>Before:
<br><br>

![#160-before](https://user-images.githubusercontent.com/3323310/94425348-fec58d00-01b5-11eb-86c9-8d22fff1f2e7.png)
</td>
<td>After:
<br><br>

![#160-after](https://user-images.githubusercontent.com/3323310/94425338-fa996f80-01b5-11eb-9a6f-ac333d924e10.png)
</td>
</tr>
</table>

