### PR TITLE
Fix left & right block align

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3876,21 +3876,21 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 		/*rtl:ignore*/
 		margin-left: 25px;
 	}
-	.entry-content > .alignleft {
+	.entry-content > .alignright {
 		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
-		.entry-content > .alignleft{
+		.entry-content > .alignright{
 		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
-		.entry-content > .alignleft{
+		.entry-content > .alignright{
 		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
-		.entry-content > .alignleft{
+		.entry-content > .alignright{
 		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1038,9 +1038,22 @@ hr.wp-block-separator.is-style-wide {
 
 .entry-content > .alignleft {
 	/*rtl:ignore*/
-	margin-left: 0;
+	margin-left: 30px;
 	/*rtl:ignore*/
 	margin-right: 30px;
+	max-width: calc(100vw - 30px);
+}
+
+@media only screen and (min-width: 482px){
+	.entry-content > .alignleft{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
+	.entry-content > .alignleft{
+	max-width: min(calc(100vw - 200px), 610px);
+	}
 }
 
 @media only screen and (min-width: 482px) {
@@ -1049,6 +1062,22 @@ hr.wp-block-separator.is-style-wide {
 		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 822px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
@@ -2575,10 +2604,6 @@ a:hover {
 	font: 1.125rem;
 }
 
-.wp-block-gallery.alignleft, .wp-block-gallery.alignright {
-	max-width: 50%;
-}
-
 .wp-block-group .wp-block-group__inner-container {
 	margin-left: auto;
 	margin-right: auto;
@@ -3810,22 +3835,6 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 	/*rtl:ignore*/
 	margin-right: 25px;
 	margin-bottom: 30px;
-}
-
-.entry-content > .alignleft {
-	max-width: calc(100vw - 30px);
-}
-
-@media only screen and (min-width: 482px){
-	.entry-content > .alignleft{
-	max-width: min(calc(100vw - 100px), 610px);
-	}
-}
-
-@media only screen and (min-width: 822px){
-	.entry-content > .alignleft{
-	max-width: min(calc(100vw - 200px), 610px);
-	}
 }
 
 /**

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1036,48 +1036,12 @@ hr.wp-block-separator.is-style-wide {
 	}
 }
 
-.entry-content > .alignleft {
-	/*rtl:ignore*/
-	margin-left: 30px;
-	/*rtl:ignore*/
-	margin-right: 30px;
-	max-width: calc(100vw - 30px);
-}
-
-@media only screen and (min-width: 482px){
-	.entry-content > .alignleft{
-	max-width: min(calc(100vw - 100px), 610px);
-	}
-}
-
-@media only screen and (min-width: 822px){
-	.entry-content > .alignleft{
-	max-width: min(calc(100vw - 200px), 610px);
-	}
-}
-
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
 		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
-	}
-	@media only screen and (min-width: 482px){
-		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
-		}
-	}
-	@media only screen and (min-width: 482px){
-		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
-		}
-	}
-	@media only screen and (min-width: 822px){
-		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
-		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
@@ -1094,13 +1058,6 @@ hr.wp-block-separator.is-style-wide {
 		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
-}
-
-.entry-content > .alignright {
-	/*rtl:ignore*/
-	margin-left: 30px;
-	/*rtl:ignore*/
-	margin-right: 0;
 }
 
 @media only screen and (min-width: 482px) {
@@ -3829,12 +3786,51 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 .alignleft {
 	/*rtl:ignore*/
 	text-align: left;
-	/*rtl:ignore*/
-	float: left;
 	margin-top: 0;
-	/*rtl:ignore*/
-	margin-right: 25px;
-	margin-bottom: 30px;
+}
+
+.entry-content > .alignleft {
+	max-width: calc(100vw - 30px);
+}
+
+@media only screen and (min-width: 482px){
+	.entry-content > .alignleft{
+	max-width: min(calc(100vw - 100px), 610px);
+	}
+}
+
+@media only screen and (min-width: 822px){
+	.entry-content > .alignleft{
+	max-width: min(calc(100vw - 200px), 610px);
+	}
+}
+
+@media only screen and (min-width: 482px) {
+	.alignleft {
+		/*rtl:ignore*/
+		float: left;
+		/*rtl:ignore*/
+		margin-right: 25px;
+		margin-bottom: 30px;
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 822px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
 }
 
 /**
@@ -3853,12 +3849,8 @@ table.is-style-stripes tbody tr:nth-child(odd) {
  * .alignright
  */
 .alignright {
-	/*rtl:ignore*/
-	float: right;
 	margin-top: 0;
 	margin-bottom: 30px;
-	/*rtl:ignore*/
-	margin-left: 25px;
 }
 
 .entry-content > .alignright {
@@ -3874,6 +3866,33 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 @media only screen and (min-width: 822px){
 	.entry-content > .alignright{
 	max-width: min(calc(100vw - 200px), 610px);
+	}
+}
+
+@media only screen and (min-width: 482px) {
+	.alignright {
+		/*rtl:ignore*/
+		float: right;
+		/*rtl:ignore*/
+		margin-left: 25px;
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 482px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
+	}
+	@media only screen and (min-width: 822px){
+		.entry-content > .alignleft{
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		}
 	}
 }
 

--- a/assets/sass/05-blocks/gallery/_style.scss
+++ b/assets/sass/05-blocks/gallery/_style.scss
@@ -15,10 +15,4 @@
 			font: var(--global--font-size-sm);
 		}
 	}
-
-	// Apply max-width to floated items that have no intrinsic width.
-	&.alignleft,
-	&.alignright {
-		max-width: 50%;
-	}
 }

--- a/assets/sass/05-blocks/utilities/_style.scss
+++ b/assets/sass/05-blocks/utilities/_style.scss
@@ -82,7 +82,7 @@
 		margin-left: var(--global--spacing-horizontal);
 	}
 
-	.entry-content > .alignleft {
+	.entry-content > .alignright {
 		max-width: calc(50% - var(--responsive--alignright-margin));
 	}
 }

--- a/assets/sass/05-blocks/utilities/_style.scss
+++ b/assets/sass/05-blocks/utilities/_style.scss
@@ -16,21 +16,31 @@
 	/*rtl:ignore*/
 	text-align: left;
 
-	/*rtl:ignore*/
-	float: left;
 	margin-top: 0;
-
-	/*rtl:ignore*/
-	margin-right: var(--global--spacing-horizontal);
-	margin-bottom: var(--global--spacing-vertical);
 }
 
 // Targeting the .entry-content class is necessary to ensure these styles
 // only apply when the block isn't nested.
 .entry-content > .alignleft {
 	max-width: var(--responsive--aligndefault-width);
-	@extend %responsive-alignleft-mobile;
 	@extend %responsive-alignleft;
+}
+
+@include media(mobile) {
+
+	.alignleft {
+
+		/*rtl:ignore*/
+		float: left;
+
+		/*rtl:ignore*/
+		margin-right: var(--global--spacing-horizontal);
+		margin-bottom: var(--global--spacing-vertical);
+	}
+
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignleft-margin));
+	}
 }
 
 /**
@@ -50,21 +60,31 @@
  */
 .alignright {
 
-	/*rtl:ignore*/
-	float: right;
 	margin-top: 0;
 	margin-bottom: var(--global--spacing-vertical);
-
-	/*rtl:ignore*/
-	margin-left: var(--global--spacing-horizontal);
 }
 
 // Targeting the .entry-content class is necessary to ensure these styles
 // only apply when the block isn't nested.
 .entry-content > .alignright {
 	max-width: var(--responsive--aligndefault-width);
-	@extend %responsive-alignright-mobile;
 	@extend %responsive-alignright;
+}
+
+@include media(mobile) {
+
+	.alignright {
+
+		/*rtl:ignore*/
+		float: right;
+
+		/*rtl:ignore*/
+		margin-left: var(--global--spacing-horizontal);
+	}
+
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignright-margin));
+	}
 }
 
 // Make sure siblings of floated elements are top-aligned when nested

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -815,14 +815,16 @@ template {
 }
 
 .entry-content > .alignleft {
-	margin-left: 0;
+	margin-left: var(--responsive--spacing-horizontal);
 	margin-right: var(--responsive--spacing-horizontal);
+	max-width: var(--responsive--aligndefault-width);
 }
 
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		margin-left: var(--responsive--alignleft-margin);
 		margin-right: var(--global--spacing-horizontal);
+		max-width: calc(50% - var(--responsive--alignleft-margin));
 	}
 }
 
