### PR TITLE
Fix fullwidth blocks

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -925,23 +925,23 @@ hr.wp-block-separator.is-style-wide {
 }
 
 .full-max-width {
-	max-width: calc(100% + 50px);
-	width: calc(100% + 50px);
-	margin-left: -25px;
+	max-width: 100%;
+	width: 100%;
+	margin-left: auto;
 	margin-right: auto;
 }
 
 .wp-block-group .wp-block-group__inner-container > *.alignfull {
-	max-width: calc(100% + 50px);
-	width: calc(100% + 50px);
-	margin-left: -25px;
+	max-width: 100%;
+	width: 100%;
+	margin-left: auto;
 	margin-right: auto;
 }
 
 .alignfull {
-	max-width: calc(100% + 50px);
-	width: calc(100% + 50px);
-	margin-left: -25px;
+	max-width: 100%;
+	width: 100%;
+	margin-left: auto;
 	margin-right: auto;
 }
 

--- a/assets/sass/03-generic/breakpoints.scss
+++ b/assets/sass/03-generic/breakpoints.scss
@@ -124,9 +124,9 @@ $breakpoint_xxl: 1024px;
 }
 
 %responsive-alignfull-width-mobile {
-	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	margin-left: calc(-1 * var(--global--spacing-horizontal));
+	max-width: var(--responsive--alignfull-width);
+	width: var(--responsive--alignfull-width);
+	margin-left: auto;
 	margin-right: auto;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -791,9 +791,9 @@ template {
 }
 
 .full-max-width, .wp-block-group .wp-block-group__inner-container > *.alignfull, .alignfull {
-	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	margin-right: calc(-1 * var(--global--spacing-horizontal));
+	max-width: var(--responsive--alignfull-width);
+	width: var(--responsive--alignfull-width);
+	margin-right: auto;
 	margin-left: auto;
 }
 

--- a/style.css
+++ b/style.css
@@ -791,9 +791,9 @@ template {
 }
 
 .full-max-width, .wp-block-group .wp-block-group__inner-container > *.alignfull, .alignfull {
-	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	width: calc(100% + (2 * var(--global--spacing-horizontal)));
-	margin-left: calc(-1 * var(--global--spacing-horizontal));
+	max-width: var(--responsive--alignfull-width);
+	width: var(--responsive--alignfull-width);
+	margin-left: auto;
 	margin-right: auto;
 }
 


### PR DESCRIPTION
Devices below the small (482px) breakpoint have full-width blocks set to `calc(100% + 50px)` for `width` and `max-width`, and a left margin of `-25px`. This makes fullwidth blocks overflow the screen.

This removes that behavior and uses the maximum width allowed.

Fixes #236 
Fixes #240 