### PR TITLE
Update the "no content" page

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3876,6 +3876,10 @@ nav a {
 	display: none;
 }
 
+.no-results.not-found > *:first-child {
+	margin-bottom: 90px;
+}
+
 .entry-title {
 	color: #28303d;
 	font-size: 2.25rem;

--- a/assets/sass/06-components/posts-and-pages.scss
+++ b/assets/sass/06-components/posts-and-pages.scss
@@ -14,3 +14,7 @@
 .updated:not(.published) {
 	display: none;
 }
+
+.no-results.not-found > *:first-child {
+	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2742,6 +2742,10 @@ nav a {
 	display: none;
 }
 
+.no-results.not-found > *:first-child {
+	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 .entry-title {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);

--- a/style.css
+++ b/style.css
@@ -2755,6 +2755,10 @@ nav a {
 	display: none;
 }
 
+.no-results.not-found > *:first-child {
+	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 .entry-title {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);


### PR DESCRIPTION
Minor update to increase the spacing on the page that shows when there is no content at all.
Partial fix for https://github.com/WordPress/twentytwentyone/issues/74

Before and after:
![nothing found](https://user-images.githubusercontent.com/7422055/94575223-4d396100-0274-11eb-9a4a-3ab733226282.png)
