### PR TITLE
Use `$wp_styles` conditional instead of `$is_IE` to load IE-specific stylesheets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -326,16 +326,11 @@ add_action( 'after_setup_theme', 'twenty_twenty_one_content_width', 0 );
  * Enqueue scripts and styles.
  */
 function twenty_twenty_one_scripts() {
-	// Note, the is_IE global variable is defined by WordPress and is used
-	// to detect if the current browser is internet explorer.
-	global $is_IE;
-	if ( $is_IE ) {
-		// If IE 11 or below, use a flattened stylesheet with static values replacing CSS Variables.
-		wp_enqueue_style( 'twenty-twenty-one-style', get_template_directory_uri() . '/assets/css/ie.css', array(), wp_get_theme()->get( 'Version' ) );
-	} else {
-		// If not IE, use the standard stylesheet.
-		wp_enqueue_style( 'twenty-twenty-one-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
-	}
+	global $wp_styles;
+
+	wp_enqueue_style( 'twenty-twenty-one-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'twenty-twenty-one-style-ie', get_template_directory_uri() . '/assets/css/ie.css', array(), wp_get_theme()->get( 'Version' ) );
+	$wp_styles->add_data( 'twenty-twenty-one-style-ie', 'conditional', 'IE' );
 
 	// RTL styles.
 	wp_style_add_data( 'twenty-twenty-one-style', 'rtl', 'replace' );


### PR DESCRIPTION
This PR changes the way the IE-specific stylesheet is loaded on the frontend. Instead of using `$is_IE` in PHP to detect if the browser is IE, it uses `$wp_styles->add_data()`.

The IE-specific stylesheet will be wrapped in `<!--[if IE]> ... <![endif]-->`

The reason for this change is caching: Relying on PHP variables for client detection is bad practice. If the site is behind a reverse proxy or is using some form of aggressive caching, then the 1st time someone visits the site is what will be cached. If the 1st visit is not IE, nobody will get the IE styles regardless of what browser they are using.
If on the other hand the 1st visit is from IE, then everyone will get the IE styles.

With this PR we don't use the PHP var and everyone gets what they need.
Note that this change was only made for the frontend stylesheet. For the editor styles it's OK to use the PHP implementation since the dashboard is not cached.

The downside: IE will get the full stylesheet twice (1st the normal one and then the IE-specific one). But I think we can live with that...