### PR TITLE
FIX: remove the static page-title "Blog" from home

### DIFF
--- a/home.php
+++ b/home.php
@@ -14,9 +14,6 @@ get_header();
 if ( have_posts() ) {
 
 	?>
-	<header class="page-header alignwide">
-		<h2 class="page-title"><?php esc_html_e( 'Blog', 'twentytwentyone' ); ?></h2>
-	</header><!-- .page-header -->
 	<?php
 	// Load posts loop.
 	while ( have_posts() ) {


### PR DESCRIPTION
A secondary issue with the static page-title "Blog": it has the same level as the blog titles, which will probably impact the clear headline structure of the home.php template.

This PR suggest to remove the static page-title completely, similar to other (default) themes.

Fixes #213