### PR TITLE
🐛 FIX: Adjust incorrect line breaks in README.md (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Twenty Twenty-One
-Contributors: wordpressdotorg
-Requires at least: 5.3
-Tested up to: 5.5
-Requires PHP: 7.2
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Contributors: wordpressdotorg  
+Requires at least: 5.3  
+Tested up to: 5.5  
+Requires PHP: 7.2  
+License: GPLv2 or later  
+License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 
 ## Description
 


### PR DESCRIPTION
Fixes #163 

<table>
<tr>
<td valign="top">Before:
<br><br>

<img width="882" alt="Screenshot 2020-09-28 at 18 26 35" src="https://user-images.githubusercontent.com/3323310/94426680-261d5980-01b8-11eb-92d3-0ed97fbfa881.png">
</td>
<td valign="top">After:
<br><br>

<img width="877" alt="Screenshot 2020-09-28 at 18 28 20" src="https://user-images.githubusercontent.com/3323310/94426843-64b31400-01b8-11eb-8e02-d1c824bd336c.png">
</td>
</tr>
</table>
