### PR TITLE
Select list line height and focus style

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -603,12 +603,6 @@ div[data-type="core/button"] {
 	border: 3px solid #28303d;
 }
 
-.wp-block-file .wp-block-file__textlink {
-	border-bottom: 1px solid #39414d;
-	color: #28303d;
-	text-decoration: none;
-}
-
 .wp-block-file .wp-block-file__button {
 	display: inline-block;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1786,11 +1786,16 @@ select {
 	-moz-appearance: none;
 	-webkit-appearance: none;
 	appearance: none;
+	line-height: 1.7;
 	padding: 10px 30px 10px 10px;
 	/* stylelint-disable */
 	background: #fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	/* stylelint-enable */
 	background-position: right 10px top 60%;
+}
+
+select:focus {
+	outline: 1px solid #39414d;
 }
 
 textarea {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -441,7 +441,7 @@ select {
 	/* stylelint-enable */
 	background-position: right var(--form--spacing-unit) top 60%;
 }
-  
+
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and
@@ -618,12 +618,6 @@ div[data-type="core/button"] {
 .wp-block-cover.is-style-twentytwentyone-border,
 .wp-block-cover-image.is-style-twentytwentyone-border {
 	border: calc(3 * var(--separator--height)) solid var(--global--color-border);
-}
-
-.wp-block-file .wp-block-file__textlink {
-	border-bottom: 1px solid var(--global--color-secondary);
-	color: var(--global--color-primary);
-	text-decoration: none;
 }
 
 .wp-block-file .wp-block-file__button {

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -56,11 +56,16 @@ select {
 	-moz-appearance: none;
 	-webkit-appearance: none;
 	appearance: none;
+	line-height: var(--global--line-height-body);
 	padding: var(--form--spacing-unit) calc(3 * var(--form--spacing-unit)) var(--form--spacing-unit) var(--form--spacing-unit);
 	/* stylelint-disable */
 	background: var(--global--color-white) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	/* stylelint-enable */
 	background-position: right var(--form--spacing-unit) top 60%;
+
+	&:focus {
+		outline: 1px solid var(--form--border-color);
+	}
 }
 
 textarea {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1239,11 +1239,16 @@ select {
 	-moz-appearance: none;
 	-webkit-appearance: none;
 	appearance: none;
+	line-height: var(--global--line-height-body);
 	padding: var(--form--spacing-unit) var(--form--spacing-unit) var(--form--spacing-unit) calc(3 * var(--form--spacing-unit));
 	/* stylelint-disable */
 	background: var(--global--color-white) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	/* stylelint-enable */
 	background-position: left var(--form--spacing-unit) top 60%;
+}
+
+select:focus {
+	outline: 1px solid var(--form--border-color);
 }
 
 textarea {

--- a/style.css
+++ b/style.css
@@ -1247,11 +1247,16 @@ select {
 	-moz-appearance: none;
 	-webkit-appearance: none;
 	appearance: none;
+	line-height: var(--global--line-height-body);
 	padding: var(--form--spacing-unit) calc(3 * var(--form--spacing-unit)) var(--form--spacing-unit) var(--form--spacing-unit);
 	/* stylelint-disable */
 	background: var(--global--color-white) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	/* stylelint-enable */
 	background-position: right var(--form--spacing-unit) top 60%;
+}
+
+select:focus {
+	outline: 1px solid var(--form--border-color);
 }
 
 textarea {


### PR DESCRIPTION
Re add focus styles to select lists.

During testing, it showed that letter with descenders ( like in the Cate**g**or**y** archive widget)  did not show correctly, so the line height was increased to match the body line height instead.