### PR TITLE
Fix stylelint local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"build:ie-editor": "postcss assets/css/style-editor.css -o assets/css/ie-editor.css",
 		"build": "run-s \"build:*\"",
 		"watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
-		"lint:scss": "stylelint assets/sass/*.scss",
+		"lint:scss": "stylelint **/*.scss",
 		"wp-env": "wp-env"
 	}
 }


### PR DESCRIPTION
Fixes #144.

Previously the `lint:scss` would only run on all sass files within the `assets/sass/` folder. This changes the pattern to match all sass files within the project — matching what we have in the stylelint github action: https://github.com/WordPress/twentytwentyone/blob/1f30e05d2b4aaaa15daa10748bd83d4de8f43e9e/.github/workflows/stylelint.yml#L27
