### PR TITLE
Adjust widget title size and widget area spacing

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5100,6 +5100,7 @@ h2.page-title {
 
 .widget-area {
 	font-size: 1rem;
+	margin-bottom: 0;
 }
 
 @media only screen and (min-width: 822px) {
@@ -5108,6 +5109,12 @@ h2.page-title {
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: 50px;
 	}
+}
+
+.widget-title {
+	font-size: 1.125rem;
+	font-weight: 700;
+	line-height: 1.4;
 }
 
 .search-form {

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -1,10 +1,18 @@
 .widget-area {
 	font-size: var(--footer--font-size);
+	margin-bottom: 0;
+
 	@include media(desktop) {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}
+}
+
+.widget-title {
+	font-size: var(--global--font-size-sm);
+	font-weight: 700;
+	line-height: 1.4;
 }
 
 // Search widget styles

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3811,6 +3811,7 @@ h2.page-title {
 
 .widget-area {
 	font-size: var(--footer--font-size);
+	margin-bottom: 0;
 }
 
 @media only screen and (min-width: 822px) {
@@ -3819,6 +3820,12 @@ h2.page-title {
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}
+}
+
+.widget-title {
+	font-size: var(--global--font-size-sm);
+	font-weight: 700;
+	line-height: 1.4;
 }
 
 .search-form {

--- a/style.css
+++ b/style.css
@@ -3824,6 +3824,7 @@ h2.page-title {
 
 .widget-area {
 	font-size: var(--footer--font-size);
+	margin-bottom: 0;
 }
 
 @media only screen and (min-width: 822px) {
@@ -3832,6 +3833,12 @@ h2.page-title {
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}
+}
+
+.widget-title {
+	font-size: var(--global--font-size-sm);
+	font-weight: 700;
+	line-height: 1.4;
 }
 
 .search-form {


### PR DESCRIPTION
Reduces the font size for the widget title.
Reduces the spacing below the widget area to better match the design.

Closes https://github.com/WordPress/twentytwentyone/issues/77