### PR TITLE
Remove horizontal margin on the site logo

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4132,7 +4132,7 @@ nav a {
 }
 
 .site-logo {
-	margin: 15px 25px;
+	margin: 15px 0;
 }
 
 .site-logo .custom-logo {

--- a/assets/sass/01-settings/file-header.scss
+++ b/assets/sass/01-settings/file-header.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -83,7 +83,7 @@ nav a {
 
 .site-logo {
 
-	margin: calc(var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
+	margin: calc(var(--global--spacing-vertical) / 2) 0;
 
 	.custom-logo {
 		max-width: var(--branding--logo--max-width-mobile);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2925,7 +2925,7 @@ nav a {
 }
 
 .site-logo {
-	margin: calc(var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
+	margin: calc(var(--global--spacing-vertical) / 2) 0;
 }
 
 .site-logo .custom-logo {

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
@@ -2938,7 +2938,7 @@ nav a {
 }
 
 .site-logo {
-	margin: calc(var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
+	margin: calc(var(--global--spacing-vertical) / 2) 0;
 }
 
 .site-logo .custom-logo {


### PR DESCRIPTION
Currently, the logo has a left and right margin, which means the logo does not align to the side of the container. This PR removes that margin.

Before | After
----- | -----
![image](https://user-images.githubusercontent.com/2846578/94966756-ca124800-04cb-11eb-92f9-7e9c266d8b3c.png) | ![image](https://user-images.githubusercontent.com/2846578/94966691-b36bf100-04cb-11eb-81bd-c467c68d9f07.png)
