### PR TITLE
👌 IMPROVE: Update styles for the RSS block (#200)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1292,6 +1292,7 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
+	text-align: center;
 	padding: 0;
 }
 
@@ -1521,6 +1522,30 @@ p.has-background {
 [style*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*="background-image"] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
+}
+
+.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+	list-style: none;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-title {
+	margin-bottom: 8px;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-author {
+	margin-bottom: 8px;
+}
+
+.wp-block-rss li {
+	margin-bottom: 30px;
+}
+
+.wp-block-rss li .wp-block-rss__item-publish-date {
+	color: #39414d;
+}
+
+.wp-block-rss li .wp-block-rss__item-author {
+	color: #39414d;
 }
 
 .wp-block-search {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1292,15 +1292,15 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
-	text-align: center;
 	padding: 0;
+	text-align: center;
 }
 
 ul.alignright,
 ol.alignright {
 	list-style-position: inside;
-	text-align: right;
 	padding: 0;
+	text-align: right;
 }
 
 li > ul,
@@ -1524,28 +1524,116 @@ p.has-background {
 	color: currentColor;
 }
 
-.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+.wp-block-rss {
+	padding-left: 0;
+}
+
+.wp-block-rss > li {
 	list-style: none;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-title {
-	margin-bottom: 8px;
+.wp-block-rss:not(.is-grid) > li {
+	margin-top: 50px;
+	margin-bottom: 50px;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-author {
-	margin-bottom: 8px;
+.wp-block-rss:not(.is-grid) > li:first-child {
+	margin-top: 0;
 }
 
-.wp-block-rss li {
+.wp-block-rss:not(.is-grid) > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid > li {
 	margin-bottom: 30px;
 }
 
-.wp-block-rss li .wp-block-rss__item-publish-date {
-	color: #39414d;
+.wp-block-rss.is-grid > li:last-child {
+	margin-bottom: 0;
 }
 
-.wp-block-rss li .wp-block-rss__item-author {
-	color: #39414d;
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+	margin-bottom: 0;
+}
+
+.wp-block-rss > li > * {
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+.wp-block-rss > li > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss > li > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss .wp-block-rss__item-title > a {
+	display: inline-block;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.875rem;
+	font-weight: normal;
+	line-height: 1.3;
+	margin-bottom: 10px;
+}
+
+@media only screen and (min-width: 652px){
+	.wp-block-rss .wp-block-rss__item-title > a{
+	font-size: 2rem;
+	}
+}
+
+.wp-block-rss .wp-block-rss__item-author {
+	color: #28303d;
+	font-size: 1.25rem;
+	line-height: 1.7;
+}
+
+.wp-block-rss .wp-block-rss__item-publish-date {
+	color: #28303d;
+	font-size: 1rem;
+	line-height: 1.7;
+}
+
+[class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
+.has-background .wp-block-rss .wp-block-rss__item-publish-date {
+	color: currentColor;
+}
+
+.wp-block-rss .wp-block-rss__item-excerpt {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.125rem;
+	line-height: 1.7;
+	margin-top: 20px;
+}
+
+.wp-block-rss .wp-block-rss__item-full-content {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.125rem;
+	line-height: 1.7;
+	margin-top: 20px;
+}
+
+.wp-block-rss.alignfull {
+	padding-left: 20px;
+	padding-right: 20px;
+}
+
+.entry-content [class*="inner-container"] .wp-block-rss.alignfull,
+.entry-content .has-background .wp-block-rss.alignfull {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .wp-block-search {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3621,6 +3621,30 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
+.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+	list-style: none;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-title {
+	margin-bottom: 8px;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-author {
+	margin-bottom: 8px;
+}
+
+.wp-block-rss li {
+	margin-bottom: 30px;
+}
+
+.wp-block-rss li .wp-block-rss__item-publish-date {
+	color: #39414d;
+}
+
+.wp-block-rss li .wp-block-rss__item-author {
+	color: #39414d;
+}
+
 .wp-block-search {
 	max-width: calc(100vw - 30px);
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3621,28 +3621,116 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
-.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+.wp-block-rss {
+	padding-left: 0;
+}
+
+.wp-block-rss > li {
 	list-style: none;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-title {
-	margin-bottom: 8px;
+.wp-block-rss:not(.is-grid) > li {
+	margin-top: 50px;
+	margin-bottom: 50px;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-author {
-	margin-bottom: 8px;
+.wp-block-rss:not(.is-grid) > li:first-child {
+	margin-top: 0;
 }
 
-.wp-block-rss li {
+.wp-block-rss:not(.is-grid) > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid > li {
 	margin-bottom: 30px;
 }
 
-.wp-block-rss li .wp-block-rss__item-publish-date {
-	color: #39414d;
+.wp-block-rss.is-grid > li:last-child {
+	margin-bottom: 0;
 }
 
-.wp-block-rss li .wp-block-rss__item-author {
-	color: #39414d;
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+	margin-bottom: 0;
+}
+
+.wp-block-rss > li > * {
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+.wp-block-rss > li > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss > li > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss .wp-block-rss__item-title > a {
+	display: inline-block;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.875rem;
+	font-weight: normal;
+	line-height: 1.3;
+	margin-bottom: 10px;
+}
+
+@media only screen and (min-width: 652px){
+	.wp-block-rss .wp-block-rss__item-title > a{
+	font-size: 2rem;
+	}
+}
+
+.wp-block-rss .wp-block-rss__item-author {
+	color: #28303d;
+	font-size: 1.25rem;
+	line-height: 1.7;
+}
+
+.wp-block-rss .wp-block-rss__item-publish-date {
+	color: #28303d;
+	font-size: 1rem;
+	line-height: 1.7;
+}
+
+[class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
+.has-background .wp-block-rss .wp-block-rss__item-publish-date {
+	color: currentColor;
+}
+
+.wp-block-rss .wp-block-rss__item-excerpt {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.125rem;
+	line-height: 1.7;
+	margin-top: 20px;
+}
+
+.wp-block-rss .wp-block-rss__item-full-content {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.125rem;
+	line-height: 1.7;
+	margin-top: 20px;
+}
+
+.wp-block-rss.alignfull {
+	padding-left: 20px;
+	padding-right: 20px;
+}
+
+.entry-content [class*="inner-container"] .wp-block-rss.alignfull,
+.entry-content .has-background .wp-block-rss.alignfull {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .wp-block-search {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -977,15 +977,15 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
-	text-align: center;
 	padding: 0;
+	text-align: center;
 }
 
 ul.alignright,
 ol.alignright {
 	list-style-position: inside;
-	text-align: right;
 	padding: 0;
+	text-align: right;
 }
 
 li > ul,
@@ -1167,22 +1167,104 @@ p.has-background {
 	color: currentColor;
 }
 
-.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+.wp-block-rss {
+	padding-left: 0;
+}
+
+.wp-block-rss > li {
 	list-style: none;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-title,
-.wp-block-rss.is-grid .wp-block-rss__item-author {
-	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+.wp-block-rss:not(.is-grid) > li {
+	margin-top: calc(1.666 * var(--global--spacing-vertical));
+	margin-bottom: calc(1.666 * var(--global--spacing-vertical));
 }
 
-.wp-block-rss li {
+.wp-block-rss:not(.is-grid) > li:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss:not(.is-grid) > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid > li {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-rss li .wp-block-rss__item-publish-date,
-.wp-block-rss li .wp-block-rss__item-author {
-	color: var(--global--color-gray);
+.wp-block-rss.is-grid > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+	margin-bottom: 0;
+}
+
+.wp-block-rss > li > * {
+	margin-top: calc(0.333 * var(--global--spacing-vertical));
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss > li > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss > li > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss .wp-block-rss__item-title > a {
+	display: inline-block;
+	font-family: var(--latest-posts--title-font-family);
+	font-size: var(--latest-posts--title-font-size);
+	font-weight: var(--heading--font-weight);
+	line-height: var(--global--line-height-heading);
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss .wp-block-rss__item-author {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-md);
+	line-height: var(--global--line-height-body);
+}
+
+.wp-block-rss .wp-block-rss__item-publish-date {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-xs);
+	line-height: var(--global--line-height-body);
+}
+
+[class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
+.has-background .wp-block-rss .wp-block-rss__item-publish-date {
+	color: currentColor;
+}
+
+.wp-block-rss .wp-block-rss__item-excerpt,
+.wp-block-rss .wp-block-rss__item-full-content {
+	font-family: var(--latest-posts--description-font-family);
+	font-size: var(--latest-posts--description-font-size);
+	line-height: var(--global--line-height-body);
+	margin-top: calc(0.666 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss.alignfull {
+	padding-left: var(--global--spacing-unit);
+	padding-right: var(--global--spacing-unit);
+}
+
+.entry-content [class*="inner-container"] .wp-block-rss.alignfull,
+.entry-content .has-background .wp-block-rss.alignfull {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .wp-block-search {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -977,6 +977,7 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
+	text-align: center;
 	padding: 0;
 }
 
@@ -1164,6 +1165,24 @@ p.has-background {
 [style*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*="background-image"] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
+}
+
+.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+	list-style: none;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-title,
+.wp-block-rss.is-grid .wp-block-rss__item-author {
+	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+}
+
+.wp-block-rss li {
+	margin-bottom: var(--global--spacing-vertical);
+}
+
+.wp-block-rss li .wp-block-rss__item-publish-date,
+.wp-block-rss li .wp-block-rss__item-author {
+	color: var(--global--color-gray);
 }
 
 .wp-block-search {

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -20,6 +20,7 @@
 @import "paragraph/editor";
 @import "pullquote/editor";
 @import "quote/editor";
+@import "rss/editor";
 @import "search/editor";
 @import "separator/editor";
 @import "table/editor";

--- a/assets/sass/05-blocks/blocks.scss
+++ b/assets/sass/05-blocks/blocks.scss
@@ -23,6 +23,7 @@
 @import "paragraph/style";
 @import "pullquote/style";
 @import "quote/style";
+@import "rss/style";
 @import "search/style";
 @import "separator/style";
 @import "spacer/style";

--- a/assets/sass/05-blocks/list/_editor.scss
+++ b/assets/sass/05-blocks/list/_editor.scss
@@ -8,12 +8,13 @@ ol {
 	&.aligncenter {
 		list-style-position: inside;
 		padding: 0;
+		text-align: center;
 	}
 
 	&.alignright {
 		list-style-position: inside;
-		text-align: right;
 		padding: 0;
+		text-align: right;
 	}
 }
 

--- a/assets/sass/05-blocks/rss/_editor.scss
+++ b/assets/sass/05-blocks/rss/_editor.scss
@@ -1,0 +1,24 @@
+.wp-block-rss {
+
+	&.aligncenter,
+	&.alignright {
+		list-style: none;
+	}
+
+	&.is-grid {
+
+		.wp-block-rss__item-title,
+		.wp-block-rss__item-author {
+			margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+		}
+	}
+
+	li {
+		margin-bottom: var(--global--spacing-vertical);
+
+		.wp-block-rss__item-publish-date,
+		.wp-block-rss__item-author {
+			color: var(--global--color-gray);
+		}
+	}
+}

--- a/assets/sass/05-blocks/rss/_editor.scss
+++ b/assets/sass/05-blocks/rss/_editor.scss
@@ -1,24 +1,109 @@
 .wp-block-rss {
+	padding-left: 0;
 
-	&.aligncenter,
-	&.alignright {
+	> li {
 		list-style: none;
+	}
+
+	// Vertical margins logic
+	&:not(.is-grid) > li {
+		margin-top: calc(1.666 * var(--global--spacing-vertical));
+		margin-bottom: calc(1.666 * var(--global--spacing-vertical));
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&.is-grid {
 
-		.wp-block-rss__item-title,
-		.wp-block-rss__item-author {
-			margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+		> li {
+			margin-bottom: var(--global--spacing-vertical);
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		// Remove bottom margins in grid columns
+		&.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+		&.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+		&.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+		&.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+		&.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+		&.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+		&.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+		&.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+		&.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+		&.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+			margin-bottom: 0;
 		}
 	}
 
-	li {
-		margin-bottom: var(--global--spacing-vertical);
+	> li > * {
+		margin-top: calc(0.333 * var(--global--spacing-vertical));
+		margin-bottom: calc(0.333 * var(--global--spacing-vertical));
 
-		.wp-block-rss__item-publish-date,
-		.wp-block-rss__item-author {
-			color: var(--global--color-gray);
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	// Post title
+	.wp-block-rss__item-title > a {
+		display: inline-block;
+		font-family: var(--latest-posts--title-font-family);
+		font-size: var(--latest-posts--title-font-size);
+		font-weight: var(--heading--font-weight);
+		line-height: var(--global--line-height-heading);
+		margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+	}
+
+	// Post author
+	.wp-block-rss__item-author {
+		color: var(--global--color-primary);
+		font-size: var(--global--font-size-md);
+		line-height: var(--global--line-height-body);
+	}
+
+	// Post date
+	.wp-block-rss__item-publish-date {
+		color: var(--global--color-primary);
+		font-size: var(--global--font-size-xs);
+		line-height: var(--global--line-height-body);
+
+		[class*="inner-container"] &,
+		.has-background & {
+			color: currentColor;
+		}
+	}
+
+	// Post content
+	.wp-block-rss__item-excerpt,
+	.wp-block-rss__item-full-content {
+		font-family: var(--latest-posts--description-font-family);
+		font-size: var(--latest-posts--description-font-size);
+		line-height: var(--global--line-height-body);
+		margin-top: calc(0.666 * var(--global--spacing-vertical));
+	}
+
+	// Utility classes
+	&.alignfull {
+		padding-left: var(--global--spacing-unit);
+		padding-right: var(--global--spacing-unit);
+
+		.entry-content [class*="inner-container"] &,
+		.entry-content .has-background & {
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 }

--- a/assets/sass/05-blocks/rss/_style.scss
+++ b/assets/sass/05-blocks/rss/_style.scss
@@ -1,0 +1,24 @@
+.wp-block-rss {
+
+	&.aligncenter,
+	&.alignright {
+		list-style: none;
+	}
+
+	&.is-grid {
+
+		.wp-block-rss__item-title,
+		.wp-block-rss__item-author {
+			margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+		}
+	}
+
+	li {
+		margin-bottom: var(--global--spacing-vertical);
+
+		.wp-block-rss__item-publish-date,
+		.wp-block-rss__item-author {
+			color: var(--global--color-gray);
+		}
+	}
+}

--- a/assets/sass/05-blocks/rss/_style.scss
+++ b/assets/sass/05-blocks/rss/_style.scss
@@ -1,24 +1,109 @@
 .wp-block-rss {
+	padding-left: 0;
 
-	&.aligncenter,
-	&.alignright {
+	> li {
 		list-style: none;
+	}
+
+	// Vertical margins logic
+	&:not(.is-grid) > li {
+		margin-top: calc(1.666 * var(--global--spacing-vertical));
+		margin-bottom: calc(1.666 * var(--global--spacing-vertical));
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&.is-grid {
 
-		.wp-block-rss__item-title,
-		.wp-block-rss__item-author {
-			margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+		> li {
+			margin-bottom: var(--global--spacing-vertical);
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		// Remove bottom margins in grid columns
+		&.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+		&.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+		&.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+		&.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+		&.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+		&.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+		&.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+		&.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+		&.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+		&.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+			margin-bottom: 0;
 		}
 	}
 
-	li {
-		margin-bottom: var(--global--spacing-vertical);
+	> li > * {
+		margin-top: calc(0.333 * var(--global--spacing-vertical));
+		margin-bottom: calc(0.333 * var(--global--spacing-vertical));
 
-		.wp-block-rss__item-publish-date,
-		.wp-block-rss__item-author {
-			color: var(--global--color-gray);
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	// Post title
+	.wp-block-rss__item-title > a {
+		display: inline-block;
+		font-family: var(--latest-posts--title-font-family);
+		font-size: var(--latest-posts--title-font-size);
+		font-weight: var(--heading--font-weight);
+		line-height: var(--global--line-height-heading);
+		margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+	}
+
+	// Post author
+	.wp-block-rss__item-author {
+		color: var(--global--color-primary);
+		font-size: var(--global--font-size-md);
+		line-height: var(--global--line-height-body);
+	}
+
+	// Post date
+	.wp-block-rss__item-publish-date {
+		color: var(--global--color-primary);
+		font-size: var(--global--font-size-xs);
+		line-height: var(--global--line-height-body);
+
+		[class*="inner-container"] &,
+		.has-background & {
+			color: currentColor;
+		}
+	}
+
+	// Post content
+	.wp-block-rss__item-excerpt,
+	.wp-block-rss__item-full-content {
+		font-family: var(--latest-posts--description-font-family);
+		font-size: var(--latest-posts--description-font-size);
+		line-height: var(--global--line-height-body);
+		margin-top: calc(0.666 * var(--global--spacing-vertical));
+	}
+
+	// Utility classes
+	&.alignfull {
+		padding-left: var(--global--spacing-unit);
+		padding-right: var(--global--spacing-unit);
+
+		.entry-content [class*="inner-container"] &,
+		.entry-content .has-background & {
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2569,6 +2569,24 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
+.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+	list-style: none;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-title,
+.wp-block-rss.is-grid .wp-block-rss__item-author {
+	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+}
+
+.wp-block-rss li {
+	margin-bottom: var(--global--spacing-vertical);
+}
+
+.wp-block-rss li .wp-block-rss__item-publish-date,
+.wp-block-rss li .wp-block-rss__item-author {
+	color: var(--global--color-gray);
+}
+
 .wp-block-search {
 	max-width: var(--responsive--aligndefault-width);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2569,22 +2569,104 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
-.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+.wp-block-rss {
+	padding-right: 0;
+}
+
+.wp-block-rss > li {
 	list-style: none;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-title,
-.wp-block-rss.is-grid .wp-block-rss__item-author {
-	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+.wp-block-rss:not(.is-grid) > li {
+	margin-top: calc(1.666 * var(--global--spacing-vertical));
+	margin-bottom: calc(1.666 * var(--global--spacing-vertical));
 }
 
-.wp-block-rss li {
+.wp-block-rss:not(.is-grid) > li:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss:not(.is-grid) > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid > li {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-rss li .wp-block-rss__item-publish-date,
-.wp-block-rss li .wp-block-rss__item-author {
-	color: var(--global--color-gray);
+.wp-block-rss.is-grid > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+	margin-bottom: 0;
+}
+
+.wp-block-rss > li > * {
+	margin-top: calc(0.333 * var(--global--spacing-vertical));
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss > li > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss > li > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss .wp-block-rss__item-title > a {
+	display: inline-block;
+	font-family: var(--latest-posts--title-font-family);
+	font-size: var(--latest-posts--title-font-size);
+	font-weight: var(--heading--font-weight);
+	line-height: var(--global--line-height-heading);
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss .wp-block-rss__item-author {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-md);
+	line-height: var(--global--line-height-body);
+}
+
+.wp-block-rss .wp-block-rss__item-publish-date {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-xs);
+	line-height: var(--global--line-height-body);
+}
+
+[class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
+.has-background .wp-block-rss .wp-block-rss__item-publish-date {
+	color: currentColor;
+}
+
+.wp-block-rss .wp-block-rss__item-excerpt,
+.wp-block-rss .wp-block-rss__item-full-content {
+	font-family: var(--latest-posts--description-font-family);
+	font-size: var(--latest-posts--description-font-size);
+	line-height: var(--global--line-height-body);
+	margin-top: calc(0.666 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss.alignfull {
+	padding-right: var(--global--spacing-unit);
+	padding-left: var(--global--spacing-unit);
+}
+
+.entry-content [class*="inner-container"] .wp-block-rss.alignfull,
+.entry-content .has-background .wp-block-rss.alignfull {
+	padding-right: 0;
+	padding-left: 0;
 }
 
 .wp-block-search {

--- a/style.css
+++ b/style.css
@@ -2577,22 +2577,104 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
-.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+.wp-block-rss {
+	padding-left: 0;
+}
+
+.wp-block-rss > li {
 	list-style: none;
 }
 
-.wp-block-rss.is-grid .wp-block-rss__item-title,
-.wp-block-rss.is-grid .wp-block-rss__item-author {
-	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+.wp-block-rss:not(.is-grid) > li {
+	margin-top: calc(1.666 * var(--global--spacing-vertical));
+	margin-bottom: calc(1.666 * var(--global--spacing-vertical));
 }
 
-.wp-block-rss li {
+.wp-block-rss:not(.is-grid) > li:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss:not(.is-grid) > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid > li {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-rss li .wp-block-rss__item-publish-date,
-.wp-block-rss li .wp-block-rss__item-author {
-	color: var(--global--color-gray);
+.wp-block-rss.is-grid > li:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1),
+.wp-block-rss.is-grid.columns-2 > li:nth-last-child(-n + 2):nth-child(2n + 1) ~ li,
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1),
+.wp-block-rss.is-grid.columns-3 > li:nth-last-child(-n + 3):nth-child(3n + 1) ~ li,
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1),
+.wp-block-rss.is-grid.columns-4 > li:nth-last-child(-n + 4):nth-child(4n + 1) ~ li,
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1),
+.wp-block-rss.is-grid.columns-5 > li:nth-last-child(-n + 5):nth-child(5n + 1) ~ li,
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1),
+.wp-block-rss.is-grid.columns-6 > li:nth-last-child(-n + 6):nth-child(6n + 1) ~ li {
+	margin-bottom: 0;
+}
+
+.wp-block-rss > li > * {
+	margin-top: calc(0.333 * var(--global--spacing-vertical));
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss > li > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-rss > li > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-rss .wp-block-rss__item-title > a {
+	display: inline-block;
+	font-family: var(--latest-posts--title-font-family);
+	font-size: var(--latest-posts--title-font-size);
+	font-weight: var(--heading--font-weight);
+	line-height: var(--global--line-height-heading);
+	margin-bottom: calc(0.333 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss .wp-block-rss__item-author {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-md);
+	line-height: var(--global--line-height-body);
+}
+
+.wp-block-rss .wp-block-rss__item-publish-date {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-xs);
+	line-height: var(--global--line-height-body);
+}
+
+[class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
+.has-background .wp-block-rss .wp-block-rss__item-publish-date {
+	color: currentColor;
+}
+
+.wp-block-rss .wp-block-rss__item-excerpt,
+.wp-block-rss .wp-block-rss__item-full-content {
+	font-family: var(--latest-posts--description-font-family);
+	font-size: var(--latest-posts--description-font-size);
+	line-height: var(--global--line-height-body);
+	margin-top: calc(0.666 * var(--global--spacing-vertical));
+}
+
+.wp-block-rss.alignfull {
+	padding-left: var(--global--spacing-unit);
+	padding-right: var(--global--spacing-unit);
+}
+
+.entry-content [class*="inner-container"] .wp-block-rss.alignfull,
+.entry-content .has-background .wp-block-rss.alignfull {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .wp-block-search {

--- a/style.css
+++ b/style.css
@@ -2577,6 +2577,24 @@ p.has-text-color a {
 	border-color: currentColor;
 }
 
+.wp-block-rss.aligncenter, .wp-block-rss.alignright {
+	list-style: none;
+}
+
+.wp-block-rss.is-grid .wp-block-rss__item-title,
+.wp-block-rss.is-grid .wp-block-rss__item-author {
+	margin-bottom: calc(var(--global--spacing-vertical) * 0.25);
+}
+
+.wp-block-rss li {
+	margin-bottom: var(--global--spacing-vertical);
+}
+
+.wp-block-rss li .wp-block-rss__item-publish-date,
+.wp-block-rss li .wp-block-rss__item-author {
+	color: var(--global--color-gray);
+}
+
 .wp-block-search {
 	max-width: var(--responsive--aligndefault-width);
 }


### PR DESCRIPTION
Fixes #200

For the meta texts, I used `--global--color-gray` which is defined as `#39414d`. The contrast ration between the meta text color and the background which uses `--global--color-green` and is defined as `#d1e4dd` is now 7.78:1 and therefore [passes the WCAG AAA standard](https://webaim.org/resources/contrastchecker/?fcolor=39414D&bcolor=D1E4DD).

## Left aligned 

<table>
<tr>
<td>Editor before:
<br><br>

![#200-editor-left-before](https://user-images.githubusercontent.com/3323310/94804718-80ffbc80-0415-11eb-88a2-85380d5fd048.png)
</td>
<td>Editor after:
<br><br>

![#200-editor-left-after](https://user-images.githubusercontent.com/3323310/94805069-fbc8d780-0415-11eb-8b3e-9e2b9363bd2c.png)
</td>
<td>Frontend before:
<br><br>

![#200-frontend-left-before](https://user-images.githubusercontent.com/3323310/94804892-bdcbb380-0415-11eb-841d-85766222c574.png)
</td>
<td>Frontend after:
<br><br>

![#200-frontend-left-after](https://user-images.githubusercontent.com/3323310/94805073-fcfa0480-0415-11eb-8e26-7d8fecc34003.png)
</td>
</tr>
</table>

## Center aligned

<table>
<tr>
<td>Editor before:
<br><br>

![#200-editor-center-before](https://user-images.githubusercontent.com/3323310/94803342-57de2c80-0413-11eb-8ccd-e6858ed76ff2.png)
</td>
<td>Editor after:
<br><br>

![#200-editor-center-after](https://user-images.githubusercontent.com/3323310/94803334-557bd280-0413-11eb-893f-be0f84676b17.png)
</td>
<td>Frontend before:
<br><br>

![#200-frontend-center-before](https://user-images.githubusercontent.com/3323310/94803355-5c0a4a00-0413-11eb-8809-e73b57991583.png)
</td>
<td>Frontend after:
<br><br>

![#200-frontend-center-after](https://user-images.githubusercontent.com/3323310/94803353-5b71b380-0413-11eb-82fd-1f27fc6f46ae.png)
</td>
</tr>
</table>

## Right aligned

<table>
<tr>
<td>Editor before:
<br><br>

![#200-editor-right-before](https://user-images.githubusercontent.com/3323310/94805472-a0e3b000-0416-11eb-96c0-250d28ceb962.png)
</td>
<td>Editor after:
<br><br>

![#200-editor-right-after](https://user-images.githubusercontent.com/3323310/94805479-a214dd00-0416-11eb-84c1-11278cfa13c8.png)
</td>
<td>Frontend before:
<br><br>

![#200-frontend-right-before](https://user-images.githubusercontent.com/3323310/94803364-5f053a80-0413-11eb-8da1-e3d36c8cb2d6.png)
</td>
<td>Frontend after:
<br><br>

![#200-frontend-right-after](https://user-images.githubusercontent.com/3323310/94803362-5e6ca400-0413-11eb-9281-7804bf9f2d98.png)
</td>
</tr>
</table>

## Grid aligned

<table>
<tr>
<td>Editor before:
<br><br>

![#200-editor-grid-before](https://user-images.githubusercontent.com/3323310/94803345-590f5980-0413-11eb-8e11-852e67d69b58.png)
</td>
<td>Editor after:
<br><br>

![#200-editor-grid-after](https://user-images.githubusercontent.com/3323310/94803344-5876c300-0413-11eb-87b0-d09956848e4b.png)
</td>
<td>Frontend before:
<br><br>

![#200-frontend-grid-before](https://user-images.githubusercontent.com/3323310/94803359-5ca2e080-0413-11eb-944d-ea40b9b4057d.png)
</td>
<td>Frontend after:
<br><br>

![#200-frontend-grid-after](https://user-images.githubusercontent.com/3323310/94803358-5ca2e080-0413-11eb-8c5f-8765796b8a3f.png)
</td>
</tr>
</table>