### PR TITLE
Update button styles

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -31,6 +31,19 @@
 }
 
 /* Button extends */
+.wp-block-button__link {
+	line-height: 1.5;
+	color: #d1e4dd;
+	cursor: pointer;
+	font-weight: 500;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.25rem;
+	background-color: #39414d;
+	border-radius: 0;
+	border: 3px solid #39414d;
+	text-decoration: none;
+	padding: 15px 30px;
+}
 .wp-block-file .wp-block-file__button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -58,11 +71,15 @@
 	padding: 15px 30px;
 }
 
-.wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
+.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
 	content: "";
 	display: block;
 	height: 0;
 	width: 0;
+}
+
+.wp-block-button__link:before {
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
@@ -73,12 +90,21 @@
 	margin-bottom: -calc(1em + 0);
 }
 
+.wp-block-button__link:after {
+	margin-top: -calc(1em + 0);
+}
+
 .wp-block-file .wp-block-file__button:after {
 	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
 	margin-top: -calc(1em + 0);
+}
+
+.wp-block-button__link:active {
+	color: #39414d;
+	background-color: #d1e4dd;
 }
 
 .wp-block-file .wp-block-file__button:active {
@@ -91,6 +117,11 @@
 	background-color: #d1e4dd;
 }
 
+.wp-block-button__link:hover {
+	color: #39414d;
+	background: transparent;
+}
+
 .wp-block-file .wp-block-file__button:hover {
 	color: #39414d;
 	background: transparent;
@@ -101,9 +132,15 @@
 	background: transparent;
 }
 
