### PR TITLE
Don't load navigation script if no menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -334,7 +334,9 @@ function twenty_twenty_one_scripts() {
 	}
 
 	// Main navigation scripts.
-	wp_enqueue_script( 'twenty-twenty-one-primary-navigation-script', get_template_directory_uri() . '/assets/js/primary-navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
+	if ( has_nav_menu( 'primary' ) ) {
+		wp_enqueue_script( 'twenty-twenty-one-primary-navigation-script', get_template_directory_uri() . '/assets/js/primary-navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twenty_twenty_one_scripts' );
 


### PR DESCRIPTION
The JS for the primary navigation doesn't need load if no navigation menu is set.