### PR TITLE
Add block style for a dark grey social icon

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1652,6 +1652,14 @@ hr {
 	margin-top: auto;
 }
 
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color button {
+	color: #28303d;
+}
+
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
+	background: none;
+}
+
 table th {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3706,6 +3706,14 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
+	color: #28303d;
+}
+
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
+	background: none;
+}
+
 .wp-block-spacer {
 	display: block;
 	margin-bottom: 0 !important;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1264,6 +1264,14 @@ hr {
 	margin-top: auto;
 }
 
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color button {
+	color: var(--global--color-primary);
+}
+
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
+	background: none;
+}
+
 table th,
 .wp-block-table th {
 	font-family: var(--heading--font-family);

--- a/assets/sass/05-blocks/blocks.scss
+++ b/assets/sass/05-blocks/blocks.scss
@@ -25,6 +25,7 @@
 @import "quote/style";
 @import "search/style";
 @import "separator/style";
+@import "social-icons/style";
 @import "spacer/style";
 @import "table/style";
 @import "verse/style";

--- a/assets/sass/05-blocks/social-icons/_editor.scss
+++ b/assets/sass/05-blocks/social-icons/_editor.scss
@@ -3,4 +3,16 @@
 	li.wp-block-social-link:first-child {
 		margin-top: auto;
 	}
+
+	&.is-style-twentytwentyone-social-icons-color {
+
+		button {
+			color: var(--global--color-primary);
+		}
+
+		.wp-social-link {
+			background: none;
+		}
+	}
+
 }

--- a/assets/sass/05-blocks/social-icons/_style.scss
+++ b/assets/sass/05-blocks/social-icons/_style.scss
@@ -1,0 +1,11 @@
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color {
+
+	a {
+		color: var(--global--color-primary);
+	}
+
+	.wp-social-link {
+		background: none;
+	}
+
+}

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -73,6 +73,15 @@ if ( function_exists( 'register_block_style' ) ) {
 				'label' => __( 'Borders', 'twentytwentyone' ),
 			)
 		);
+
+		/* Social icons: Dark gray color */
+		register_block_style(
+			'core/social-links',
+			array(
+				'name'  => 'twentytwentyone-social-icons-color',
+				'label' => __( 'Dark Gray', 'twentytwentyone' ),
+			)
+		);
 	}
 	add_action( 'init', 'twenty_twenty_one_register_block_styles' );
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2637,6 +2637,14 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
+	color: var(--global--color-primary);
+}
+
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
+	background: none;
+}
+
 .wp-block-spacer {
 	display: block;
 	margin-bottom: 0 !important;

--- a/style.css
+++ b/style.css
@@ -2645,6 +2645,14 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
+	color: var(--global--color-primary);
+}
+
+.wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
+	background: none;
+}
+
 .wp-block-spacer {
 	display: block;
 	margin-bottom: 0 !important;


### PR DESCRIPTION
Adds a block style so that the user can show social icons in the primary color, without background.

In Figma, the size is 18px18, but the default size for the icons is 24. I did not attempt to change the size.

Closes https://github.com/WordPress/twentytwentyone/issues/204

Top: Custom style.
Below: Default.

![social links with dark gray custom style](https://user-images.githubusercontent.com/7422055/94997072-02d41f00-05a9-11eb-8d21-82309ff90b87.png)

![social links over dark background](https://user-images.githubusercontent.com/7422055/94997094-2b5c1900-05a9-11eb-937d-fac75c8ee8db.png)