@@ -1810,10 +1812,6 @@ a:hover {
 	font: var(--global--font-size-sm);
 }
 
-.wp-block-gallery.alignleft, .wp-block-gallery.alignright {
-	max-width: 50%;
-}
-
 .wp-block-group .wp-block-group__inner-container {
 	margin-right: auto;
 	margin-left: auto;
@@ -2714,10 +2712,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	margin-top: 0;
 	margin-right: var(--global--spacing-horizontal);
 	margin-bottom: var(--global--spacing-vertical);
-}
-
-.entry-content > .alignleft {
-	max-width: var(--responsive--aligndefault-width);
 }
 
 /**

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -814,23 +814,11 @@ template {
 	max-width: var(--responsive--alignfull-width);
 }
 
-.entry-content > .alignleft {
-	margin-left: var(--responsive--spacing-horizontal);
-	margin-right: var(--responsive--spacing-horizontal);
-	max-width: var(--responsive--aligndefault-width);
-}
-
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		margin-left: var(--responsive--alignleft-margin);
 		margin-right: var(--global--spacing-horizontal);
-		max-width: calc(50% - var(--responsive--alignleft-margin));
 	}
-}
-
-.entry-content > .alignright {
-	margin-left: var(--responsive--spacing-horizontal);
-	margin-right: 0;
 }
 
 @media only screen and (min-width: 482px) {
@@ -2708,10 +2696,22 @@ table.is-style-stripes tbody tr:nth-child(odd),
  */
 .alignleft {
 	text-align: left;
-	float: left;
 	margin-top: 0;
-	margin-right: var(--global--spacing-horizontal);
-	margin-bottom: var(--global--spacing-vertical);
+}
+
+.entry-content > .alignleft {
+	max-width: var(--responsive--aligndefault-width);
+}
+
+@media only screen and (min-width: 482px) {
+	.alignleft {
+		float: left;
+		margin-right: var(--global--spacing-horizontal);
+		margin-bottom: var(--global--spacing-vertical);
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignleft-margin));
+	}
 }
 
 /**
@@ -2730,14 +2730,22 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * .alignright
  */
 .alignright {
-	float: right;
 	margin-top: 0;
 	margin-bottom: var(--global--spacing-vertical);
-	margin-left: var(--global--spacing-horizontal);
 }
 
 .entry-content > .alignright {
 	max-width: var(--responsive--aligndefault-width);
+}
+
+@media only screen and (min-width: 482px) {
+	.alignright {
+		float: right;
+		margin-left: var(--global--spacing-horizontal);
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignright-margin));
+	}
 }
 
 [class*="inner-container"] > .alignleft + *,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2743,7 +2743,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 		float: right;
 		margin-left: var(--global--spacing-horizontal);
 	}
