### PR TITLE
Update primary navigation

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5076,7 +5076,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container > ul > li > ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -5112,31 +5112,37 @@ h1.page-title {
 	margin: 13px 0;
 	position: relative;
 	width: 100%;
-	z-index: 1;
-}
-
-.primary-navigation > div > .menu-wrapper li:hover, .primary-navigation > div > .menu-wrapper li:focus-within {
-	cursor: pointer;
-	z-index: 99999;
 }
 
 @media only screen and (min-width: 482px) {
 	.primary-navigation > div > .menu-wrapper li {
-		display: inherit;
 		margin: 0;
 		width: inherit;
-		/* Submenu display in the responsive menu */
-	}
-	.primary-navigation > div > .menu-wrapper li:hover > ul,
-	.primary-navigation > div > .menu-wrapper li:focus-within > ul,
-	.primary-navigation > div > .menu-wrapper li ul:hover,
-	.primary-navigation > div > .menu-wrapper li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.primary-navigation > div > .menu-wrapper li:last-child {
 		margin-right: 0;
+	}
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+	display: flex;
+	height: 44px;
+	width: 44px;
+	padding: 0;
+	justify-content: center;
+	align-items: center;
+	background: transparent;
+	color: currentColor;
+	border: none;
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
+	outline: 2px solid #28303d;
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+		display: none;
 	}
 }
 
