### PR TITLE
Keep focus inside the menu modal

### DIFF
--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -36,7 +36,7 @@
 		document.addEventListener( 'keydown', function( event ) {
 			if ( ! wrapper.classList.contains( `${ id }-navigation-open` ) ){
 				return;
-			} 
+			}
 			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 
 			modal = document.querySelector( `.${ id }-navigation` );
@@ -58,10 +58,10 @@
 
 			if ( ! shiftKey && tabKey && lastEl === activeEl ) {
 				event.preventDefault();
-				firstEl.focus();
+				closeButton.focus();
 			}
 
-			if ( shiftKey && tabKey && firstEl === activeEl ) {
+			if ( shiftKey && tabKey && closeButton === activeEl ) {
 				event.preventDefault();
 				lastEl.focus();
 			}


### PR DESCRIPTION
This is an attempt to make sure that the focus is kept inside the menu modal when it is open.

Before:
When you reach the last menu item, you can no longer tab forwards.
When tabbing backwards, focus can move past the close button, all the way around the page, and the visible focus is lost since 
the focus is now on content that is hidden by the open menu.

After:
Focus is kept inside the menu modal, looped, until the menu is closed.