-	.entry-content > .alignleft {
+	.entry-content > .alignright {
 		max-width: calc(50% - var(--responsive--alignright-margin));
 	}
 }

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 7.2
+Requires PHP: 5.6
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description:
 Requires at least: 5.3
 Tested up to: 5.5
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
@@ -814,13 +814,6 @@ template {
 	max-width: var(--responsive--alignfull-width);
 }
 
-.entry-content > .alignleft {
-	/*rtl:ignore*/
-	margin-left: 0;
-	/*rtl:ignore*/
-	margin-right: var(--responsive--spacing-horizontal);
-}
-
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
@@ -828,13 +821,6 @@ template {
 		/*rtl:ignore*/
 		margin-right: var(--global--spacing-horizontal);
 	}
-}
-
-.entry-content > .alignright {
-	/*rtl:ignore*/
-	margin-left: var(--responsive--spacing-horizontal);
-	/*rtl:ignore*/
-	margin-right: 0;
 }
 
 @media only screen and (min-width: 482px) {
@@ -1818,10 +1804,6 @@ a:hover {
 	font: var(--global--font-size-sm);
 }
 
-.wp-block-gallery.alignleft, .wp-block-gallery.alignright {
-	max-width: 50%;
-}
-
 .wp-block-group .wp-block-group__inner-container {
 	margin-left: auto;
 	margin-right: auto;
@@ -2719,16 +2701,24 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .alignleft {
 	/*rtl:ignore*/
 	text-align: left;
-	/*rtl:ignore*/
-	float: left;
 	margin-top: 0;
-	/*rtl:ignore*/
-	margin-right: var(--global--spacing-horizontal);
-	margin-bottom: var(--global--spacing-vertical);
 }
 
 .entry-content > .alignleft {
 	max-width: var(--responsive--aligndefault-width);
+}
+
+@media only screen and (min-width: 482px) {
+	.alignleft {
+		/*rtl:ignore*/
+		float: left;
+		/*rtl:ignore*/
+		margin-right: var(--global--spacing-horizontal);
+		margin-bottom: var(--global--spacing-vertical);
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignleft-margin));
+	}
 }
 
 /**
@@ -2747,16 +2737,24 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * .alignright
  */
 .alignright {
-	/*rtl:ignore*/
-	float: right;
 	margin-top: 0;
 	margin-bottom: var(--global--spacing-vertical);
-	/*rtl:ignore*/
-	margin-left: var(--global--spacing-horizontal);
 }
 
 .entry-content > .alignright {
 	max-width: var(--responsive--aligndefault-width);
+}
+
+@media only screen and (min-width: 482px) {
+	.alignright {
+		/*rtl:ignore*/
+		float: right;
+		/*rtl:ignore*/
+		margin-left: var(--global--spacing-horizontal);
+	}
+	.entry-content > .alignleft {
+		max-width: calc(50% - var(--responsive--alignright-margin));
+	}
 }
 
 [class*="inner-container"] > .alignleft + *,

