### PR TITLE
Set the background color to the CSS variable in the customizer

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -1,49 +1,50 @@
 ( function( api, _ ) {
 
-    /**
-     * Get luminance from a HEX color.
-     *
-     * @param {string} hex - The hex color.
-     *
-     * @return {number}
-     */
-    function twentytwentyoneGetHexLum( hex ) {
-        var rgb = twentytwentyoneGetRgbFromHex( hex );
-        return Math.round( ( 0.2126 * rgb.r ) + ( 0.7152 * rgb.g ) + ( 0.0722 * rgb.b ) );
-    }
+	/**
+	 * Get luminance from a HEX color.
+	 *
+	 * @param {string} hex - The hex color.
+	 *
+	 * @return {number}
+	 */
+	function twentytwentyoneGetHexLum( hex ) {
+		var rgb = twentytwentyoneGetRgbFromHex( hex );
+		return Math.round( ( 0.2126 * rgb.r ) + ( 0.7152 * rgb.g ) + ( 0.0722 * rgb.b ) );
+	}
 
-    /**
-     * Get RGB from HEX.
-     *
-     * @param {string} hex - The hex color.
-     *
-     * @return {Object} - Returns an object {r, g, b}
-     */
-    function twentytwentyoneGetRgbFromHex( hex ) {
-        var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
-            result;
+	/**
+	 * Get RGB from HEX.
+	 *
+	 * @param {string} hex - The hex color.
+	 *
+	 * @return {Object} - Returns an object {r, g, b}
+	 */
+	function twentytwentyoneGetRgbFromHex( hex ) {
+		var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
+			result;
 
-        // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF").
-        hex = hex.replace( shorthandRegex, function( m, r, g, b ) {
-            return `${r}${r}${g}${g}${b}${b}`;
-        } );
+		// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF").
+		hex = hex.replace( shorthandRegex, function( m, r, g, b ) {
+			return `${r}${r}${g}${g}${b}${b}`;
+		} );
 
-        result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec( hex );
-        return result ? {
-            r: parseInt( result[1], 16 ),
-            g: parseInt( result[2], 16 ),
-            b: parseInt( result[3], 16 )
-        } : null;
-    }
+		result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec( hex );
+		return result ? {
+			r: parseInt( result[1], 16 ),
+			g: parseInt( result[2], 16 ),
+			b: parseInt( result[3], 16 )
+		} : null;
+	}
 
-    // Add listener for the "background_color" control.
+	// Add listener for the "background_color" control.
 	api( 'background_color', function( value ) {
 		value.bind( function( to ) {
-            var lum = twentytwentyoneGetHexLum( to ),
-                textColor = 127 < lum ? '#000' : '#fff';
+			var lum = twentytwentyoneGetHexLum( to ),
+				textColor = 127 < lum ? '#000' : '#fff';
 
-            document.documentElement.style.setProperty( '--global--color-primary', textColor );
-            document.documentElement.style.setProperty( '--global--color-secondary', textColor );
-        } );
+			document.documentElement.style.setProperty( '--global--color-primary', textColor );
+			document.documentElement.style.setProperty( '--global--color-secondary', textColor );
+			document.documentElement.style.setProperty( '--global--color-background', to );
+		} );
 	} );
 }( wp.customize, _ ) );


### PR DESCRIPTION
Sets the color from the background color option to the `--global--color-background` CSS variable in the customizer live preview.
Also replaces spaces with tabs.

Fixes https://github.com/WordPress/twentytwentyone/issues/128
