### PR TITLE
🐛 FIX: Align first social icon in editor (#203)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1637,6 +1637,10 @@ hr {
 	border-color: currentColor;
 }
 
+.wp-block-social-links li.wp-block-social-link:first-child {
+	margin-top: auto;
+}
+
 table th {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1248,6 +1248,10 @@ hr {
 	border-color: currentColor;
 }
 
+.wp-block-social-links li.wp-block-social-link:first-child {
+	margin-top: auto;
+}
+
 table th,
 .wp-block-table th {
 	font-family: var(--heading--font-family);

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -22,6 +22,7 @@
 @import "quote/editor";
 @import "search/editor";
 @import "separator/editor";
+@import "social-icons/editor";
 @import "table/editor";
 @import "verse/editor";
 @import "utilities/editor"; // Import LAST to cascade properly

--- a/assets/sass/05-blocks/social-icons/_editor.scss
+++ b/assets/sass/05-blocks/social-icons/_editor.scss
@@ -1,0 +1,6 @@
+.wp-block-social-links {
+
+	li.wp-block-social-link:first-child {
+		margin-top: auto;
+	}
+}


### PR DESCRIPTION
Fixes #203 

<table>
<tr>
<td>Before:
<br><br>

![#203-after-editor](https://user-images.githubusercontent.com/3323310/94817056-ce385a00-0426-11eb-98c0-60f5c4ba4d3b.png)
</td>
<td>After:
<br><br>

![#203-before-editor](https://user-images.githubusercontent.com/3323310/94817047-cc6e9680-0426-11eb-8cb2-c5f7d881ba34.png)
</td>
</tr>
</table>

**Note**

I had to use `.wp-block-social-links li.wp-block-social-link:first-child` instead of `.wp-block-social-links li.:first-child` due to [CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).