-.wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
+.wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
 	outline-offset: -4px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-button__link:disabled {
+	background-color: rgba(255, 255, 255, 0.5);
+	border-color: rgba(255, 255, 255, 0.5);
+	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -355,32 +392,6 @@ a:hover {
 	color: #28303d;
 }
 
-.wp-block-button__link {
-	color: #d1e4dd;
-	font-weight: 500;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.25rem;
-	line-height: 1.5;
-	background-color: #39414d;
-	border-radius: 0;
-	border: 3px solid #39414d;
-	padding: 15px 30px;
-}
-
-.wp-block-button__link:visited {
-	color: #d1e4dd;
-}
-
-.wp-block-button__link:hover {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
-.wp-block-button__link:focus, .wp-block-button__link.has-focus {
-	outline-offset: -4px;
-	outline: 2px dotted currentColor;
-}
-
 .wp-block-button__link.is-style-outline {
 	color: #39414d;
 	background: transparent;
@@ -428,7 +439,7 @@ a:hover {
 .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus,
 .is-style-outline .wp-block-button__link:focus,
 .is-style-outline .wp-block-button__link.has-focus {
-	outline-offset: -6px;
+	outline-offset: -7px;
 	background: transparent;
 }
 
@@ -438,16 +449,13 @@ a:hover {
 }
 
 .is-selected.is-style-outline .wp-block-button__link:hover {
+	background-color: transparent;
 	color: #39414d;
 }
 
 .is-style-outline .wp-block-button__link[style*="radius"],
 .wp-block-button__link[style*="radius"] {
 	outline-offset: 2px;
-}
-
-div[data-type="core/button"] {
-	display: block;
 }
 
 .wp-block-cover {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -174,7 +174,7 @@ input[type="reset"] {
 	text-decoration: none;
 	padding: 15px 30px;
 }
-.wp-block-button__link {
+.wp-block-button .wp-block-button__link {
 	line-height: 1.5;
 	color: #d1e4dd;
 	cursor: pointer;
@@ -205,11 +205,11 @@ input[type="reset"] {
 .site .button:before,
 input[type="submit"]:before,
 input[type="reset"]:before,
-.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
+.wp-block-button .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
 .site .button:after,
 input[type="submit"]:after,
 input[type="reset"]:after,
-.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
+.wp-block-button .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
 	content: "";
 	display: block;
 	height: 0;
@@ -232,7 +232,7 @@ input[type="reset"]:before {
 	margin-bottom: -calc(1em + 0);
 }
 
-.wp-block-button__link:before {
+.wp-block-button .wp-block-button__link:before {
 	margin-bottom: -calc(1em + 0);
 }
 
@@ -256,7 +256,7 @@ input[type="reset"]:after {
 	margin-top: -calc(1em + 0);
 }
 
-.wp-block-button__link:after {
+.wp-block-button .wp-block-button__link:after {
 	margin-top: -calc(1em + 0);
 }
 
@@ -284,7 +284,7 @@ input:active[type="reset"] {
 	background-color: #d1e4dd;
 }
 
-.wp-block-button__link:active {
+.wp-block-button .wp-block-button__link:active {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
@@ -314,7 +314,7 @@ input:hover[type="reset"] {
 	background: transparent;
 }
 
-.wp-block-button__link:hover {
+.wp-block-button .wp-block-button__link:hover {
 	color: #39414d;
 	background: transparent;
 }
@@ -328,11 +328,11 @@ input:hover[type="reset"] {
 .site .button:focus,
 input:focus[type="submit"],
 input:focus[type="reset"],
-.wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
+.wp-block-button .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
 .site .has-focus.button,
 input.has-focus[type="submit"],
 input.has-focus[type="reset"],
-.has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
+.wp-block-button .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
 	outline-offset: -4px;
 	outline: 2px dotted currentColor;
 }
@@ -361,7 +361,7 @@ input:disabled[type="reset"] {
 	color: #39414d;
 }
 
-.wp-block-button__link:disabled {
+.wp-block-button .wp-block-button__link:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
@@ -2099,38 +2099,12 @@ a:hover {
 /**
  * Block Options
  */
-.wp-block-button {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.25rem;
-	font-weight: 500;
-	line-height: 1.5;
-}
-
-.wp-block-button a.wp-block-button__link {
-	border-bottom: 3px solid #39414d;
-}
-
-.wp-block-button a.wp-block-button__link:focus {
-	outline-offset: -4px;
-	outline: 2px dotted #d1e4dd;
-	color: #d1e4dd;
-}
-
-.wp-block-button .wp-block-button__link:visited {
-	color: #d1e4dd;
-}
-
-.wp-block-button .wp-block-button__link:visited:hover {
-	color: #39414d;
-}
-
 .wp-block-button.is-style-outline.wp-block-button__link {
 	color: #39414d;
 	background: transparent;
 	border: 3px solid currentColor;
 	padding: 15px 30px;
 }
-
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: #39414d;
 	background: transparent;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -220,7 +220,7 @@
 }
 
 /* Button extends */
-.wp-block-file .wp-block-file__button, .wp-block-search .wp-block-search__button {
+.wp-block-button__link, .wp-block-file .wp-block-file__button, .wp-block-search .wp-block-search__button {
 	line-height: var(--button--line-height);
 	color: var(--button--color-text);
 	cursor: pointer;
@@ -234,37 +234,37 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
+.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
 	content: "";
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before {
+.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before {
 	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
 }
 
-.wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
+.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
 	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
-.wp-block-file .wp-block-file__button:active, .wp-block-search .wp-block-search__button:active {
+.wp-block-button__link:active, .wp-block-file .wp-block-file__button:active, .wp-block-search .wp-block-search__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
 
-.wp-block-file .wp-block-file__button:hover, .wp-block-search .wp-block-search__button:hover {
+.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover, .wp-block-search .wp-block-search__button:hover {
 	color: var(--button--color-text-hover);
 	background: transparent;
 }
 
-.wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
+.wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
 	outline-offset: -4px;
 	outline: 2px dotted currentColor;
 }
 
-.wp-block-file .wp-block-file__button:disabled, .wp-block-search .wp-block-search__button:disabled {
+.wp-block-button__link:disabled, .wp-block-file .wp-block-file__button:disabled, .wp-block-search .wp-block-search__button:disabled {
 	background-color: var(--global--color-white-50);
 	border-color: var(--global--color-white-50);
 	color: var(--button--color-text-active);
@@ -468,32 +468,6 @@ a:hover {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.wp-block-button__link {
-	color: var(--button--color-text);
-	font-weight: var(--button--font-weight);
-	font-family: var(--button--font-family);
-	font-size: var(--button--font-size);
-	line-height: var(--button--line-height);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border: var(--button--border-width) solid var(--button--color-background);
-	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
-}
-
-.wp-block-button__link:visited {
-	color: var(--button--color-text);
-}
-
-.wp-block-button__link:hover {
-	color: var(--button--color-text-hover);
-	background-color: var(--button--color-background-hover);
-}
-
-.wp-block-button__link:focus, .wp-block-button__link.has-focus {
-	outline-offset: -4px;
-	outline: 2px dotted currentColor;
-}
-
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);
@@ -517,7 +491,7 @@ a:hover {
 .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus,
 .is-style-outline .wp-block-button__link:focus,
 .is-style-outline .wp-block-button__link.has-focus {
-	outline-offset: -6px;
+	outline-offset: -7px;
 	background: transparent;
 }
 
@@ -527,16 +501,13 @@ a:hover {
 }
 
 .is-selected.is-style-outline .wp-block-button__link:hover {
+	background-color: transparent;
 	color: var(--button--color-background);
 }
 
 .is-style-outline .wp-block-button__link[style*="radius"],
 .wp-block-button__link[style*="radius"] {
 	outline-offset: 2px;
-}
-
-div[data-type="core/button"] {
-	display: block;
 }
 
 .wp-block-cover,

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -1,29 +1,7 @@
+
 .wp-block-button__link {
-
-	color: var(--button--color-text);
-	font-weight: var(--button--font-weight);
-	font-family: var(--button--font-family);
-	font-size: var(--button--font-size);
-	line-height: var(--button--line-height);
-	background-color: var(--button--color-background);
-	border-radius: var(--button--border-radius);
-	border: var(--button--border-width) solid var(--button--color-background);
-	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
-
-	&:visited {
-		color: var(--button--color-text);
-	}
-
-	&:hover {
-		color: var(--button--color-text-hover);
-		background-color: var(--button--color-background-hover);
-	}
-
-	&:focus,
-	&.has-focus {
-		outline-offset: -4px;
-		outline: 2px dotted currentColor;
-	}
+	// Extend button style
+	@extend %button-style;
 
 	// Outline Style
 	&.is-style-outline,
@@ -45,7 +23,7 @@
 
 		&:focus,
 		&.has-focus {
-			outline-offset: -6px;
+			outline-offset: -7px;
 			background: transparent;
 		}
 	}
@@ -58,14 +36,11 @@
 }
 
 .is-selected.is-style-outline .wp-block-button__link:hover {
+	background-color: transparent;
 	color: var(--button--color-background);
 }
 
 .is-style-outline .wp-block-button__link[style*="radius"],
 .wp-block-button__link[style*="radius"] {
 	outline-offset: 2px;
-}
-
-div[data-type="core/button"] {
-	display: block;
 }

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -5,7 +5,7 @@
 .site .button,
 input[type="submit"],
 input[type="reset"],
-.wp-block-button__link {
+.wp-block-button .wp-block-button__link {
 	// Extend button style
 	@extend %button-style;
 }
@@ -14,30 +14,6 @@ input[type="reset"],
  * Block Options
  */
 .wp-block-button {
-
-	font-family: var(--button--font-family);
-	font-size: var(--button--font-size);
-	font-weight: var(--button--font-weight);
-	line-height: var(--button--line-height);
-
-	// Override the link style in the reset file.
-	a.wp-block-button__link {
-		border-bottom: var(--button--border-width) solid var(--button--color-background);
-	}
-
-	a.wp-block-button__link:focus {
-		outline-offset: -4px;
-		outline: 2px dotted var(--button--color-text);
-		color: var(--button--color-text);
-	}
-
-	.wp-block-button__link:visited {
-		color: var(--button--color-text);
-
-		&:hover {
-			color: var(--button--color-text-hover);
-		}
-	}
 
 	// Outline Style.
 	&.is-style-outline {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -315,7 +315,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 .site .button,
 input[type="submit"],
 input[type="reset"],
-.wp-block-button__link, .wp-block-file .wp-block-file__button {
+.wp-block-button .wp-block-button__link, .wp-block-file .wp-block-file__button {
 	line-height: var(--button--line-height);
 	color: var(--button--color-text);
 	cursor: pointer;
@@ -333,11 +333,11 @@ input[type="reset"],
 .site .button:before,
 input[type="submit"]:before,
 input[type="reset"]:before,
-.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
+.wp-block-button .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
 .site .button:after,
 input[type="submit"]:after,
 input[type="reset"]:after,
-.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
+.wp-block-button .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
 	content: "";
 	display: block;
 	height: 0;
@@ -348,7 +348,7 @@ input[type="reset"]:after,
 .site .button:before,
 input[type="submit"]:before,
 input[type="reset"]:before,
-.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before {
+.wp-block-button .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before {
 	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
 }
 
@@ -356,7 +356,7 @@ input[type="reset"]:before,
 .site .button:after,
 input[type="submit"]:after,
 input[type="reset"]:after,
-.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
+.wp-block-button .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
 	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
@@ -364,7 +364,7 @@ input[type="reset"]:after,
 .site .button:active,
 input:active[type="submit"],
 input:active[type="reset"],
-.wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
+.wp-block-button .wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
@@ -373,7 +373,7 @@ input:active[type="reset"],
 .site .button:hover,
 input:hover[type="submit"],
 input:hover[type="reset"],
-.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
+.wp-block-button .wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
 	color: var(--button--color-text-hover);
 	background: transparent;
 }
@@ -382,11 +382,11 @@ input:hover[type="reset"],
 .site .button:focus,
 input:focus[type="submit"],
 input:focus[type="reset"],
-.wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
+.wp-block-button .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
 .site .has-focus.button,
 input.has-focus[type="submit"],
 input.has-focus[type="reset"],
-.has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
+.wp-block-button .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
 	outline-offset: -4px;
 	outline: 2px dotted currentColor;
 }
@@ -395,7 +395,7 @@ input.has-focus[type="reset"],
 .site .button:disabled,
 input:disabled[type="submit"],
 input:disabled[type="reset"],
-.wp-block-button__link:disabled, .wp-block-file .wp-block-file__button:disabled {
+.wp-block-button .wp-block-button__link:disabled, .wp-block-file .wp-block-file__button:disabled {
 	background-color: var(--global--color-white-50);
 	border-color: var(--global--color-white-50);
 	color: var(--button--color-text-active);
@@ -1521,31 +1521,6 @@ a:hover {
 /**
  * Block Options
  */
-.wp-block-button {
-	font-family: var(--button--font-family);
-	font-size: var(--button--font-size);
-	font-weight: var(--button--font-weight);
-	line-height: var(--button--line-height);
-}
-
-.wp-block-button a.wp-block-button__link {
-	border-bottom: var(--button--border-width) solid var(--button--color-background);
-}
-
-.wp-block-button a.wp-block-button__link:focus {
-	outline-offset: -4px;
-	outline: 2px dotted var(--button--color-text);
-	color: var(--button--color-text);
-}
-
-.wp-block-button .wp-block-button__link:visited {
-	color: var(--button--color-text);
-}
-
-.wp-block-button .wp-block-button__link:visited:hover {
-	color: var(--button--color-text-hover);
-}
-
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);

--- a/style.css
+++ b/style.css
@@ -315,7 +315,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 .site .button,
 input[type="submit"],
 input[type="reset"],
-.wp-block-button__link, .wp-block-file .wp-block-file__button {
+.wp-block-button .wp-block-button__link, .wp-block-file .wp-block-file__button {
 	line-height: var(--button--line-height);
 	color: var(--button--color-text);
 	cursor: pointer;
@@ -333,11 +333,11 @@ input[type="reset"],
 .site .button:before,
 input[type="submit"]:before,
 input[type="reset"]:before,
-.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
+.wp-block-button .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .site button:not(.customize-partial-edit-shortcut-button):after,
 .site .button:after,
 input[type="submit"]:after,
 input[type="reset"]:after,
-.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
+.wp-block-button .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
 	content: "";
 	display: block;
 	height: 0;
@@ -348,7 +348,7 @@ input[type="reset"]:after,
 .site .button:before,
 input[type="submit"]:before,
 input[type="reset"]:before,
-.wp-block-button__link:before, .wp-block-file .wp-block-file__button:before {
+.wp-block-button .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before {
 	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
 }
 
@@ -356,7 +356,7 @@ input[type="reset"]:before,
 .site .button:after,
 input[type="submit"]:after,
 input[type="reset"]:after,
-.wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
+.wp-block-button .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after {
 	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
@@ -364,7 +364,7 @@ input[type="reset"]:after,
 .site .button:active,
 input:active[type="submit"],
 input:active[type="reset"],
-.wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
+.wp-block-button .wp-block-button__link:active, .wp-block-file .wp-block-file__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
@@ -373,7 +373,7 @@ input:active[type="reset"],
 .site .button:hover,
 input:hover[type="submit"],
 input:hover[type="reset"],
-.wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
+.wp-block-button .wp-block-button__link:hover, .wp-block-file .wp-block-file__button:hover {
 	color: var(--button--color-text-hover);
 	background: transparent;
 }
@@ -382,11 +382,11 @@ input:hover[type="reset"],
 .site .button:focus,
 input:focus[type="submit"],
 input:focus[type="reset"],
-.wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
+.wp-block-button .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .site button.has-focus:not(.customize-partial-edit-shortcut-button),
 .site .has-focus.button,
 input.has-focus[type="submit"],
 input.has-focus[type="reset"],
-.has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
+.wp-block-button .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button {
 	outline-offset: -4px;
 	outline: 2px dotted currentColor;
 }
@@ -395,7 +395,7 @@ input.has-focus[type="reset"],
 .site .button:disabled,
 input:disabled[type="submit"],
 input:disabled[type="reset"],
-.wp-block-button__link:disabled, .wp-block-file .wp-block-file__button:disabled {
+.wp-block-button .wp-block-button__link:disabled, .wp-block-file .wp-block-file__button:disabled {
 	background-color: var(--global--color-white-50);
 	border-color: var(--global--color-white-50);
 	color: var(--button--color-text-active);
@@ -1529,31 +1529,6 @@ a:hover {
 /**
  * Block Options
  */
-.wp-block-button {
-	font-family: var(--button--font-family);
-	font-size: var(--button--font-size);
-	font-weight: var(--button--font-weight);
-	line-height: var(--button--line-height);
-}
-
-.wp-block-button a.wp-block-button__link {
-	border-bottom: var(--button--border-width) solid var(--button--color-background);
-}
-
-.wp-block-button a.wp-block-button__link:focus {
-	outline-offset: -4px;
-	outline: 2px dotted var(--button--color-text);
-	color: var(--button--color-text);
-}
-
-.wp-block-button .wp-block-button__link:visited {
-	color: var(--button--color-text);
-}
-
-.wp-block-button .wp-block-button__link:visited:hover {
-	color: var(--button--color-text-hover);
-}
-
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);


### PR DESCRIPTION
This is a follow up on [a comment about reducing the editor button styles and using the extend.](https://github.com/WordPress/twentytwentyone/pull/142#discussion_r496164506)

It also:
Fixes a problem where a clicked button (the active state) would have the incorrect text color.
Fixes a problem where the text was not visible when the outlined button was selected in the editor.

The styles were tested with Gutenberg version 9.1, and the 
```
div[data-type="core/button"] {	
	display: block;	
}
```
in the editor style was removed because it caused the buttons block to display vertically not horizontally.
