### PR TITLE
Update audio focus styles

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2088,12 +2088,9 @@ a:hover {
 }
 
 /* Category 05 is all about adjusting the default block styles to the given layout. I only added three blocks as examples. */
-.wp-block-audio {
-	min-width: inherit;
-}
-
-.wp-block-audio.alignleft, .wp-block-audio.alignright {
-	min-width: 300px;
+.wp-block-audio audio:focus {
+	outline-offset: 5px;
+	outline: 2px solid #28303d;
 }
 
 /**

--- a/assets/sass/05-blocks/audio/_style.scss
+++ b/assets/sass/05-blocks/audio/_style.scss
@@ -1,9 +1,7 @@
 .wp-block-audio {
 
-	min-width: inherit;
-
-	&.alignleft,
-	&.alignright {
-		min-width: 300px;
+	audio:focus {
+		outline-offset: 5px;
+		outline: 2px solid var(--global--color-primary);
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1509,12 +1509,9 @@ a:hover {
 }
 
 /* Category 05 is all about adjusting the default block styles to the given layout. I only added three blocks as examples. */
-.wp-block-audio {
-	min-width: inherit;
-}
-
-.wp-block-audio.alignleft, .wp-block-audio.alignright {
-	min-width: 300px;
+.wp-block-audio audio:focus {
+	outline-offset: 5px;
+	outline: 2px solid var(--global--color-primary);
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -1517,12 +1517,9 @@ a:hover {
 }
 
 /* Category 05 is all about adjusting the default block styles to the given layout. I only added three blocks as examples. */
-.wp-block-audio {
-	min-width: inherit;
-}
-
-.wp-block-audio.alignleft, .wp-block-audio.alignright {
-	min-width: 300px;
+.wp-block-audio audio:focus {
+	outline-offset: 5px;
+	outline: 2px solid var(--global--color-primary);
 }
 
 /**


### PR DESCRIPTION
Updates the audio focus styles.
The primary color is used to make sure that the focus is visible on all backgrounds.

Removes the style for the width since the same width is already in the block library styles. The width of the aligned items was tested in multiple combinations with other blocks.
See 
https://github.com/WordPress/gutenberg/commit/567875eaa8dfddd863dd972e7e96ec4306798801#diff-cc1a89df338f7b42f8fd932ff37e9407

Closes https://github.com/WordPress/twentytwentyone/issues/207