### PR TITLE
fixes #272

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5309,6 +5309,7 @@ h1.page-title {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
+		flex-wrap: wrap;
 	}
 	.navigation .nav-links .nav-next {
 		flex: 0 1 auto;

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -26,6 +26,7 @@
 		@include media(mobile) {
 			display: flex;
 			justify-content: center;
+			flex-wrap: wrap;
 
 			.nav-next,
 			.nav-previous {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3963,6 +3963,7 @@ h1.page-title {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
+		flex-wrap: wrap;
 	}
 	.navigation .nav-links .nav-next,
 	.navigation .nav-links .nav-previous {

--- a/style.css
+++ b/style.css
@@ -3976,6 +3976,7 @@ h1.page-title {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
+		flex-wrap: wrap;
 	}
 	.navigation .nav-links .nav-next,
 	.navigation .nav-links .nav-previous {


### PR DESCRIPTION
Fixes #272 

Adds `flex-wrap:wrap;` to pagination and now pagination shows properly for all screen sizes.

![Screenshot_2020-10-05 My Blog – Page 36 – Just another WordPress site](https://user-images.githubusercontent.com/588688/95083005-91b97680-0724-11eb-9acf-78b705dc9b10.png)
