### PR TITLE
Update comments pagination

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -924,6 +924,24 @@ hr.wp-block-separator.is-style-wide {
 	}
 }
 
+.comments-pagination {
+	max-width: calc(100vw - 30px);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+@media only screen and (min-width: 482px){
+	.comments-pagination{
+	max-width: calc(100vw - 100px);
+	}
+}
+
+@media only screen and (min-width: 822px){
+	.comments-pagination{
+	max-width: min(calc(100vw - 200px), 1240px);
+	}
+}
+
 .full-max-width {
 	max-width: calc(100% + 50px);
 	width: calc(100% + 50px);
@@ -4615,29 +4633,11 @@ h1.page-title {
 }
 
 .comment-reply-title small a {
-	border-color: transparent;
-	color: currentColor;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1rem;
 	font-style: normal;
 	font-weight: normal;
 	letter-spacing: normal;
-}
-
-.comment-reply-title small a:hover {
-	color: #28303d;
-}
-
-.comment-reply-title small a:focus {
-	color: #28303d;
-}
-
-.comment-reply-title small a:hover {
-	border-color: #39414d;
-}
-
-.comment-reply-title small a:active {
-	color: currentColor;
 }
 
 /* Nested comment reply title*/
@@ -4709,27 +4709,6 @@ h1.page-title {
 
 .comment-meta .comment-metadata .edit-link {
 	margin-left: 25px;
-}
-
-.comment-meta .comment-metadata a {
-	color: currentColor;
-	border-color: transparent;
-}
-
-.comment-meta .comment-metadata a:hover {
-	color: #28303d;
-}
-
-.comment-meta .comment-metadata a:focus {
-	color: #28303d;
-}
-
-.comment-meta .comment-metadata a:hover {
-	border-color: #39414d;
-}
-
-.comment-meta .comment-metadata a:active {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -4917,12 +4896,6 @@ h1.page-title {
 	.comment-form > p.comment-notes, .comment-form > p.logged-in-as {
 		display: block;
 	}
-}
-
-.comment-navigation a {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.25rem;
-	font-weight: 600;
 }
 
 .menu-button-container {
@@ -5386,8 +5359,17 @@ h1.page-title {
 	margin: 30px auto;
 }
 
+.comments-pagination {
+	border-top: 3px solid #28303d;
+	padding-top: 30px;
+	margin: 30px auto;
+}
+
 @media only screen and (min-width: 822px) {
 	.pagination {
+		margin: 30px auto;
+	}
+	.comments-pagination {
 		margin: 30px auto;
 	}
 }
@@ -5401,11 +5383,25 @@ h1.page-title {
 	margin-right: 13px;
 }
 
+.comments-pagination .nav-links > * {
+	color: #28303d;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.5rem;
+	font-weight: normal;
+	margin-left: 13px;
+	margin-right: 13px;
+}
+
 .pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
 }
 
-.pagination .nav-links > *:first-child {
+.comments-pagination .nav-links > *.current {
+	border-bottom: 1px solid #28303d;
+}
+
+.pagination .nav-links > *:first-child,
+.comments-pagination .nav-links > *:first-child {
 	margin-left: 0;
 }
 
@@ -5413,16 +5409,38 @@ h1.page-title {
 	color: #28303d;
 }
 
-.pagination .nav-links > *:last-child {
+.comments-pagination .nav-links > *a:hover {
+	color: #28303d;
+}
+
+.pagination .nav-links > *:last-child,
+.comments-pagination .nav-links > *:last-child {
 	margin-right: 0;
 }
 
-.pagination .nav-links > *.next {
+.pagination .nav-links > *.next,
+.comments-pagination .nav-links > *.next {
 	margin-left: auto;
 }
 
-.pagination .nav-links > *.prev {
+.pagination .nav-links > *.prev,
+.comments-pagination .nav-links > *.prev {
 	margin-right: auto;
+}
+
+.comments-pagination {
+	padding-top: 20px;
+	margin: 90px auto;
+}
+
+@media only screen and (min-width: 822px) {
+	.comments-pagination {
+		margin: 90px auto 120px auto;
+	}
+}
+
+.comments-pagination .nav-links > * {
+	font-size: 1.25rem;
 }
 
 .widget-area {

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -52,26 +52,11 @@
 	small {
 
 		a {
-			border-color: transparent;
-			color: currentColor;
 			font-family: var(--global--font-secondary);
 			font-size: var(--global--font-size-xs);
 			font-style: normal;
 			font-weight: normal;
 			letter-spacing: normal;
-
-			&:hover,
-			&:focus {
-				color: var(--global--color-primary-hover);
-			}
-
-			&:hover {
-				border-color: var(--global--color-secondary);
-			}
-
-			&:active {
-				color: currentColor;
-			}
 		}
 	}
 }
@@ -147,23 +132,6 @@
 			margin-left: var(--global--spacing-horizontal);
 		}
 
-		a {
-			color: currentColor;
-			border-color: transparent;
-
-			&:hover,
-			&:focus {
-				color: var(--global--color-primary-hover);
-			}
-
-			&:hover {
-				border-color: var(--global--color-secondary);
-			}
-
-			&:active {
-				color: currentColor;
-			}
-		}
 	}
 
 	@include media(mobile) {
@@ -316,15 +284,5 @@
 		&.logged-in-as {
 			display: block;
 		}
-	}
-}
-
-// Comment navigation
-.comment-navigation {
-
-	a {
-		font-family: var(--global--font-primary);
-		font-size: var(--global--font-size-md);
-		font-weight: 600;
 	}
 }

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -98,7 +98,8 @@
 }
 
 // Index/archive navigation
-.pagination {
+.pagination,
+.comments-pagination {
 
 	border-top: 3px solid var(--global--color-border);
 	padding-top: var(--global--spacing-vertical);
@@ -142,4 +143,19 @@
 			margin-right: auto;
 		}
 	}
+}
+
+// Comments pagination
+.comments-pagination {
+	padding-top: calc(0.66 * var(--global--spacing-vertical));
+	margin: calc(3 * var(--global--spacing-vertical)) auto;
+
+	@include media(desktop) {
+		margin: calc(3 * var(--global--spacing-vertical)) auto calc(4 * var(--global--spacing-vertical)) auto;
+	}
+
+	.nav-links > * {
+		font-size: var(--global--font-size-md);
+	}
+
 }

--- a/comments.php
+++ b/comments.php
@@ -43,8 +43,6 @@ if ( post_password_required() ) {
 			?>
 		</h2><!-- .comments-title -->
 
-		<?php the_comments_navigation(); ?>
-
 		<ol class="comment-list">
 			<?php
 			wp_list_comments(
@@ -58,7 +56,23 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php
-		the_comments_navigation();
+		the_comments_pagination(
+			array(
+				'mid_size'  => 2,
+				'prev_text' => sprintf(
+					/* Translators: Left arrow */
+					'%s <span class="nav-prev-text">%s</span>',
+					is_rtl() ? twenty_twenty_one_get_icon_svg( 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'arrow_left' ),
+					__( 'Older comments', 'twentytwentyone' )
+				),
+				'next_text' => sprintf(
+					/* Translators: Right arrow */
+					'<span class="nav-next-text">%s</span> %s',
+					__( 'Newer comments', 'twentytwentyone' ),
+					is_rtl() ? twenty_twenty_one_get_icon_svg( 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'arrow_right' )
+				),
+			)
+		);
 
 		// If comments are closed and there are comments, let's leave a little note, shall we?
 		if ( ! comments_open() ) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -784,7 +784,8 @@ template {
 	margin-left: auto;
 }
 
-.wide-max-width, .alignwide, .site-header, .site-footer, .post-navigation, .pagination {
+.wide-max-width, .alignwide, .site-header, .site-footer, .post-navigation, .pagination,
+.comments-pagination {
 	max-width: var(--responsive--alignwide-width);
 	margin-right: auto;
 	margin-left: auto;
@@ -3326,25 +3327,11 @@ h1.page-title {
 }
 
 .comment-reply-title small a {
-	border-color: transparent;
-	color: currentColor;
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-xs);
 	font-style: normal;
 	font-weight: normal;
 	letter-spacing: normal;
-}
-
-.comment-reply-title small a:hover, .comment-reply-title small a:focus {
-	color: var(--global--color-primary-hover);
-}
-
-.comment-reply-title small a:hover {
-	border-color: var(--global--color-secondary);
-}
-
-.comment-reply-title small a:active {
-	color: currentColor;
 }
 
 /* Nested comment reply title*/
@@ -3414,23 +3401,6 @@ h1.page-title {
 
 .comment-meta .comment-metadata .edit-link {
 	margin-right: var(--global--spacing-horizontal);
-}
-
-.comment-meta .comment-metadata a {
-	color: currentColor;
-	border-color: transparent;
-}
-
-.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:focus {
-	color: var(--global--color-primary-hover);
-}
-
-.comment-meta .comment-metadata a:hover {
-	border-color: var(--global--color-secondary);
-}
-
-.comment-meta .comment-metadata a:active {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -3579,12 +3549,6 @@ h1.page-title {
 	.comment-form > p.comment-notes, .comment-form > p.logged-in-as {
 		display: block;
 	}
-}
-
-.comment-navigation a {
-	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-md);
-	font-weight: 600;
 }
 
 .menu-button-container {
@@ -4025,19 +3989,22 @@ h1.page-title {
 	margin-bottom: 0;
 }
 
-.pagination {
+.pagination,
+.comments-pagination {
 	border-top: 3px solid var(--global--color-border);
 	padding-top: var(--global--spacing-vertical);
 	margin: var(--global--spacing-vertical) auto;
 }
 
 @media only screen and (min-width: 822px) {
-	.pagination {
+	.pagination,
+	.comments-pagination {
 		margin: var(--global--spacing-vertical) auto;
 	}
 }
 
-.pagination .nav-links > * {
+.pagination .nav-links > *,
+.comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);
 	font-family: var(--pagination--font-family);
 	font-size: var(--pagination--font-size);
@@ -4046,28 +4013,49 @@ h1.page-title {
 	margin-left: calc(0.66 * var(--global--spacing-unit));
 }
 
-.pagination .nav-links > *.current {
+.pagination .nav-links > *.current,
+.comments-pagination .nav-links > *.current {
 	border-bottom: 1px solid var(--pagination--color-text);
 }
 
-.pagination .nav-links > *:first-child {
+.pagination .nav-links > *:first-child,
+.comments-pagination .nav-links > *:first-child {
 	margin-right: 0;
 }
 
-.pagination .nav-links > *a:hover {
+.pagination .nav-links > *a:hover,
+.comments-pagination .nav-links > *a:hover {
 	color: var(--pagination--color-link-hover);
 }
 
-.pagination .nav-links > *:last-child {
+.pagination .nav-links > *:last-child,
+.comments-pagination .nav-links > *:last-child {
 	margin-left: 0;
 }
 
-.pagination .nav-links > *.next {
+.pagination .nav-links > *.next,
+.comments-pagination .nav-links > *.next {
 	margin-right: auto;
 }
 
-.pagination .nav-links > *.prev {
+.pagination .nav-links > *.prev,
+.comments-pagination .nav-links > *.prev {
 	margin-left: auto;
+}
+
+.comments-pagination {
+	padding-top: calc(0.66 * var(--global--spacing-vertical));
+	margin: calc(3 * var(--global--spacing-vertical)) auto;
+}
+
+@media only screen and (min-width: 822px) {
+	.comments-pagination {
+		margin: calc(3 * var(--global--spacing-vertical)) auto calc(4 * var(--global--spacing-vertical)) auto;
+	}
+}
+
+.comments-pagination .nav-links > * {
+	font-size: var(--global--font-size-md);
 }
 
 .widget-area {

--- a/style.css
+++ b/style.css
@@ -784,7 +784,8 @@ template {
 	margin-right: auto;
 }
 
-.wide-max-width, .alignwide, .site-header, .site-footer, .post-navigation, .pagination {
+.wide-max-width, .alignwide, .site-header, .site-footer, .post-navigation, .pagination,
+.comments-pagination {
 	max-width: var(--responsive--alignwide-width);
 	margin-left: auto;
 	margin-right: auto;
@@ -3339,25 +3340,11 @@ h1.page-title {
 }
 
 .comment-reply-title small a {
-	border-color: transparent;
-	color: currentColor;
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-xs);
 	font-style: normal;
 	font-weight: normal;
 	letter-spacing: normal;
-}
-
-.comment-reply-title small a:hover, .comment-reply-title small a:focus {
-	color: var(--global--color-primary-hover);
-}
-
-.comment-reply-title small a:hover {
-	border-color: var(--global--color-secondary);
-}
-
-.comment-reply-title small a:active {
-	color: currentColor;
 }
 
 /* Nested comment reply title*/
@@ -3427,23 +3414,6 @@ h1.page-title {
 
 .comment-meta .comment-metadata .edit-link {
 	margin-left: var(--global--spacing-horizontal);
-}
-
-.comment-meta .comment-metadata a {
-	color: currentColor;
-	border-color: transparent;
-}
-
-.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:focus {
-	color: var(--global--color-primary-hover);
-}
-
-.comment-meta .comment-metadata a:hover {
-	border-color: var(--global--color-secondary);
-}
-
-.comment-meta .comment-metadata a:active {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -3592,12 +3562,6 @@ h1.page-title {
 	.comment-form > p.comment-notes, .comment-form > p.logged-in-as {
 		display: block;
 	}
-}
-
-.comment-navigation a {
-	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-md);
-	font-weight: 600;
 }
 
 .menu-button-container {
@@ -4038,19 +4002,22 @@ h1.page-title {
 	margin-bottom: 0;
 }
 
-.pagination {
+.pagination,
+.comments-pagination {
 	border-top: 3px solid var(--global--color-border);
 	padding-top: var(--global--spacing-vertical);
 	margin: var(--global--spacing-vertical) auto;
 }
 
 @media only screen and (min-width: 822px) {
-	.pagination {
+	.pagination,
+	.comments-pagination {
 		margin: var(--global--spacing-vertical) auto;
 	}
 }
 
-.pagination .nav-links > * {
+.pagination .nav-links > *,
+.comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);
 	font-family: var(--pagination--font-family);
 	font-size: var(--pagination--font-size);
@@ -4059,28 +4026,49 @@ h1.page-title {
 	margin-right: calc(0.66 * var(--global--spacing-unit));
 }
 
-.pagination .nav-links > *.current {
+.pagination .nav-links > *.current,
+.comments-pagination .nav-links > *.current {
 	border-bottom: 1px solid var(--pagination--color-text);
 }
 
-.pagination .nav-links > *:first-child {
+.pagination .nav-links > *:first-child,
+.comments-pagination .nav-links > *:first-child {
 	margin-left: 0;
 }
 
-.pagination .nav-links > *a:hover {
+.pagination .nav-links > *a:hover,
+.comments-pagination .nav-links > *a:hover {
 	color: var(--pagination--color-link-hover);
 }
 
-.pagination .nav-links > *:last-child {
+.pagination .nav-links > *:last-child,
+.comments-pagination .nav-links > *:last-child {
 	margin-right: 0;
 }
 
-.pagination .nav-links > *.next {
+.pagination .nav-links > *.next,
+.comments-pagination .nav-links > *.next {
 	margin-left: auto;
 }
 
-.pagination .nav-links > *.prev {
+.pagination .nav-links > *.prev,
+.comments-pagination .nav-links > *.prev {
 	margin-right: auto;
+}
+
+.comments-pagination {
+	padding-top: calc(0.66 * var(--global--spacing-vertical));
+	margin: calc(3 * var(--global--spacing-vertical)) auto;
+}
+
+@media only screen and (min-width: 822px) {
+	.comments-pagination {
+		margin: calc(3 * var(--global--spacing-vertical)) auto calc(4 * var(--global--spacing-vertical)) auto;
+	}
+}
+
+.comments-pagination .nav-links > * {
+	font-size: var(--global--font-size-md);
 }
 
 .widget-area {


### PR DESCRIPTION
Adds styling to the comment pagination.
Removes the comment pagination that was above the comments.
Removes some link border styles that are no longer used since we are using an underline.

![comment](https://user-images.githubusercontent.com/7422055/94993455-69e5d980-0591-11eb-988b-0f175846ecd2.png)


Closes https://github.com/WordPress/twentytwentyone/issues/177 and https://github.com/WordPress/twentytwentyone/issues/80

