### PR TITLE
Fix editor custom colors bug

### DIFF
--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -105,7 +105,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			array(),
 			(string) filemtime( get_theme_file_path( 'assets/css/custom-color-overrides.css' ) )
 		);
-		if ( 'D1E4DD' !== get_theme_mod( 'background_color', 'D1E4DD' ) ) {
+		if ( 'd1e4dd' !== strtolower( get_theme_mod( 'background_color', 'D1E4DD' ) ) ) {
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', $this->generate_custom_color_variables( 'editor' ) );
 		}
 	}


### PR DESCRIPTION
This PR fixes a small bug in the conditional for when to run custom color generation in the editor.

Previously, if you change the default color of your site, and then back to the default color, the script to generate and load custom colors would still run in the editor — causing slightly differences to the background color in the editor and front-end:

**Before**
![Screen Shot 2020-10-05 at 12 58 59 PM](https://user-images.githubusercontent.com/5375500/95126016-a5f07a00-070a-11eb-9cc3-4d39a6b81f6c.png)

**After**
![Screen Shot 2020-10-05 at 12 59 31 PM](https://user-images.githubusercontent.com/5375500/95126051-b43e9600-070a-11eb-9439-9368fd8d3023.png)

To test:
- Change the background color of your site via the customizer to something from the default, then change it back to the default.
- Add a button to your site
- Verify that it uses the correct button background color