### PR TITLE
Add and adjust global page title line height

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1606,13 +1606,7 @@ pre.wp-block-verse {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-weight: 300;
 	font-size: 4rem;
-	line-height: 4rem;
-}
-
-@media only screen and (min-width: 652px){
-	.wp-block.editor-post-title__block .editor-post-title__input{
-	line-height: 6rem;
-	}
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -805,7 +805,7 @@ h6[style*="--wp--typography--line-height"] {
 .wp-block-heading h1 {
 	font-size: 4rem;
 	letter-spacing: normal;
-	line-height: 1.3;
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){
@@ -817,7 +817,7 @@ h6[style*="--wp--typography--line-height"] {
 h1 {
 	font-size: 4rem;
 	letter-spacing: normal;
-	line-height: 1.3;
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){
@@ -829,7 +829,7 @@ h1 {
 .h1 {
 	font-size: 4rem;
 	letter-spacing: normal;
-	line-height: 1.3;
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){
@@ -1606,7 +1606,13 @@ pre.wp-block-verse {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-weight: 300;
 	font-size: 4rem;
-	line-height: 1.3;
+	line-height: 4rem;
+}
+
+@media only screen and (min-width: 652px){
+	.wp-block.editor-post-title__block .editor-post-title__input{
+	line-height: 6rem;
+	}
 }
 
 @media only screen and (min-width: 652px){
@@ -1740,8 +1746,8 @@ pre.wp-block-verse {
 	font-weight: 300;
 }
 
-@media only screen and (min-width: 652px) {
-	.is-gigantic-text {
+@media only screen and (min-width: 652px){
+	.is-gigantic-text{
 	font-size: 6rem;
 	}
 }
@@ -1752,8 +1758,8 @@ pre.wp-block-verse {
 	font-weight: 300;
 }
 
-@media only screen and (min-width: 652px) {
-	.has-gigantic-font-size {
+@media only screen and (min-width: 652px){
+	.has-gigantic-font-size{
 	font-size: 6rem;
 	}
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2422,7 +2422,7 @@ h6 strong {
 h1 {
 	font-size: 4rem;
 	letter-spacing: normal;
-	line-height: 1.3;
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){
@@ -2434,7 +2434,7 @@ h1 {
 .h1 {
 	font-size: 4rem;
 	letter-spacing: normal;
-	line-height: 1.3;
+	line-height: 1.1;
 }
 
 @media only screen and (min-width: 652px){
@@ -3934,6 +3934,7 @@ nav a {
 }
 
 h1.entry-title {
+	line-height: 1.1;
 	font-weight: 300;
 }
 
@@ -4199,6 +4200,10 @@ h1.page-title {
 
 h2.page-title {
 	font-weight: 300;
+}
+
+h1.page-title {
+	line-height: 1.1;
 }
 
 .page-header {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -23,6 +23,7 @@
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
@@ -43,7 +44,7 @@
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: var(--heading--line-height);
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -1215,7 +1216,7 @@ pre.wp-block-verse {
 	font-family: var(--heading--font-family);
 	font-weight: var(--heading--font-weight-page-title);
 	font-size: var(--global--font-size-page-title);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--font-size-h1);
 }
 
 .wp-block.block-editor-default-block-appender > textarea {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1216,7 +1216,7 @@ pre.wp-block-verse {
 	font-family: var(--heading--font-family);
 	font-weight: var(--heading--font-weight-page-title);
 	font-size: var(--global--font-size-page-title);
-	line-height: var(--heading--font-size-h1);
+	line-height: var(--heading--line-height-h1);
 }
 
 .wp-block.block-editor-default-block-appender > textarea {

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -27,6 +27,7 @@ $baseline-unit: 10px;
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
@@ -51,7 +52,7 @@ $baseline-unit: 10px;
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: var(--heading--line-height);
+	--heading--line-height-h1: var(--global--line-height-page-title);
 
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;

--- a/assets/sass/05-blocks/utilities/_editor.scss
+++ b/assets/sass/05-blocks/utilities/_editor.scss
@@ -15,7 +15,7 @@
 		font-family: var(--heading--font-family);
 		font-weight: var(--heading--font-weight-page-title);
 		font-size: var(--global--font-size-page-title);
-		line-height: var(--heading--font-size-h1);
+		line-height: var(--heading--line-height-h1);
 	}
 }
 

--- a/assets/sass/05-blocks/utilities/_editor.scss
+++ b/assets/sass/05-blocks/utilities/_editor.scss
@@ -15,7 +15,7 @@
 		font-family: var(--heading--font-family);
 		font-weight: var(--heading--font-weight-page-title);
 		font-size: var(--global--font-size-page-title);
-		line-height: var(--heading--line-height);
+		line-height: var(--heading--font-size-h1);
 	}
 }
 

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -8,6 +8,10 @@ h2.page-title {
 	font-weight: var(--heading--font-weight-page-title);
 }
 
+h1.page-title {
+	line-height: var(--heading--line-height-h1);
+}
+
 .page-header {
 	border-bottom: 3px solid var(--global--color-border);
 	padding-bottom: calc(2 * var(--global--spacing-vertical));

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -28,6 +28,7 @@
 }
 
 h1.entry-title {
+	line-height: var(--heading--line-height-h1);
 	font-weight: var(--heading--font-weight-page-title);
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -114,6 +114,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
@@ -134,7 +135,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: var(--heading--line-height);
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -2772,6 +2773,7 @@ nav a {
 }
 
 h1.entry-title {
+	line-height: var(--heading--line-height-h1);
 	font-weight: var(--heading--font-weight-page-title);
 }
 
@@ -2984,6 +2986,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 h1.page-title,
 h2.page-title {
 	font-weight: var(--heading--font-weight-page-title);
+}
+
+h1.page-title {
+	line-height: var(--heading--line-height-h1);
 }
 
 .page-header {

--- a/style.css
+++ b/style.css
@@ -114,6 +114,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
@@ -134,7 +135,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: var(--heading--line-height);
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -2785,6 +2786,7 @@ nav a {
 }
 
 h1.entry-title {
+	line-height: var(--heading--line-height-h1);
 	font-weight: var(--heading--font-weight-page-title);
 }
 
@@ -2997,6 +2999,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 h1.page-title,
 h2.page-title {
 	font-weight: var(--heading--font-weight-page-title);
+}
+
+h1.page-title {
+	line-height: var(--heading--line-height-h1);
 }
 
 .page-header {


### PR DESCRIPTION
The line height of entry and page titles is reduced from 1.3 to 1.1 for all screens. A take to solve #193.

I am not sure if this is the right approach, so please comment.