### PR TITLE
📦 NEW: Add :hover and :focus states (#36)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -31,14 +31,14 @@
 /* Button extends */
 .wp-block-search .wp-block-search__button {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
@@ -59,23 +59,39 @@
 }
 
 .wp-block-search .wp-block-search__button:active {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 .wp-block-search .wp-block-search__button:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 .wp-block-search .wp-block-search__button:focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .wp-block-search .has-focus.wp-block-search__button {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 /**
@@ -279,18 +295,18 @@ figcaption {
 }
 
 .wp-block-button__link:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-button__link:focus {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-button__link.has-focus {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-button__link.is-style-outline {
@@ -485,18 +501,18 @@ div[data-type="core/button"] {
 }
 
 .wp-block-file .wp-block-file__button:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-file .wp-block-file__button.has-focus {
-	color: #d1e4dd;
-	background-color: #39414d;
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-gallery figcaption {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -123,66 +123,66 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 /* Button extends */
 button {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
 .button {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
 input[type="submit"] {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
 .wp-block-button__link {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
 .wp-block-file .wp-block-file__button {
 	line-height: 1;
+	background-color: #39414d;
+	border-radius: 4px;
+	border-width: 0;
 	color: #d1e4dd;
 	cursor: pointer;
 	font-weight: normal;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
-	background-color: #39414d;
-	border-radius: 4px;
-	border-width: 0;
 	text-decoration: none;
 	padding: 23px 25px;
 }
@@ -241,103 +241,183 @@ input[type="submit"]:after {
 }
 
 button:active {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 .button:active {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 input:active[type="submit"] {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 .wp-block-button__link:active {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 .wp-block-file .wp-block-file__button:active {
+	background-color: #39414d;
 	color: #d1e4dd;
-	background-color: #28303d;
 }
 
 button:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 .button:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 input:hover[type="submit"] {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 .wp-block-button__link:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 .wp-block-file .wp-block-file__button:hover {
-	color: #d1e4dd;
-	background-color: #39414d;
+	background-color: #d1e4dd;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #39414d;
+	padding: 21px 23px;
 }
 
 button:focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .button:focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 input:focus[type="submit"] {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .wp-block-button__link:focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 button.has-focus {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .has-focus.button {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 input.has-focus[type="submit"] {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .has-focus.wp-block-button__link {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 .wp-block-file .has-focus.wp-block-file__button {
-	color: #d1e4dd;
 	background-color: #39414d;
+	border-color: #39414d;
+	border-style: solid;
+	border-width: 2px;
+	color: #d1e4dd;
+	outline-color: #d1e4dd;
+	outline-offset: -5px;
+	padding: 21px 23px;
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -1422,10 +1502,10 @@ a:active {
 	color: #28303d;
 }
 
-.site *:focus {
-	outline-width: 1px;
-	outline-style: dotted;
+*:focus {
 	outline-color: #39414d;
+	outline-style: dotted;
+	outline-width: 1px;
 }
 
 button,
@@ -1533,6 +1613,7 @@ blockquote.alignright footer {
 }
 
 input[type="text"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1541,6 +1622,7 @@ input[type="text"] {
 }
 
 input[type="email"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1549,6 +1631,7 @@ input[type="email"] {
 }
 
 input[type="url"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1557,6 +1640,7 @@ input[type="url"] {
 }
 
 input[type="password"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1565,6 +1649,7 @@ input[type="password"] {
 }
 
 input[type="search"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1573,6 +1658,7 @@ input[type="search"] {
 }
 
 input[type="number"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1581,6 +1667,7 @@ input[type="number"] {
 }
 
 input[type="tel"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1589,6 +1676,7 @@ input[type="tel"] {
 }
 
 input[type="range"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1597,6 +1685,7 @@ input[type="range"] {
 }
 
 input[type="date"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1605,6 +1694,7 @@ input[type="date"] {
 }
 
 input[type="month"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1613,6 +1703,7 @@ input[type="month"] {
 }
 
 input[type="week"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1621,6 +1712,7 @@ input[type="week"] {
 }
 
 input[type="time"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1629,6 +1721,7 @@ input[type="time"] {
 }
 
 input[type="datetime"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1637,6 +1730,7 @@ input[type="datetime"] {
 }
 
 input[type="datetime-local"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1645,6 +1739,7 @@ input[type="datetime-local"] {
 }
 
 input[type="color"] {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1653,6 +1748,7 @@ input[type="color"] {
 }
 
 textarea {
+	background-color: rgba(255, 255, 255, 0.5);
 	border: 3px solid #28303d;
 	border-radius: 0;
 	color: #28303d;
@@ -1661,83 +1757,99 @@ textarea {
 }
 
 input[type="text"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="email"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="url"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="password"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="search"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="number"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="tel"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="range"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="date"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="month"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="week"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="time"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="datetime"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="datetime-local"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 input[type="color"]:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 textarea:focus {
-	color: #28303d;
+	background-color: #fff;
 	border-color: #28303d;
+	color: #28303d;
 }
 
 select {
@@ -1855,15 +1967,15 @@ i {
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link {
-	color: #39414d;
 	background: transparent;
+	color: #39414d;
 	border: 2px solid currentColor;
 	padding: 23px 25px;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: #39414d;
 	background: transparent;
+	color: #39414d;
 	border: 2px solid currentColor;
 	padding: 23px 25px;
 }
@@ -1877,27 +1989,37 @@ i {
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:hover {
-	color: #39414d;
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link:focus {
-	color: #39414d;
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link.has-focus {
-	color: #39414d;
+	background: #39414d;
+	color: #d1e4dd;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
+	background: #39414d;
+	color: #d1e4dd;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:focus {
+	background: transparent;
 	color: #39414d;
+	outline-color: #39414d;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link.has-focus {
+	background: transparent;
+	color: #39414d;
+	outline-color: #39414d;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:focus {
+	background: transparent;
 	color: #39414d;
+	outline-color: #39414d;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	background: transparent;
 	color: #39414d;
+	outline-color: #39414d;
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {
@@ -2217,22 +2339,22 @@ i {
 }
 
 .wp-block-file a.wp-block-file__button:active {
-	color: #d1e4dd;
+	color: #39414d;
 	opacity: inherit;
 }
 
 .wp-block-file a.wp-block-file__button:focus {
-	color: #d1e4dd;
+	color: #39414d;
 	opacity: inherit;
 }
 
 .wp-block-file a.wp-block-file__button:hover {
-	color: #d1e4dd;
+	color: #39414d;
 	opacity: inherit;
 }
 
 .wp-block-file a.wp-block-file__button:visited {
-	color: #d1e4dd;
+	color: #39414d;
 	opacity: inherit;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -97,11 +97,11 @@
 	--cover--color-background: var(--global--color-black);
 	/* Buttons */
 	--button--color-text: var(--global--color-background);
-	--button--color-text-hover: var(--button--color-text);
+	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--button--color-text);
-	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-secondary-hover);
-	--button--color-background-active: var(--global--color-primary);
+	--button--color-background: var(--button--color-text-hover);
+	--button--color-background-hover: var(--global--color-background);
+	--button--color-background-active: var(--button--color-background);
 	--button--font-family: var(--global--font-ui);
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
@@ -212,14 +212,14 @@
 /* Button extends */
 .wp-block-search .wp-block-search__button {
 	line-height: var(--button--line-height);
+	background-color: var(--button--color-background);
+	border-radius: var(--button--border-radius);
+	border-width: 0;
 	color: var(--button--color-text);
 	cursor: pointer;
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
 	font-size: var(--button--font-size);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
@@ -240,13 +240,28 @@
 }
 
 .wp-block-search .wp-block-search__button:active {
-	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
+	color: var(--button--color-text-active);
 }
 
-.wp-block-search .wp-block-search__button:hover, .wp-block-search .wp-block-search__button:focus, .wp-block-search .has-focus.wp-block-search__button {
-	color: var(--button--color-text-hover);
+.wp-block-search .wp-block-search__button:hover {
 	background-color: var(--button--color-background-hover);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text-hover);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
+}
+
+.wp-block-search .wp-block-search__button:focus, .wp-block-search .has-focus.wp-block-search__button {
+	background-color: var(--button--color-background);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text);
+	outline-color: var(--button--color-text);
+	outline-offset: calc(var(--button--border-width) * -2.5);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
 }
 
 /**

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -112,11 +112,11 @@ $baseline-unit: 10px;
 	/* Buttons */
 	// Colors
 	--button--color-text: var(--global--color-background);
-	--button--color-text-hover: var(--button--color-text);
+	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--button--color-text);
-	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-secondary-hover);
-	--button--color-background-active: var(--global--color-primary);
+	--button--color-background: var(--button--color-text-hover);
+	--button--color-background-hover: var(--global--color-background);
+	--button--color-background-active: var(--button--color-background);
 	// Fonts
 	--button--font-family: var(--global--font-ui);
 	--button--font-size: var(--global--font-size-base);

--- a/assets/sass/02-tools/extends.scss
+++ b/assets/sass/02-tools/extends.scss
@@ -5,27 +5,40 @@
 //   in-sync
 %button-style {
 	@include crop-text(var(--button--line-height));
+	background-color: var(--button--color-background);
+	border-radius: var(--button--border-radius);
+	border-width: 0;
 	color: var(--button--color-text);
 	cursor: pointer;
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
 	font-size: var(--button--font-size);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:active {
-		color: var(--button--color-text-active);
 		background-color: var(--button--color-background-active);
+		color: var(--button--color-text-active);
 	}
 
-	&:hover,
+	&:hover {
+		background-color: var(--button--color-background-hover);
+		border-color: var(--button--color-background);
+		border-style: solid;
+		border-width: var(--button--border-width);
+		color: var(--button--color-text-hover);
+		padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
+	}
+
 	&:focus,
 	&.has-focus {
-		color: var(--button--color-text-hover);
-		background-color: var(--button--color-background-hover);
+		background-color: var(--button--color-background);
+		border-color: var(--button--color-background);
+		border-style: solid;
+		border-width: var(--button--border-width);
+		color: var(--button--color-text);
+		outline-color: var(--button--color-text);
+		outline-offset: calc(var(--button--border-width) * -2.5);
+		padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
 	}
 }
-

--- a/assets/sass/03-generic/reset.scss
+++ b/assets/sass/03-generic/reset.scss
@@ -110,10 +110,10 @@ a {
 }
 
 // Focus styles
-.site *:focus {
-	outline-width: 1px;
-	outline-style: dotted;
+*:focus {
 	outline-color: var(--global--color-secondary);
+	outline-style: dotted;
+	outline-width: 1px;
 }
 
 button,

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -14,6 +14,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
+	background-color: var(--global--color-white-50);
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
 	color: var(--form--color-text);
@@ -21,8 +22,9 @@ textarea {
 	padding: var(--form--spacing-unit);
 
 	&:focus {
-		color: var(--form--color-text);
+		background-color: var(--global--color-white);
 		border-color: var(--form--border-color);
+		color: var(--form--color-text);
 	}
 }
 

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -25,8 +25,8 @@ input[type="submit"],
 
 		&.wp-block-button__link,
 		.wp-block-button__link {
-			color: var(--button--color-background);
 			background: transparent;
+			color: var(--button--color-background);
 			border: var(--button--border-width) solid currentColor;
 			padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
@@ -34,10 +34,16 @@ input[type="submit"],
 				color: var(--button--color-background);
 			}
 
-			&:hover,
+			&:hover {
+				background: var(--button--color-background);
+				color: var(--button--color-background-hover);
+			}
+
 			&:focus,
 			&.has-focus {
-				color: var(--button--color-background-hover);
+				background: transparent;
+				color: var(--button--color-background);
+				outline-color: var(--button--color-background);
 			}
 		}
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -189,11 +189,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--cover--color-background: var(--global--color-black);
 	/* Buttons */
 	--button--color-text: var(--global--color-background);
-	--button--color-text-hover: var(--button--color-text);
+	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--button--color-text);
-	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-secondary-hover);
-	--button--color-background-active: var(--global--color-primary);
+	--button--color-background: var(--button--color-text-hover);
+	--button--color-background-hover: var(--global--color-background);
+	--button--color-background-active: var(--button--color-background);
 	--button--font-family: var(--global--font-ui);
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
@@ -307,14 +307,14 @@ button,
 input[type="submit"],
 .wp-block-button__link, .wp-block-file .wp-block-file__button {
 	line-height: var(--button--line-height);
+	background-color: var(--button--color-background);
+	border-radius: var(--button--border-radius);
+	border-width: 0;
 	color: var(--button--color-text);
 	cursor: pointer;
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
 	font-size: var(--button--font-size);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
@@ -350,22 +350,37 @@ button:active,
 .button:active,
 input:active[type="submit"],
 .wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
-	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
+	color: var(--button--color-text-active);
 }
 
 button:hover,
 .button:hover,
 input:hover[type="submit"],
-.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover, button:focus,
+.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
+	background-color: var(--button--color-background-hover);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text-hover);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
+}
+
+button:focus,
 .button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, button.has-focus,
 .has-focus.button,
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
-	color: var(--button--color-text-hover);
-	background-color: var(--button--color-background-hover);
+	background-color: var(--button--color-background);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text);
+	outline-color: var(--button--color-text);
+	outline-offset: calc(var(--button--border-width) * -2.5);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -1079,10 +1094,10 @@ a:active {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.site *:focus {
-	outline-width: 1px;
-	outline-style: dotted;
+*:focus {
 	outline-color: var(--global--color-secondary);
+	outline-style: dotted;
+	outline-width: 1px;
 }
 
 button,
@@ -1181,6 +1196,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
+	background-color: var(--global--color-white-50);
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
 	color: var(--form--color-text);
@@ -1204,8 +1220,9 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-	color: var(--form--color-text);
+	background-color: var(--global--color-white);
 	border-color: var(--form--border-color);
+	color: var(--form--color-text);
 }
 
 select {
@@ -1310,8 +1327,8 @@ i {
 
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: var(--button--color-background);
 	background: transparent;
+	color: var(--button--color-background);
 	border: var(--button--border-width) solid currentColor;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
@@ -1321,11 +1338,18 @@ i {
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
-.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline.wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:hover {
+	background: var(--button--color-background);
+	color: var(--button--color-background-hover);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
-	color: var(--button--color-background-hover);
+	background: transparent;
+	color: var(--button--color-background);
+	outline-color: var(--button--color-background);
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {

--- a/style.css
+++ b/style.css
@@ -189,11 +189,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--cover--color-background: var(--global--color-black);
 	/* Buttons */
 	--button--color-text: var(--global--color-background);
-	--button--color-text-hover: var(--button--color-text);
+	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--button--color-text);
-	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-secondary-hover);
-	--button--color-background-active: var(--global--color-primary);
+	--button--color-background: var(--button--color-text-hover);
+	--button--color-background-hover: var(--global--color-background);
+	--button--color-background-active: var(--button--color-background);
 	--button--font-family: var(--global--font-ui);
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
@@ -307,14 +307,14 @@ button,
 input[type="submit"],
 .wp-block-button__link, .wp-block-file .wp-block-file__button {
 	line-height: var(--button--line-height);
+	background-color: var(--button--color-background);
+	border-radius: var(--button--border-radius);
+	border-width: 0;
 	color: var(--button--color-text);
 	cursor: pointer;
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
 	font-size: var(--button--font-size);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
@@ -350,22 +350,37 @@ button:active,
 .button:active,
 input:active[type="submit"],
 .wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
-	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
+	color: var(--button--color-text-active);
 }
 
 button:hover,
 .button:hover,
 input:hover[type="submit"],
-.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover, button:focus,
+.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
+	background-color: var(--button--color-background-hover);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text-hover);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
+}
+
+button:focus,
 .button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, button.has-focus,
 .has-focus.button,
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
-	color: var(--button--color-text-hover);
-	background-color: var(--button--color-background-hover);
+	background-color: var(--button--color-background);
+	border-color: var(--button--color-background);
+	border-style: solid;
+	border-width: var(--button--border-width);
+	color: var(--button--color-text);
+	outline-color: var(--button--color-text);
+	outline-offset: calc(var(--button--border-width) * -2.5);
+	padding: calc(var(--button--padding-vertical) - var(--button--border-width)) calc(var(--button--padding-horizontal) - var(--button--border-width));
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -1087,10 +1102,10 @@ a:active {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.site *:focus {
-	outline-width: 1px;
-	outline-style: dotted;
+*:focus {
 	outline-color: var(--global--color-secondary);
+	outline-style: dotted;
+	outline-width: 1px;
 }
 
 button,
@@ -1189,6 +1204,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
+	background-color: var(--global--color-white-50);
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
 	color: var(--form--color-text);
@@ -1212,8 +1228,9 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-	color: var(--form--color-text);
+	background-color: var(--global--color-white);
 	border-color: var(--form--border-color);
+	color: var(--form--color-text);
 }
 
 select {
@@ -1318,8 +1335,8 @@ i {
 
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: var(--button--color-background);
 	background: transparent;
+	color: var(--button--color-background);
 	border: var(--button--border-width) solid currentColor;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
@@ -1329,11 +1346,18 @@ i {
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
-.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline.wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:hover {
+	background: var(--button--color-background);
+	color: var(--button--color-background-hover);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
-	color: var(--button--color-background-hover);
+	background: transparent;
+	color: var(--button--color-background);
+	outline-color: var(--button--color-background);
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {


### PR DESCRIPTION
Fixes #36 

Add `:focus`  and `:hover` state to buttons and `:focus` state to input fields and textareas.

## Buttons

<table>
<tr>
<td><strong>Default<strong>
<br><br>

![#36-button](https://user-images.githubusercontent.com/3323310/94678888-6bbd5c00-0349-11eb-856f-15c661001558.png)
</td>
<td><strong>Hover<strong>
<br><br>

![#36-button-hover](https://user-images.githubusercontent.com/3323310/94678885-6b24c580-0349-11eb-992a-3c4e6d2b4d79.png)
</td>
<td><strong>Focus<strong>
<br><br>

![#36-button-focus](https://user-images.githubusercontent.com/3323310/94678880-695b0200-0349-11eb-8a94-e46d15ff8fb9.png)
</td>
</tr>
</table>

## Textareas

<table>
<tr>
<td><strong>Default<strong>
<br><br>

![#36-taxtarea](https://user-images.githubusercontent.com/3323310/94678931-78da4b00-0349-11eb-8732-dbe7642594d7.png)
</td>
<td><strong>Focus<strong>
<br><br>

![#36-taxtarea-focus](https://user-images.githubusercontent.com/3323310/94678926-77a91e00-0349-11eb-9da0-58d6aad846c5.png)
</td>
</tr>
</table>

## Radio buttons and checkboxes

I haven't adjusted the `:focus` styles for radio buttons and checkboxes as their `:focus` styling would not be visible once selected.

@melchoyce Are you fine with skipping the `:focus` styles for radio buttons and checkboxes? Or do you have some alternative styling in mind?

![#36-radio-and-checkbox](https://user-images.githubusercontent.com/3323310/94679137-ca82d580-0349-11eb-8b61-df5ffb021d7f.png)
