### PR TITLE
FIX: fixing tables with a background-color on a dark page background

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1688,11 +1688,27 @@ table.is-style-regular .has-background {
 	color: #28303d;
 }
 
+table.is-style-stripes .has-background thead tr {
+	color: #28303d;
+}
+
+table.is-style-stripes .has-background tfoot tr {
+	color: #28303d;
+}
+
 table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: #28303d;
 }
 
 .wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background thead tr {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background tfoot tr {
 	color: #28303d;
 }
 
@@ -1708,7 +1724,9 @@ table.is-style-stripes {
 	border-color: #f0f0f0;
 }
 
+table.is-style-stripes th,
 table.is-style-stripes td,
+.wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes td {
 	border-width: 0;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1684,12 +1684,33 @@ table th {
 	padding: 10px;
 }
 
+table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: #28303d;
+}
+
 table.is-style-stripes {
 	border-color: #f0f0f0;
 }
 
 .wp-block-table.is-style-stripes {
 	border-color: #f0f0f0;
+}
+
+table.is-style-stripes td,
+.wp-block-table.is-style-stripes td {
+	border-width: 0;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd) {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3765,12 +3765,33 @@ table th {
 	word-break: break-all;
 }
 
+table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: #28303d;
+}
+
 table.is-style-stripes {
 	border-color: #f0f0f0;
 }
 
 .wp-block-table.is-style-stripes {
 	border-color: #f0f0f0;
+}
+
+table.is-style-stripes td,
+.wp-block-table.is-style-stripes td {
+	border-width: 0;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd) {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3769,11 +3769,27 @@ table.is-style-regular .has-background {
 	color: #28303d;
 }
 
+table.is-style-stripes .has-background thead tr {
+	color: #28303d;
+}
+
+table.is-style-stripes .has-background tfoot tr {
+	color: #28303d;
+}
+
 table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: #28303d;
 }
 
 .wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background thead tr {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background tfoot tr {
 	color: #28303d;
 }
 
@@ -3789,7 +3805,9 @@ table.is-style-stripes {
 	border-color: #f0f0f0;
 }
 
+table.is-style-stripes th,
 table.is-style-stripes td,
+.wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes td {
 	border-width: 0;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1287,8 +1287,12 @@ table th,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background thead tr,
+table.is-style-stripes .has-background tfoot tr,
 table.is-style-stripes .has-background tbody tr:nth-child(even),
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background thead tr,
+.wp-block-table.is-style-stripes .has-background tfoot tr,
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: var(--table--has-background-text-color);
 }
@@ -1298,7 +1302,9 @@ table.is-style-stripes,
 	border-color: var(--table--stripes-border-color);
 }
 
+table.is-style-stripes th,
 table.is-style-stripes td,
+.wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes td {
 	border-width: 0;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -208,6 +208,8 @@
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
+	--table--has-background-border-color: var(--global--color-dark-gray);
+	--table--has-background-text-color: var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -1284,9 +1286,21 @@ table th,
 	padding: calc(0.5 * var(--global--spacing-unit));
 }
 
+table.is-style-regular .has-background,
+table.is-style-stripes .has-background tbody tr:nth-child(even),
+.wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: var(--table--has-background-text-color);
+}
+
 table.is-style-stripes,
 .wp-block-table.is-style-stripes {
 	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes td,
+.wp-block-table.is-style-stripes td {
+	border-width: 0;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -236,6 +236,8 @@ $baseline-unit: 10px;
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
+	--table--has-background-border-color: var(--global--color-dark-gray);
+	--table--has-background-text-color: var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 652px) { // Not using the mixin because it's compiled after this file

--- a/assets/sass/05-blocks/table/_editor.scss
+++ b/assets/sass/05-blocks/table/_editor.scss
@@ -10,8 +10,17 @@ table,
 		padding: calc(0.5 * var(--global--spacing-unit));
 	}
 
+	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background tbody tr:nth-child(even) {
+		color: var(--table--has-background-text-color);
+	}
+
 	&.is-style-stripes {
 		border-color: var(--table--stripes-border-color);
+
+		td {
+			border-width: 0;
+		}
 
 		tbody tr:nth-child(odd) {
 			background-color: var(--table--stripes-background-color);

--- a/assets/sass/05-blocks/table/_editor.scss
+++ b/assets/sass/05-blocks/table/_editor.scss
@@ -11,6 +11,8 @@ table,
 	}
 
 	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background thead tr,
+	&.is-style-stripes .has-background tfoot tr,
 	&.is-style-stripes .has-background tbody tr:nth-child(even) {
 		color: var(--table--has-background-text-color);
 	}
@@ -18,6 +20,7 @@ table,
 	&.is-style-stripes {
 		border-color: var(--table--stripes-border-color);
 
+		th,
 		td {
 			border-width: 0;
 		}

--- a/assets/sass/05-blocks/table/_style.scss
+++ b/assets/sass/05-blocks/table/_style.scss
@@ -15,8 +15,17 @@ table,
 		word-break: break-all;
 	}
 
+	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background tbody tr:nth-child(even) {
+		color: var(--table--has-background-text-color);
+	}
+
 	&.is-style-stripes {
 		border-color: var(--table--stripes-border-color);
+
+		td {
+			border-width: 0;
+		}
 
 		tbody tr:nth-child(odd) {
 			background-color: var(--table--stripes-background-color);

--- a/assets/sass/05-blocks/table/_style.scss
+++ b/assets/sass/05-blocks/table/_style.scss
@@ -16,6 +16,8 @@ table,
 	}
 
 	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background thead tr,
+	&.is-style-stripes .has-background tfoot tr,
 	&.is-style-stripes .has-background tbody tr:nth-child(even) {
 		color: var(--table--has-background-text-color);
 	}
@@ -23,6 +25,7 @@ table,
 	&.is-style-stripes {
 		border-color: var(--table--stripes-border-color);
 
+		th,
 		td {
 			border-width: 0;
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2681,8 +2681,12 @@ table th,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background thead tr,
+table.is-style-stripes .has-background tfoot tr,
 table.is-style-stripes .has-background tbody tr:nth-child(even),
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background thead tr,
+.wp-block-table.is-style-stripes .has-background tfoot tr,
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: var(--table--has-background-text-color);
 }
@@ -2692,7 +2696,9 @@ table.is-style-stripes,
 	border-color: var(--table--stripes-border-color);
 }
 
+table.is-style-stripes th,
 table.is-style-stripes td,
+.wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes td {
 	border-width: 0;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -299,6 +299,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
+	--table--has-background-border-color: var(--global--color-dark-gray);
+	--table--has-background-text-color: var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -2678,9 +2680,21 @@ table th,
 	word-break: break-all;
 }
 
+table.is-style-regular .has-background,
+table.is-style-stripes .has-background tbody tr:nth-child(even),
+.wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: var(--table--has-background-text-color);
+}
+
 table.is-style-stripes,
 .wp-block-table.is-style-stripes {
 	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes td,
+.wp-block-table.is-style-stripes td {
+	border-width: 0;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/style.css
+++ b/style.css
@@ -2689,8 +2689,12 @@ table th,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background thead tr,
+table.is-style-stripes .has-background tfoot tr,
 table.is-style-stripes .has-background tbody tr:nth-child(even),
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background thead tr,
+.wp-block-table.is-style-stripes .has-background tfoot tr,
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: var(--table--has-background-text-color);
 }
@@ -2700,7 +2704,9 @@ table.is-style-stripes,
 	border-color: var(--table--stripes-border-color);
 }
 
+table.is-style-stripes th,
 table.is-style-stripes td,
+.wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes td {
 	border-width: 0;
 }

--- a/style.css
+++ b/style.css
@@ -299,6 +299,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
+	--table--has-background-border-color: var(--global--color-dark-gray);
+	--table--has-background-text-color: var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 652px) {
@@ -2686,9 +2688,21 @@ table th,
 	word-break: break-all;
 }
 
+table.is-style-regular .has-background,
+table.is-style-stripes .has-background tbody tr:nth-child(even),
+.wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+	color: var(--table--has-background-text-color);
+}
+
 table.is-style-stripes,
 .wp-block-table.is-style-stripes {
 	border-color: var(--table--stripes-border-color);
+}
+
+table.is-style-stripes td,
+.wp-block-table.is-style-stripes td {
+	border-width: 0;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),


### PR DESCRIPTION
This will set an alternating text color for tables using the stripes style and a dark text color for tables using the regular style. It will also fix the second issue with the borders on bottom and right.

**Screenshots**

| Before | After| 
| --------|------| 
| ![table-dark-background-before](https://user-images.githubusercontent.com/1793177/94857601-0ee9a080-0432-11eb-8cdc-f0e894e25b45.PNG) | ![table-dark-background-after](https://user-images.githubusercontent.com/1793177/94857630-1c068f80-0432-11eb-91d7-7eada3cae148.PNG) | 

| Before | After |
|--------|------|
| ![table-light-background-before](https://user-images.githubusercontent.com/1793177/94857644-20cb4380-0432-11eb-87fb-0f8e7b8be331.PNG) | ![table-light-background-after](https://user-images.githubusercontent.com/1793177/94857655-258ff780-0432-11eb-8dfd-712f673f3a1b.PNG) |

Fixes #226 
