### PR TITLE
Hide the site title in the footer when the display option is unchecked

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -27,7 +27,7 @@
 					<?php
 					else :
 						$blog_info = get_bloginfo( 'name' );
-						if ( ! empty( $blog_info ) ) :
+						if ( ! empty( $blog_info ) && get_theme_mod( 'display_title_and_tagline', true ) === true) :
 							if ( is_front_page() && ! is_paged() ) :
 								?>
 								<?php bloginfo( 'name' ); ?>

--- a/footer.php
+++ b/footer.php
@@ -27,7 +27,7 @@
 					<?php
 					else :
 						$blog_info = get_bloginfo( 'name' );
-						if ( ! empty( $blog_info ) && get_theme_mod( 'display_title_and_tagline', true ) === true ) :
+						if ( ! empty( $blog_info ) && get_theme_mod( 'display_title_and_tagline', true ) ) :
 							if ( is_front_page() && ! is_paged() ) :
 								?>
 								<?php bloginfo( 'name' ); ?>

--- a/footer.php
+++ b/footer.php
@@ -27,7 +27,7 @@
 					<?php
 					else :
 						$blog_info = get_bloginfo( 'name' );
-						if ( ! empty( $blog_info ) && get_theme_mod( 'display_title_and_tagline', true ) === true) :
+						if ( ! empty( $blog_info ) && get_theme_mod( 'display_title_and_tagline', true ) === true ) :
 							if ( is_front_page() && ! is_paged() ) :
 								?>
 								<?php bloginfo( 'name' ); ?>


### PR DESCRIPTION
If the Display Site Title & Tagline option is unchecked, hide the site title in the footer.
