### PR TITLE
remove entry-header from front-page

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4234,6 +4234,10 @@ nav a {
 	margin-bottom: 90px;
 }
 
+.home.singular .entry-header {
+	display: none;
+}
+
 .entry-title {
 	color: #28303d;
 	font-size: 2.25rem;

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -1,3 +1,7 @@
+.home.singular .entry-header {
+	display: none;
+}
+
 .entry-title {
 
 	color: var(--entry-header--color);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3023,6 +3023,10 @@ nav a {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.home.singular .entry-header {
+	display: none;
+}
+
 .entry-title {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);

--- a/style.css
+++ b/style.css
@@ -3036,6 +3036,10 @@ nav a {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.home.singular .entry-header {
+	display: none;
+}
+
 .entry-title {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);


### PR DESCRIPTION
Remove the entry-header from the front-page. Since the site-title is an h1 on the front-page, we could simply use `display: none`?