@@ -5150,11 +5156,10 @@ h1.page-title {
 		left: 0;
 		margin: 0;
 		min-width: max-content;
-		opacity: 0;
 		position: absolute;
-		top: calc(100% - 13px);
+		top: 100%;
 		transition: all 0.5s ease;
-		visibility: hidden;
+		z-index: 99999;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5146,6 +5146,18 @@ h1.page-title {
 	}
 }
 
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="false"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
 .primary-navigation > div > .menu-wrapper > li > .sub-menu {
 	position: relative;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5076,7 +5076,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -5153,6 +5153,12 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle {
 	/* stylelint-disable */
 	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
 	/* stylelint-enable */

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,0 +1,41 @@
+/**
+ * File primary-navigation.js.
+ *
+ * Required to open and close the mobile navigation.
+ */
+
+/**
+ * Polyfill for Element.closest() because we need to support IE11.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+ */
+if ( ! Element.prototype.matches ) {
+	Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+}
+
+if ( ! Element.prototype.closest ) {
+	Element.prototype.closest = function( s ) {
+		var el = this;
+		do {
+			if ( Element.prototype.matches.call( el, s ) ) {
+				return el;
+			}
+			el = el.parentElement || el.parentNode;
+		} while ( el !== null && el.nodeType === 1 );
+		return null;
+	};
+}
+
+/**
+ * Polyfill for NodeList.foreach() because we need to support IE11.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+ */
+if ( window.NodeList && ! NodeList.prototype.forEach ) {
+	NodeList.prototype.forEach = function( callback, thisArg ) {
+		thisArg = thisArg || window;
+		for ( var i = 0; i < this.length; i++ ) {
+            callback.call( thisArg, this[i], i, this );
+        }
+    };
+}

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -3,30 +3,40 @@
  *
  * Required to open and close the mobile navigation.
  */
-( function() {
 
-	/**
-	 * Toggle an attribute's value
-	 * 
-	 * @param {Element} element
-	 * @param {Attribute} attribute
-	 * @param {String} trueVal
-	 * @param {String} falseVal
-	 * @since 1.0.0
-	 */
-	var toggleAttribute = function ( element, attribute, trueVal, falseVal ) {
-		if ( undefined === trueVal ) {
-			trueVal = true;
-		}
-		if ( undefined === falseVal ) {
-			falseVal = false;
-		}
-		if ( trueVal !== element.getAttribute( attribute ) ) {
-			element.setAttribute( attribute, trueVal );
-		} else {
-			element.setAttribute( attribute, falseVal );
-		}
+/**
+ * Toggle an attribute's value
+ *
+ * @param {Element} element
+ * @param {Attribute} attribute
+ * @param {String} trueVal
+ * @param {String} falseVal
+ * @since 1.0.0
+ */
+function twentytwentyoneToggleAttribute(element, attribute, trueVal, falseVal) {
+	if (undefined === trueVal) {
+		trueVal = true;
 	}
+	if (undefined === falseVal) {
+		falseVal = false;
+	}
+	if (trueVal !== element.getAttribute(attribute)) {
+		element.setAttribute(attribute, trueVal);
+	} else {
+		element.setAttribute(attribute, falseVal);
+	}
+}
+
+/**
+ * Handle clicks on submenu toggles.
+ *
+ * @param {Element} el
+ */
+function twentytwentyoneExpandSubMenu(el) { // eslint-disable-line no-unused-vars
+	twentytwentyoneToggleAttribute(el, 'aria-expanded', 'true', 'false');
+}
+
+( function() {
 
 	/**
 	 * Menu Toggle Behaviors
@@ -41,11 +51,10 @@
 			mobileButton.onclick = function() {
 				wrapper.classList.toggle( `${ id }-navigation-open` );
 				wrapper.classList.toggle( 'lock-scrolling' );
-				toggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
+				twentytwentyoneToggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
 				mobileButton.focus();
 			}
 		}
-
 		/**
 		 * Trap keyboard navigation in the menu modal.
 		 * Adapted from TwentyTwenty
@@ -53,7 +62,7 @@
 		document.addEventListener( 'keydown', function( event ) {
 			if ( ! wrapper.classList.contains( `${ id }-navigation-open` ) ){
 				return;
-			} 
+			}
 			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 
 			modal = document.querySelector( `.${ id }-navigation` );

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -32,7 +32,7 @@ function twentytwentyoneToggleAttribute(element, attribute, trueVal, falseVal) {
  *
  * @param {Element} el
  */
-function twentytwentyoneExpandSubMenu(el) { // eslint-disable-line no-unused-vars
+function twentytwentyoneExpandSubMenu(el) {
 	twentytwentyoneToggleAttribute(el, 'aria-expanded', 'true', 'false');
 }
 

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -79,7 +79,7 @@ function twentytwentyoneExpandSubMenu(el) { // eslint-disable-line no-unused-var
 			if ( escKey ) {
 				event.preventDefault();
 				wrapper.classList.remove( `${ id }-navigation-open`, 'lock-scrolling' );
-				toggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
+				twentytwentyoneToggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
 				mobileButton.focus();
 			}
 

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -10,13 +10,17 @@
  * @param {Element} el - The element.
  * @since 1.0.0
  */
-function twentytwentyoneToggleAriaExpanded( el ) {
+function twentytwentyoneToggleAriaExpanded( el, withListeners ) {
 	if ( 'true' !== el.getAttribute( 'aria-expanded' ) ) {
 		el.setAttribute( 'aria-expanded', 'true' );
-		document.addEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
+		if ( withListeners ) {
+			document.addEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
+		}
 	} else {
 		el.setAttribute( 'aria-expanded', 'false' );
-		document.removeEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
+		if ( withListeners ) {
+			document.removeEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
+		}
 	}
 }
 
@@ -28,23 +32,31 @@ function twentytwentyoneCollapseMenuOnClickOutside( event ) {
 	}
 }
 
-function twentytwentyoneCollapseAllOtherSubMenus( element ) {
-	var nav = element.closest( 'nav' );
-	nav.querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
-		if ( button !== element ) {
-			button.setAttribute( 'aria-expanded', 'false' );
-		}
-	} );
-}
-
 /**
  * Handle clicks on submenu toggles.
  *
  * @param {Element} el - The element.
  */
 function twentytwentyoneExpandSubMenu( el ) {
-	twentytwentyoneCollapseAllOtherSubMenus( el );
-	twentytwentyoneToggleAriaExpanded( el );
+
+	// Close other expanded items.
+	el.closest( 'nav' ).querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
+		if ( button !== el ) {
+			button.setAttribute( 'aria-expanded', 'false' );
+		}
+	} );
+
+	// Toggle aria-expanded on the button.
+	twentytwentyoneToggleAriaExpanded( el, true );
+
+	// On tab-away collapse the menu.
+	el.parentNode.querySelectorAll( 'ul > li:last-child > a' ).forEach( function( linkEl ) {
+		linkEl.addEventListener( 'blur', function( event ) {
+			if ( ! el.parentNode.contains( event.relatedTarget ) ) {
+				el.setAttribute( 'aria-expanded', 'false' );
+			}
+		} );
+	} );
 }
 
 ( function() {

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -7,23 +7,14 @@
 /**
  * Toggle an attribute's value
  *
- * @param {Element} element
- * @param {Attribute} attribute
- * @param {String} trueVal
- * @param {String} falseVal
+ * @param {Element} el - The element.
  * @since 1.0.0
  */
-function twentytwentyoneToggleAttribute(element, attribute, trueVal, falseVal) {
-	if (undefined === trueVal) {
-		trueVal = true;
-	}
-	if (undefined === falseVal) {
-		falseVal = false;
-	}
-	if (trueVal !== element.getAttribute(attribute)) {
-		element.setAttribute(attribute, trueVal);
+function twentytwentyoneToggleAriaExpanded( el ) {
+	if ( 'true' !== el.getAttribute( 'aria-expanded' ) ) {
+		el.setAttribute( 'aria-expanded', 'true' );
 	} else {
-		element.setAttribute(attribute, falseVal);
+		el.setAttribute( 'aria-expanded', 'false' );
 	}
 }
 
@@ -39,11 +30,11 @@ function twentytwentyoneCollapseAllOtherSubMenus(element) {
 /**
  * Handle clicks on submenu toggles.
  *
- * @param {Element} el
+ * @param {Element} el - The element.
  */
-function twentytwentyoneExpandSubMenu(el) {
-	twentytwentyoneCollapseAllOtherSubMenus(el);
-	twentytwentyoneToggleAttribute(el, 'aria-expanded', 'true', 'false');
+function twentytwentyoneExpandSubMenu( el ) {
+	twentytwentyoneCollapseAllOtherSubMenus( el );
+	twentytwentyoneToggleAriaExpanded( el );
 }
 
 ( function() {
@@ -54,14 +45,14 @@ function twentytwentyoneExpandSubMenu(el) {
 	 * @param {Element} element
 	 */
 	var navMenu = function ( id ){
-		var wrapper      = document.body; // this is the element to which a CSS class is added when a mobile nav menu is open
-		var mobileButton = document.getElementById( `${ id }-mobile-menu` );
+		var wrapper      = document.body, // this is the element to which a CSS class is added when a mobile nav menu is open
+			mobileButton = document.getElementById( `${ id }-mobile-menu` );
 
 		if ( mobileButton ){
 			mobileButton.onclick = function() {
 				wrapper.classList.toggle( `${ id }-navigation-open` );
 				wrapper.classList.toggle( 'lock-scrolling' );
-				twentytwentyoneToggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
+				twentytwentyoneToggleAriaExpanded( mobileButton );
 				mobileButton.focus();
 			}
 		}
@@ -70,10 +61,10 @@ function twentytwentyoneExpandSubMenu(el) {
 		 * Adapted from TwentyTwenty
 		 */
 		document.addEventListener( 'keydown', function( event ) {
+			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 			if ( ! wrapper.classList.contains( `${ id }-navigation-open` ) ){
 				return;
 			}
-			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 
 			modal = document.querySelector( `.${ id }-navigation` );
 			selectors = "input, a, button";
@@ -89,7 +80,7 @@ function twentytwentyoneExpandSubMenu(el) {
 			if ( escKey ) {
 				event.preventDefault();
 				wrapper.classList.remove( `${ id }-navigation-open`, 'lock-scrolling' );
-				twentytwentyoneToggleAttribute( mobileButton, 'aria-expanded', 'true', 'false' );
+				twentytwentyoneToggleAriaExpanded( mobileButton );
 				mobileButton.focus();
 			}
 
@@ -107,7 +98,7 @@ function twentytwentyoneExpandSubMenu(el) {
 			if ( tabKey && firstEl === lastEl ) {
 				event.preventDefault();
 			}
-		});
+		} );
 	}
 
 	window.addEventListener( 'load', function() {

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -13,12 +13,22 @@
 function twentytwentyoneToggleAriaExpanded( el ) {
 	if ( 'true' !== el.getAttribute( 'aria-expanded' ) ) {
 		el.setAttribute( 'aria-expanded', 'true' );
+		document.addEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
 	} else {
 		el.setAttribute( 'aria-expanded', 'false' );
+		document.removeEventListener( 'click', twentytwentyoneCollapseMenuOnClickOutside );
 	}
 }
 
-function twentytwentyoneCollapseAllOtherSubMenus(element) {
+function twentytwentyoneCollapseMenuOnClickOutside( event ) {
+	if ( ! document.getElementById( 'site-navigation' ).contains( event.target ) ) {
+		document.getElementById( 'site-navigation' ).querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
+			button.setAttribute( 'aria-expanded', 'false' );
+		} );
+	}
+}
+
+function twentytwentyoneCollapseAllOtherSubMenus( element ) {
 	var nav = element.closest( 'nav' );
 	nav.querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
 		if ( button !== element ) {

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -27,12 +27,22 @@ function twentytwentyoneToggleAttribute(element, attribute, trueVal, falseVal) {
 	}
 }
 
+function twentytwentyoneCollapseAllOtherSubMenus(element) {
+	var nav = element.closest( 'nav' );
+	nav.querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
+		if ( button !== element ) {
+			button.setAttribute( 'aria-expanded', 'false' );
+		}
+	} );
+}
+
 /**
  * Handle clicks on submenu toggles.
  *
  * @param {Element} el
  */
 function twentytwentyoneExpandSubMenu(el) {
+	twentytwentyoneCollapseAllOtherSubMenus(el);
 	twentytwentyoneToggleAttribute(el, 'aria-expanded', 'true', 'false');
 }
 

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -99,6 +99,15 @@ function twentytwentyoneExpandSubMenu( el ) {
 				event.preventDefault();
 			}
 		} );
+
+		document.getElementById( 'site-navigation' ).querySelectorAll( '.menu-wrapper > .menu-item-has-children' ).forEach( function( li ) {
+			li.addEventListener( 'mouseenter', function() {
+				this.classList.add( 'hover' );
+			} );
+			li.addEventListener( 'mouseleave', function() {
+				this.classList.remove( 'hover' );
+			} );
+		} );
 	}
 
 	window.addEventListener( 'load', function() {

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -162,7 +162,7 @@
 		}
 
 		// Hide sub-sub-menus
-		> .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
+		> .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
 			display: none;
 		}
 
@@ -245,6 +245,12 @@
 				/* stylelint-enable */
 			}
 
+		}
+
+		.hover .sub-menu-toggle {
+			/* stylelint-disable */
+			background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+			/* stylelint-enable */
 		}
 
 		// Sub-menus Flyout

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -162,7 +162,7 @@
 		}
 
 		// Hide sub-sub-menus
-		> .primary-menu-container > ul > li > ul {
+		> .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 			display: none;
 		}
 
@@ -200,32 +200,35 @@
 			margin: var(--primary-nav--padding) 0;
 			position: relative;
 			width: 100%;
-			z-index: 1;
-
-			&:hover,
-			&:focus-within {
-				cursor: pointer;
-				z-index: 99999;
-			}
 
 			@include media(mobile) {
-				display: inherit;
 				margin: 0;
 				width: inherit;
-
-				/* Submenu display in the responsive menu */
-				&:hover > ul,
-				&:focus-within > ul,
-				ul:hover,
-				ul:focus {
-					visibility: visible;
-					opacity: 1;
-					display: block;
-				}
 
 				&:last-child() {
 					margin-right: 0;
 				}
+			}
+		}
+
+		// Sub menu buttons
+		.sub-menu-toggle {
+			display: flex;
+			height: 44px;
+			width: 44px;
+			padding: 0;
+			justify-content: center;
+			align-items: center;
+			background: transparent;
+			color: currentColor;
+			border: none;
+
+			&:focus {
+				outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+			}
+
+			@include media(mobile-only) {
+				display: none;
 			}
 		}
 
@@ -239,11 +242,10 @@
 				left: 0;
 				margin: 0;
 				min-width: max-content;
-				opacity: 0;
 				position: absolute;
-				top: calc(100% - var(--primary-nav--padding));
+				top: 100%;
 				transition: all 0.5s ease;
-				visibility: hidden;
+				z-index: 99999;
 			}
 
 			.sub-menu {

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -211,7 +211,7 @@
 			}
 		}
 
-		// Sub menu buttons
+		// Sub-menu buttons
 		.sub-menu-toggle {
 			display: flex;
 			height: 44px;
@@ -230,6 +230,21 @@
 			@include media(mobile-only) {
 				display: none;
 			}
+
+			// When the sub-menu is closed, display the plus icon
+			&[aria-expanded="false"] {
+				/* stylelint-disable */
+				background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z' fill='%2328303d'/></svg>") no-repeat center center;
+				/* stylelint-enable */
+			}
+
+			// When the sub-menu is open, display the minus icon
+			&[aria-expanded="true"] {
+				/* stylelint-disable */
+				background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+				/* stylelint-enable */
+			}
+
 		}
 
 		// Sub-menus Flyout
@@ -317,7 +332,7 @@
 		list-style: none;
 		margin-left: var(--primary-nav--padding);
 
-		// Sub menu items om wide screens.
+		// Sub-menu items om wide screens.
 		@include media(mobile) {
 			padding: 0 var(--primary-nav--padding);
 

--- a/classes/class-twenty-twenty-one-svg-icons.php
+++ b/classes/class-twenty-twenty-one-svg-icons.php
@@ -62,7 +62,5 @@ class Twenty_Twenty_One_SVG_Icons {
 		'arrow_left'  => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M9.737 18.011L3.98 12.255l5.734-6.28 1.107 1.012-4.103 4.494h13.3v1.5H6.828l3.97 3.97-1.06 1.06z" fill="currentColor"/></svg>',
 		'close'       => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 10.9394L5.53033 4.46973L4.46967 5.53039L10.9393 12.0001L4.46967 18.4697L5.53033 19.5304L12 13.0607L18.4697 19.5304L19.5303 18.4697L13.0607 12.0001L19.5303 5.53039L18.4697 4.46973L12 10.9394Z" fill="currentColor"/></svg>',
 		'menu'        => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 6H19.5V7.5H4.5V6ZM4.5 12H19.5V13.5H4.5V12ZM19.5 18H4.5V19.5H19.5V18Z" fill="currentColor"/></svg>',
-		'minus'       => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9h12v2H4V9z" fill="currentColor"/></svg>',
-		'plus'        => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" fill="currentColor"/></svg>',
 	);
 }

--- a/functions.php
+++ b/functions.php
@@ -350,7 +350,20 @@ function twenty_twenty_one_scripts() {
 
 	// Main navigation scripts.
 	if ( has_nav_menu( 'primary' ) ) {
-		wp_enqueue_script( 'twenty-twenty-one-primary-navigation-script', get_template_directory_uri() . '/assets/js/primary-navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
+		wp_register_script(
+			'twenty-twenty-one-ie11-polyfills',
+			get_template_directory_uri() . '/assets/js/polyfills.js',
+			array(),
+			wp_get_theme()->get( 'Version' ),
+			true
+		);
+		wp_enqueue_script(
+			'twenty-twenty-one-primary-navigation-script',
+			get_template_directory_uri() . '/assets/js/primary-navigation.js',
+			array( 'twenty-twenty-one-ie11-polyfills' ),
+			wp_get_theme()->get( 'Version' ),
+			true
+		);
 	}
 }
 add_action( 'wp_enqueue_scripts', 'twenty_twenty_one_scripts' );

--- a/header.php
+++ b/header.php
@@ -30,9 +30,9 @@
 		<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
 			<?php if ( has_nav_menu( 'primary' ) ) { ?>
-				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary', 'twentytwentyone' ); ?>" aria-expanded="false">
+				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary', 'twentytwentyone' ); ?>">
 					<div class="menu-button-container">
-						<button id="primary-mobile-menu" class="button" aria-haspopup="true" aria-controls="primary-navigation">
+						<button id="primary-mobile-menu" class="button" aria-controls="primary-menu-list" aria-expanded="false">
 							<span class="dropdown-icon open"><?php esc_html_e( 'Menu', 'twentytwentyone' ); ?>
 								<?php echo twenty_twenty_one_get_icon_svg( 'menu' ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
 							</span>
@@ -47,7 +47,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							'items_wrap'      => '<ul id="primary-menu-list" class="%2$s">%3$s</ul>',
 						)
 					);
 					?>

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -13,7 +13,8 @@
  */
 
 /**
- * Add a dropdown toggle with icon to top-level menu items.
+ * Add a button to top-level menu items that has sub-menus.
+ * An icon is added using CSS depending on the value of aria-expanded.
  *
  * @param string $output Nav menu item start element.
  * @param object $item   Nav menu item.
@@ -21,13 +22,13 @@
  * @param object $args   Nav menu args.
  * @return string Nav menu item start element.
  */
-function twenty_twenty_one_add_dropdown_toggle( $output, $item, $depth, $args ) {
+function twenty_twenty_one_add_sub_menu_toggle( $output, $item, $depth, $args ) {
 
 	if ( 0 === $depth && in_array( 'menu-item-has-children', $item->classes, true ) ) {
-		// Add toggle button with icon.
-		$output .= '<button class="sub-menu-toggle" aria-expanded="false" onClick="twentytwentyoneExpandSubMenu(this)"><span class="screen-reader-text">' . esc_html__( 'Toggle child menu', 'twentytwentyone' ) . '</span>' . twenty_twenty_one_get_icon_svg( 'plus', 18 ) . '</button>';
+		// Add toggle button.
+		$output .= '<button class="sub-menu-toggle" aria-expanded="false" onClick="twentytwentyoneExpandSubMenu(this)"><span class="screen-reader-text">' . esc_html__( 'Toggle child menu', 'twentytwentyone' ) . '</span></button>';
 	}
 
 	return $output;
 }
-add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_add_dropdown_toggle', 10, 4 );
+add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_add_sub_menu_toggle', 10, 4 );

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -13,50 +13,21 @@
  */
 
 /**
- * Add a dropdown icon to top-level menu items.
+ * Add a dropdown toggle with icon to top-level menu items.
  *
  * @param string $output Nav menu item start element.
  * @param object $item   Nav menu item.
  * @param int    $depth  Depth.
  * @param object $args   Nav menu args.
  * @return string Nav menu item start element.
- * Add a dropdown icon to top-level menu items
  */
-function twenty_twenty_one_add_dropdown_icons( $output, $item, $depth, $args ) {
+function twenty_twenty_one_add_dropdown_toggle( $output, $item, $depth, $args ) {
 
-	if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-		// Add SVG icon to parent items.
-		$output .= twenty_twenty_one_get_icon_svg( 'plus', 18 );
+	if ( 0 === $depth && in_array( 'menu-item-has-children', $item->classes, true ) ) {
+		// Add toggle button with icon.
+		$output .= '<button class="sub-menu-toggle" aria-expanded="false" onClick="twentytwentyoneExpandSubMenu(this)"><span class="screen-reader-text">' . esc_html__( 'Toggle child menu', 'twentytwentyone' ) . '</span>' . twenty_twenty_one_get_icon_svg( 'plus', 18 ) . '</button>';
 	}
 
 	return $output;
 }
-add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_add_dropdown_icons', 10, 4 );
-
-/**
- * WCAG 2.0 Attributes for Dropdown Menus.
- *
- * Adjustments to menu attributes to support WCAG 2.0 recommendations
- * for flyout and dropdown menus.
- *
- * @see https://www.w3.org/WAI/tutorials/menus/flyout/
- *
- * @param array    $atts  The HTML attributes applied to the menu item's <a> element, empty strings are ignored.
- * @param WP_Post  $item  The current menu item.
- * @param stdClass $args  An object of wp_nav_menu() arguments.
- * @param int      $depth Depth of menu item. Used for padding.
- *
- * @return array
- */
-function twenty_twenty_one_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
-
-	// Add [aria-haspopup] and [aria-expanded] to menu items that have children.
-	$item_has_children = in_array( 'menu-item-has-children', $item->classes, true );
-	if ( $item_has_children ) {
-		$atts['aria-haspopup'] = 'true';
-		$atts['aria-expanded'] = 'false';
-	}
-
-	return $atts;
-}
-add_filter( 'nav_menu_link_attributes', 'twenty_twenty_one_nav_menu_link_attributes', 10, 4 );
+add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_add_dropdown_toggle', 10, 4 );

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3808,6 +3808,18 @@ h1.page-title {
 	}
 }
 
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="false"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
 .primary-navigation > div > .menu-wrapper > li > .sub-menu {
 	position: relative;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3738,7 +3738,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -3815,6 +3815,12 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle {
 	/* stylelint-disable */
 	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
 	/* stylelint-enable */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3738,7 +3738,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container > ul > li > ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -3774,31 +3774,37 @@ h1.page-title {
 	margin: var(--primary-nav--padding) 0;
 	position: relative;
 	width: 100%;
-	z-index: 1;
-}
-
-.primary-navigation > div > .menu-wrapper li:hover, .primary-navigation > div > .menu-wrapper li:focus-within {
-	cursor: pointer;
-	z-index: 99999;
 }
 
 @media only screen and (min-width: 482px) {
 	.primary-navigation > div > .menu-wrapper li {
-		display: inherit;
 		margin: 0;
 		width: inherit;
-		/* Submenu display in the responsive menu */
-	}
-	.primary-navigation > div > .menu-wrapper li:hover > ul,
-	.primary-navigation > div > .menu-wrapper li:focus-within > ul,
-	.primary-navigation > div > .menu-wrapper li ul:hover,
-	.primary-navigation > div > .menu-wrapper li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.primary-navigation > div > .menu-wrapper li:last-child {
 		margin-left: 0;
+	}
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+	display: flex;
+	height: 44px;
+	width: 44px;
+	padding: 0;
+	justify-content: center;
+	align-items: center;
+	background: transparent;
+	color: currentColor;
+	border: none;
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
+	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+		display: none;
 	}
 }
 
@@ -3812,11 +3818,10 @@ h1.page-title {
 		right: 0;
 		margin: 0;
 		min-width: max-content;
-		opacity: 0;
 		position: absolute;
-		top: calc(100% - var(--primary-nav--padding));
+		top: 100%;
 		transition: all 0.5s ease;
-		visibility: hidden;
+		z-index: 99999;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -3751,7 +3751,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container > ul > li > ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -3787,31 +3787,37 @@ h1.page-title {
 	margin: var(--primary-nav--padding) 0;
 	position: relative;
 	width: 100%;
-	z-index: 1;
-}
-
-.primary-navigation > div > .menu-wrapper li:hover, .primary-navigation > div > .menu-wrapper li:focus-within {
-	cursor: pointer;
-	z-index: 99999;
 }
 
 @media only screen and (min-width: 482px) {
 	.primary-navigation > div > .menu-wrapper li {
-		display: inherit;
 		margin: 0;
 		width: inherit;
-		/* Submenu display in the responsive menu */
-	}
-	.primary-navigation > div > .menu-wrapper li:hover > ul,
-	.primary-navigation > div > .menu-wrapper li:focus-within > ul,
-	.primary-navigation > div > .menu-wrapper li ul:hover,
-	.primary-navigation > div > .menu-wrapper li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.primary-navigation > div > .menu-wrapper li:last-child {
 		margin-right: 0;
+	}
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+	display: flex;
+	height: 44px;
+	width: 44px;
+	padding: 0;
+	justify-content: center;
+	align-items: center;
+	background: transparent;
+	color: currentColor;
+	border: none;
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
+	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
+		display: none;
 	}
 }
 
@@ -3825,11 +3831,10 @@ h1.page-title {
 		left: 0;
 		margin: 0;
 		min-width: max-content;
-		opacity: 0;
 		position: absolute;
-		top: calc(100% - var(--primary-nav--padding));
+		top: 100%;
 		transition: all 0.5s ease;
-		visibility: hidden;
+		z-index: 99999;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -3821,6 +3821,18 @@ h1.page-title {
 	}
 }
 
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="false"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
 .primary-navigation > div > .menu-wrapper > li > .sub-menu {
 	position: relative;
 }

--- a/style.css
+++ b/style.css
@@ -3751,7 +3751,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -3828,6 +3828,12 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] {
+	/* stylelint-disable */
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
+	/* stylelint-enable */
+}
+
+.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle {
 	/* stylelint-disable */
 	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='18' height='18'><path d='M4 9h12v2H4V9z' fill='%2328303d'/></svg>") no-repeat center center;
 	/* stylelint-enable */


### PR DESCRIPTION
Removes aria-haspopup -this is only intended for application menus, not navigation.
Moves the aria-expanded to the menu toggle button.
Fixes a problem with the aria-controls, that was pointing to an incorrect class, adding a new ID to the first ul.

Adds a toggle button for sub menus.
Clicking the button toggles the sub menus. Sub menus no longer open on hover or focus.

When the sub menu is closed, the plus icon shows, and when open, the minus icon shows.

The button is not visible in the mobile menu.


