### PR TITLE
Fix: Color contrast is too low in striped table blocks (#185)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -27,6 +27,7 @@
 	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
+	/* Block: Table */
 }
 
 /* Button extends */
@@ -1574,6 +1575,22 @@ table th {
 
 .wp-block-table th {
 	padding: 10px;
+}
+
+table.is-style-stripes {
+	border-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes {
+	border-color: #f0f0f0;
+}
+
+table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
 }
 
 pre.wp-block-verse {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -118,6 +118,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
+	/* Block: Table */
 }
 
 /* Button extends */
@@ -3432,6 +3433,22 @@ table th {
 	padding: 10px;
 	border: 1px solid;
 	word-break: break-all;
+}
+
+table.is-style-stripes {
+	border-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes {
+	border-color: #f0f0f0;
+}
+
+table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
 }
 
 .wp-block-verse {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -58,6 +58,7 @@
 	--global--color-black: #000;
 	--global--color-dark-gray: #28303d;
 	--global--color-gray: #39414d;
+	--global--color-light-gray: #f0f0f0;
 	--global--color-green: #d1e4dd;
 	--global--color-blue: #d1dfe4;
 	--global--color-purple: #d1d1e4;
@@ -200,6 +201,9 @@
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 1px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));
+	/* Block: Table */
+	--table--stripes-border-color: var(--global--color-light-gray);
+	--table--stripes-background-color: var(--global--color-light-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -1193,6 +1197,16 @@ table th,
 .wp-block-table td,
 .wp-block-table th {
 	padding: calc(0.5 * var(--global--spacing-unit));
+}
+
+table.is-style-stripes,
+.wp-block-table.is-style-stripes {
+	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: var(--table--stripes-background-color);
 }
 
 pre.wp-block-verse {

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -40,11 +40,14 @@
 	api( 'background_color', function( value ) {
 		value.bind( function( to ) {
 			var lum = twentytwentyoneGetHexLum( to ),
-				textColor = 127 < lum ? '#000' : '#fff';
+				textColor = 127 < lum ? '#000' : '#fff',
+				tableColor = 127 < lum ? 'var(--global--color-light-gray)' : 'var(--global--color-dark-gray)';
 
 			document.documentElement.style.setProperty( '--global--color-primary', textColor );
 			document.documentElement.style.setProperty( '--global--color-secondary', textColor );
 			document.documentElement.style.setProperty( '--global--color-background', to );
+			document.documentElement.style.setProperty( '--table--stripes-border-color', tableColor );
+			document.documentElement.style.setProperty( '--table--stripes-background-color', tableColor );
 		} );
 	} );
 }( wp.customize, _ ) );

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -70,6 +70,7 @@ $baseline-unit: 10px;
 	--global--color-black: #000;
 	--global--color-dark-gray: #28303d;
 	--global--color-gray: #39414d;
+	--global--color-light-gray: #f0f0f0;
 	--global--color-green: #d1e4dd;
 	--global--color-blue: #d1dfe4;
 	--global--color-purple: #d1d1e4;
@@ -227,6 +228,10 @@ $baseline-unit: 10px;
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 1px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));
+
+	/* Block: Table */
+	--table--stripes-border-color: var(--global--color-light-gray);
+	--table--stripes-background-color: var(--global--color-light-gray);
 }
 
 @media only screen and (min-width: 652px) { // Not using the mixin because it's compiled after this file

--- a/assets/sass/05-blocks/table/_editor.scss
+++ b/assets/sass/05-blocks/table/_editor.scss
@@ -9,4 +9,12 @@ table,
 	th {
 		padding: calc(0.5 * var(--global--spacing-unit));
 	}
+
+	&.is-style-stripes {
+		border-color: var(--table--stripes-border-color);
+
+		tbody tr:nth-child(odd) {
+			background-color: var(--table--stripes-background-color);
+		}
+	}
 }

--- a/assets/sass/05-blocks/table/_style.scss
+++ b/assets/sass/05-blocks/table/_style.scss
@@ -14,4 +14,12 @@ table,
 		border: 1px solid;
 		word-break: break-all;
 	}
+
+	&.is-style-stripes {
+		border-color: var(--table--stripes-border-color);
+
+		tbody tr:nth-child(odd) {
+			background-color: var(--table--stripes-background-color);
+		}
+	}
 }

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -64,6 +64,11 @@ class Twenty_Twenty_One_Custom_Colors {
 			$theme_css .= '--global--color-background: #' . get_theme_mod( 'background_color', 'D1E4DD' ) . ';';
 			$theme_css .= '--global--color-primary: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
 			$theme_css .= '--global--color-secondary: ' . $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) . ';';
+
+			if ( '#fff' === $this->custom_get_readable_color( get_theme_mod( 'background_color', 'D1E4DD' ) ) ) {
+				$theme_css .= '--table--stripes-border-color: var(--global--color-dark-gray);';
+				$theme_css .= '--table--stripes-background-color: var(--global--color-dark-gray);';
+			}
 		}
 
 		$theme_css .= '}';

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -149,6 +149,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--color-black: #000;
 	--global--color-dark-gray: #28303d;
 	--global--color-gray: #39414d;
+	--global--color-light-gray: #f0f0f0;
 	--global--color-green: #d1e4dd;
 	--global--color-blue: #d1dfe4;
 	--global--color-purple: #d1d1e4;
@@ -291,6 +292,9 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 1px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));
+	/* Block: Table */
+	--table--stripes-border-color: var(--global--color-light-gray);
+	--table--stripes-background-color: var(--global--color-light-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -2400,6 +2404,16 @@ table th,
 	padding: calc(0.5 * var(--global--spacing-unit));
 	border: 1px solid;
 	word-break: break-all;
+}
+
+table.is-style-stripes,
+.wp-block-table.is-style-stripes {
+	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: var(--table--stripes-background-color);
 }
 
 .wp-block-verse {

--- a/style.css
+++ b/style.css
@@ -149,6 +149,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--color-black: #000;
 	--global--color-dark-gray: #28303d;
 	--global--color-gray: #39414d;
+	--global--color-light-gray: #f0f0f0;
 	--global--color-green: #d1e4dd;
 	--global--color-blue: #d1dfe4;
 	--global--color-purple: #d1d1e4;
@@ -291,6 +292,9 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 1px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));
+	/* Block: Table */
+	--table--stripes-border-color: var(--global--color-light-gray);
+	--table--stripes-background-color: var(--global--color-light-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -2408,6 +2412,16 @@ table th,
 	padding: calc(0.5 * var(--global--spacing-unit));
 	border: 1px solid;
 	word-break: break-all;
+}
+
+table.is-style-stripes,
+.wp-block-table.is-style-stripes {
+	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: var(--table--stripes-background-color);
 }
 
 .wp-block-verse {


### PR DESCRIPTION
The current implementation of the swapped colors on a dark mode made it a bit hard to implement the fix. I've tried to do it as closely to the current code as possible. But maybe functions like `custom_get_readable_color` could be rewritten a bit, so they don't return a color hex value but a keyword such as `light` or `dark` and the functions calling them can then set a color based on that result. This would make the code a bit easier to read and extend.

As there was no global color already defined that would match the Core background color for the "stripes" style, I've added a "light-gray" color, using the same value as in the Core block styles. I've also introduced another CSS custom property so it's easier to overwrite those in child themes.

Fixes #185