--- a/style.css
+++ b/style.css
@@ -2752,7 +2752,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 		/*rtl:ignore*/
 		margin-left: var(--global--spacing-horizontal);
 	}
-	.entry-content > .alignleft {
+	.entry-content > .alignright {
 		max-width: calc(50% - var(--responsive--alignright-margin));
 	}
 }


### PR DESCRIPTION
The underlying cause for #237 ended up being that the theme has default behaviors for left- & right-aligned content, which does not actually left- or right-align block elements.

Here's a breakdown of what was done in this PR:
* The gallery block has `.alignleft` & `.alignright` styles, but they get overridden by the global `.alignleft, .alignright` styles so I removed them (as they were redundant)
* Fixed `max-width` to use `calc(50% - var(--responsive-align[left/right]-margin]))`
  * (Note: the article content is technically full-width and has a margin; this takes that in to account since just `50%` will be oversized)
* **The default behavior for `.alignleft` & `.alignright` is now to be one-column**
  * The small breakpoint is 482px and the default behavior covers sizes below that
    * To have two-columns below this would mean a max size of 240px-ish, which is hard to see (particularly for media)

**This PR could use extra testing.** I've tried to test it the best I could, but it would be good to have extra eyes on given how this could change behavior. In particular, if anyone knows of somewhere outside of `.entry-content` where `.alignleft`/`.alignright` are used, that should be tested.

Fixes #237 