### PR TITLE
Allow for flexible logo sizes

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4139,6 +4139,7 @@ nav a {
 	max-width: 96px;
 	max-height: 96px;
 	height: auto;
+	width: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -4146,6 +4147,7 @@ nav a {
 		max-width: 300px;
 		max-height: 100px;
 		height: auto;
+		width: auto;
 	}
 }
 

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -89,6 +89,7 @@ nav a {
 		max-width: var(--branding--logo--max-width-mobile);
 		max-height: var(--branding--logo--max-height-mobile);
 		height: auto;
+		width: auto;
 	}
 
 	@include media(mobile) {
@@ -97,6 +98,7 @@ nav a {
 			max-width: var(--branding--logo--max-width);
 			max-height: var(--branding--logo--max-height);
 			height: auto;
+			width: auto;
 		}
 	}
 }

--- a/footer.php
+++ b/footer.php
@@ -23,7 +23,7 @@
 		<div class="site-info">
 			<div class="site-name">
 				<?php if ( has_custom_logo() ) : ?>
-					<?php the_custom_logo(); ?>
+					<div class="site-logo"><?php the_custom_logo(); ?></div>
 					<?php
 					else :
 						$blog_info = get_bloginfo( 'name' );

--- a/functions.php
+++ b/functions.php
@@ -95,8 +95,8 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) :
 			array(
 				'height'               => $logo_height,
 				'width'                => $logo_width,
-				'flex-width'           => false,
-				'flex-height'          => false,
+				'flex-width'           => true,
+				'flex-height'          => true,
 				'unlink-homepage-logo' => true,
 			)
 		);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2931,6 +2931,7 @@ nav a {
 	max-width: var(--branding--logo--max-width-mobile);
 	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+	width: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -2938,6 +2939,7 @@ nav a {
 		max-width: var(--branding--logo--max-width);
 		max-height: var(--branding--logo--max-height);
 		height: auto;
+		width: auto;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -2944,6 +2944,7 @@ nav a {
 	max-width: var(--branding--logo--max-width-mobile);
 	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+	width: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -2951,6 +2952,7 @@ nav a {
 		max-width: var(--branding--logo--max-width);
 		max-height: var(--branding--logo--max-height);
 		height: auto;
+		width: auto;
 	}
 }
 


### PR DESCRIPTION
A larger image can be uploaded and displayed, and the CSS will take care of making it the expected size on the frontend. Using this method, we can remove the `retina_logo` option, because larger image sizes will be supported.

See #57 

To test:

- Open the customizer and choose a large (1000px+) image for your site logo
- You should be able to skip the cropping step, or crop it to the 3:1 aspect ratio
- When saved, you see the image in the header & footer 👍 
