### PR TITLE
Set PHP version to 5.6 to match PHPCS

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE


### PR DESCRIPTION
In setting up the demo site, which runs on a server using the WP minimum of PHP 5.6, the theme would not activate.

In examining the `phpcs.xml.dist`, we are testing for PHP 5.6 compat and, by manually removing the line from `style.css`, the theme appears to activate and work without issue.

This PR would update the minimum PHP version to the WP current minimum of 5.6.