### PR TITLE
👌 IMPROVE: Adjust 404 page styling (#74)

### DIFF
--- a/404.php
+++ b/404.php
@@ -12,11 +12,11 @@
 get_header();
 ?>
 
-	<div class="error-404 not-found default-max-width">
-		<header class="page-header">
-			<h1 class="page-title"><?php esc_html_e( 'Nothing here', 'twentytwentyone' ); ?></h1>
-		</header><!-- .page-header -->
+	<header class="page-header alignwide">
+		<h1 class="page-title"><?php esc_html_e( 'Nothing here', 'twentytwentyone' ); ?></h1>
+	</header><!-- .page-header -->
 
+	<div class="error-404 not-found default-max-width">
 		<div class="page-content">
 			<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try a search?', 'twentytwentyone' ); ?></p>
 			<?php get_search_form(); ?>

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4214,19 +4214,7 @@ h2.page-title {
 	padding-bottom: 60px;
 }
 
-.error-404 {
-	display: flex;
-	justify-content: center;
-	height: 60vh;
-	flex-direction: column;
-}
-
-.error404 .page-header {
-	border-bottom: 3px solid transparent;
-	margin-bottom: 1rem;
-}
-
-.error404 p {
+.error404 main p {
 	font-size: 1.5rem;
 	margin-bottom: 3rem;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4216,7 +4216,7 @@ h2.page-title {
 
 .error404 main p {
 	font-size: 1.5rem;
-	margin-bottom: 3rem;
+	margin-bottom: 50px;
 }
 
 .search-no-results .page-content {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4217,17 +4217,18 @@ h2.page-title {
 .error-404 {
 	display: flex;
 	justify-content: center;
-	align-items: center;
 	height: 60vh;
 	flex-direction: column;
 }
 
 .error404 .page-header {
 	border-bottom: 3px solid transparent;
+	margin-bottom: 1rem;
 }
 
 .error404 p {
 	font-size: 1.5rem;
+	margin-bottom: 3rem;
 }
 
 .search-no-results .page-content {

--- a/assets/sass/06-components/404.scss
+++ b/assets/sass/06-components/404.scss
@@ -1,16 +1,11 @@
 .error-404 {
-	display: flex;
-	justify-content: center;
-	height: 60vh;
-	flex-direction: column;
 }
 
 .error404 .page-header {
-	border-bottom: 3px solid transparent;
-	margin-bottom: calc(var(--global--font-size-base) * 0.5);
+
 }
 
-.error404 p {
+.error404 main p {
 	font-size: var(--global--font-size-lg);
 	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }

--- a/assets/sass/06-components/404.scss
+++ b/assets/sass/06-components/404.scss
@@ -1,15 +1,16 @@
 .error-404 {
 	display: flex;
 	justify-content: center;
-	align-items: center;
 	height: 60vh;
 	flex-direction: column;
 }
 
 .error404 .page-header {
 	border-bottom: 3px solid transparent;
+	margin-bottom: calc(var(--global--font-size-base) * 0.5);
 }
 
 .error404 p {
 	font-size: var(--global--font-size-lg);
+	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }

--- a/assets/sass/06-components/404.scss
+++ b/assets/sass/06-components/404.scss
@@ -1,10 +1,3 @@
-.error-404 {
-}
-
-.error404 .page-header {
-
-}
-
 .error404 main p {
 	font-size: var(--global--font-size-lg);
 	margin-bottom: calc(var(--global--font-size-base) * 2.5);

--- a/assets/sass/06-components/404.scss
+++ b/assets/sass/06-components/404.scss
@@ -1,4 +1,4 @@
 .error404 main p {
 	font-size: var(--global--font-size-lg);
-	margin-bottom: calc(var(--global--font-size-base) * 2.5);
+	margin-bottom: calc(var(--global--spacing-vertical) * 1.6666666667);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3024,7 +3024,7 @@ h2.page-title {
 
 .error404 main p {
 	font-size: var(--global--font-size-lg);
-	margin-bottom: calc(var(--global--font-size-base) * 2.5);
+	margin-bottom: calc(var(--global--spacing-vertical) * 1.6666666667);
 }
 
 .search-no-results .page-content {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3025,17 +3025,18 @@ h2.page-title {
 .error-404 {
 	display: flex;
 	justify-content: center;
-	align-items: center;
 	height: 60vh;
 	flex-direction: column;
 }
 
 .error404 .page-header {
 	border-bottom: 3px solid transparent;
+	margin-bottom: calc(var(--global--font-size-base) * 0.5);
 }
 
 .error404 p {
 	font-size: var(--global--font-size-lg);
+	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }
 
 .search-no-results .page-content {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3022,19 +3022,7 @@ h2.page-title {
 	padding-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
-.error-404 {
-	display: flex;
-	justify-content: center;
-	height: 60vh;
-	flex-direction: column;
-}
-
-.error404 .page-header {
-	border-bottom: 3px solid transparent;
-	margin-bottom: calc(var(--global--font-size-base) * 0.5);
-}
-
-.error404 p {
+.error404 main p {
 	font-size: var(--global--font-size-lg);
 	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }

--- a/style.css
+++ b/style.css
@@ -3038,17 +3038,18 @@ h2.page-title {
 .error-404 {
 	display: flex;
 	justify-content: center;
-	align-items: center;
 	height: 60vh;
 	flex-direction: column;
 }
 
 .error404 .page-header {
 	border-bottom: 3px solid transparent;
+	margin-bottom: calc(var(--global--font-size-base) * 0.5);
 }
 
 .error404 p {
 	font-size: var(--global--font-size-lg);
+	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }
 
 .search-no-results .page-content {

--- a/style.css
+++ b/style.css
@@ -3037,7 +3037,7 @@ h2.page-title {
 
 .error404 main p {
 	font-size: var(--global--font-size-lg);
-	margin-bottom: calc(var(--global--font-size-base) * 2.5);
+	margin-bottom: calc(var(--global--spacing-vertical) * 1.6666666667);
 }
 
 .search-no-results .page-content {

--- a/style.css
+++ b/style.css
@@ -3035,19 +3035,7 @@ h2.page-title {
 	padding-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
-.error-404 {
-	display: flex;
-	justify-content: center;
-	height: 60vh;
-	flex-direction: column;
-}
-
-.error404 .page-header {
-	border-bottom: 3px solid transparent;
-	margin-bottom: calc(var(--global--font-size-base) * 0.5);
-}
-
-.error404 p {
+.error404 main p {
 	font-size: var(--global--font-size-lg);
 	margin-bottom: calc(var(--global--font-size-base) * 2.5);
 }


### PR DESCRIPTION
Fixes #74 

Applied the following changes ad described in https://github.com/WordPress/twentytwentyone/issues/74#issuecomment-695755890 & https://github.com/WordPress/twentytwentyone/issues/74#issuecomment-696400230:

- [x] Remove align-items: center so that the heading is left aligned.
- [x] Reduce the spacing between the heading and paragraph to 100px.
- [x] Add spacing of 50px between the paragraph and the form.
- [x] Make the title full-width and added border

<table>
<tr>
<td>Before:
<br><br>

![#74-before](https://user-images.githubusercontent.com/3323310/94509031-85717d00-023d-11eb-9368-e793cb561ca7.png)
</td>
<td>After:
<br><br>

![#74-after](https://user-images.githubusercontent.com/3323310/94510009-e601b980-023f-11eb-9639-fe78a3ed34f0.png)
</td>
</tr>
</table>