### PR TITLE
Update social links alignment in widgets

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5438,6 +5438,15 @@ h1.page-title {
 	}
 }
 
+.widget-area .wp-block-social-links.alignright {
+	margin-top: 30px;
+	justify-content: flex-end;
+}
+
+.widget-area .wp-block-social-links.alignleft {
+	margin-top: 30px;
+}
+
 .widget-title {
 	font-size: 1.125rem;
 	font-weight: 700;
@@ -5476,15 +5485,6 @@ h1.page-title {
 
 .search-form .search-submit {
 	margin-left: 10px;
-}
-
-.widget .wp-block-social-links.alignright {
-	margin-top: 30px;
-	justify-content: flex-end;
-}
-
-.widget .wp-block-social-links.alignleft {
-	margin-top: 30px;
 }
 
 /* Category 07 is for any utility classes that are not assigned to a specific component. */

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5478,6 +5478,15 @@ h1.page-title {
 	margin-left: 10px;
 }
 
+.widget .wp-block-social-links.alignright {
+	margin-top: 30px;
+	justify-content: flex-end;
+}
+
+.widget .wp-block-social-links.alignleft {
+	margin-top: 30px;
+}
+
 /* Category 07 is for any utility classes that are not assigned to a specific component. */
 .screen-reader-text {
 	border: 0;

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -37,3 +37,19 @@
 		margin-left: 10px;
 	}
 }
+
+// This style only affects social links inside widget areas.
+.widget {
+
+	.wp-block-social-links {
+
+		&.alignright {
+			margin-top: var(--global--spacing-vertical);
+			justify-content: flex-end;
+		}
+
+		&.alignleft {
+			margin-top: var(--global--spacing-vertical);
+		}
+	}
+}

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -7,6 +7,18 @@
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}
+
+	.wp-block-social-links {
+
+		&.alignright {
+			margin-top: var(--global--spacing-vertical);
+			justify-content: flex-end;
+		}
+
+		&.alignleft {
+			margin-top: var(--global--spacing-vertical);
+		}
+	}
 }
 
 .widget-title {
@@ -35,21 +47,5 @@
 
 	.search-submit {
 		margin-left: 10px;
-	}
-}
-
-// This style only affects social links inside widget areas.
-.widget {
-
-	.wp-block-social-links {
-
-		&.alignright {
-			margin-top: var(--global--spacing-vertical);
-			justify-content: flex-end;
-		}
-
-		&.alignleft {
-			margin-top: var(--global--spacing-vertical);
-		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4083,6 +4083,15 @@ h1.page-title {
 	}
 }
 
+.widget-area .wp-block-social-links.alignright {
+	margin-top: var(--global--spacing-vertical);
+	justify-content: flex-end;
+}
+
+.widget-area .wp-block-social-links.alignleft {
+	margin-top: var(--global--spacing-vertical);
+}
+
 .widget-title {
 	font-size: var(--global--font-size-sm);
 	font-weight: 700;
@@ -4109,15 +4118,6 @@ h1.page-title {
 
 .search-form .search-submit {
 	margin-right: 10px;
-}
-
-.widget .wp-block-social-links.alignright {
-	margin-top: var(--global--spacing-vertical);
-	justify-content: flex-end;
-}
-
-.widget .wp-block-social-links.alignleft {
-	margin-top: var(--global--spacing-vertical);
 }
 
 /* Category 07 is for any utility classes that are not assigned to a specific component. */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4111,6 +4111,15 @@ h1.page-title {
 	margin-right: 10px;
 }
 
+.widget .wp-block-social-links.alignright {
+	margin-top: var(--global--spacing-vertical);
+	justify-content: flex-end;
+}
+
+.widget .wp-block-social-links.alignleft {
+	margin-top: var(--global--spacing-vertical);
+}
+
 /* Category 07 is for any utility classes that are not assigned to a specific component. */
 .screen-reader-text {
 	border: 0;

--- a/style.css
+++ b/style.css
@@ -4096,6 +4096,15 @@ h1.page-title {
 	}
 }
 
+.widget-area .wp-block-social-links.alignright {
+	margin-top: var(--global--spacing-vertical);
+	justify-content: flex-end;
+}
+
+.widget-area .wp-block-social-links.alignleft {
+	margin-top: var(--global--spacing-vertical);
+}
+
 .widget-title {
 	font-size: var(--global--font-size-sm);
 	font-weight: 700;
@@ -4122,15 +4131,6 @@ h1.page-title {
 
 .search-form .search-submit {
 	margin-left: 10px;
-}
-
-.widget .wp-block-social-links.alignright {
-	margin-top: var(--global--spacing-vertical);
-	justify-content: flex-end;
-}
-
-.widget .wp-block-social-links.alignleft {
-	margin-top: var(--global--spacing-vertical);
 }
 
 /* Category 07 is for any utility classes that are not assigned to a specific component. */

--- a/style.css
+++ b/style.css
@@ -4124,6 +4124,15 @@ h1.page-title {
 	margin-left: 10px;
 }
 
+.widget .wp-block-social-links.alignright {
+	margin-top: var(--global--spacing-vertical);
+	justify-content: flex-end;
+}
+
+.widget .wp-block-social-links.alignleft {
+	margin-top: var(--global--spacing-vertical);
+}
+
 /* Category 07 is for any utility classes that are not assigned to a specific component. */
 .screen-reader-text {
 	border: 0;


### PR DESCRIPTION
Corrects alignments for the social links block when placed inside a widget area.

Closes https://github.com/WordPress/twentytwentyone/issues/205

-I went back and forward on if this should be placed in widgets, or blocks?