### PR TITLE
Pagination: Wrap pagination links on smaller screens

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5467,13 +5467,18 @@ h1.page-title {
 @media only screen and (max-width: 591px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
-		text-align: center;
+		display: flex;
+		flex-wrap: wrap;
 	}
-	.pagination .nav-links .next,
-	.pagination .nav-links .prev,
-	.comments-pagination .nav-links .next,
-	.comments-pagination .nav-links .prev {
-		display: block;
+	.pagination .page-numbers,
+	.comments-pagination .page-numbers {
+		display: none;
+	}
+	.pagination .page-numbers.prev, .pagination .page-numbers.next,
+	.comments-pagination .page-numbers.prev,
+	.comments-pagination .page-numbers.next {
+		display: inline-block;
+		flex: 0 1 auto;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5305,7 +5305,7 @@ h1.page-title {
 	color: #28303d;
 }
 
-@media only screen and (min-width: 482px) {
+@media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -5462,6 +5462,19 @@ h1.page-title {
 .pagination .nav-links > *.prev,
 .comments-pagination .nav-links > *.prev {
 	margin-right: auto;
+}
+
+@media only screen and (max-width: 591px) {
+	.pagination .nav-links,
+	.comments-pagination .nav-links {
+		text-align: center;
+	}
+	.pagination .nav-links .next,
+	.pagination .nav-links .prev,
+	.comments-pagination .nav-links .next,
+	.comments-pagination .nav-links .prev {
+		display: block;
+	}
 }
 
 .comments-pagination {

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -148,11 +148,17 @@
 	@include media(tablet-only) {
 
 		.nav-links {
-			text-align: center;
+			display: flex;
+			flex-wrap: wrap;
+		}
 
-			.next,
-			.prev {
-				display: block;
+		.page-numbers {
+			display: none;
+
+			&.prev,
+			&.next {
+				display: inline-block;
+				flex: 0 1 auto;
 			}
 		}
 	}

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -23,7 +23,7 @@
 	}
 
 	.nav-links {
-		@include media(mobile) {
+		@include media(tablet) {
 			display: flex;
 			justify-content: center;
 			flex-wrap: wrap;
@@ -142,6 +142,18 @@
 
 		&.prev {
 			margin-right: auto;
+		}
+	}
+
+	@include media(tablet-only) {
+
+		.nav-links {
+			text-align: center;
+
+			.next,
+			.prev {
+				display: block;
+			}
 		}
 	}
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -227,19 +227,16 @@ if ( ! function_exists( 'twenty_twenty_one_the_posts_navigation' ) ) {
 			array(
 				'mid_size'  => 2,
 				'prev_text' => sprintf(
-					/* Translators: Left arrow */
 					'%s <span class="nav-prev-text">%s</span>',
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'arrow_left' ),
-					__( 'Older posts', 'twentytwentyone' )
+					__( 'Newer posts', 'twentytwentyone' )
 				),
 				'next_text' => sprintf(
-					/* Translators: Right arrow */
 					'<span class="nav-next-text">%s</span> %s',
-					__( 'Newer posts', 'twentytwentyone' ),
+					__( 'Older posts', 'twentytwentyone' ),
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'arrow_right' )
 				),
 			)
 		);
 	}
 }
-

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3925,7 +3925,7 @@ h1.page-title {
 	color: var(--global--color-primary);
 }
 
-@media only screen and (min-width: 482px) {
+@media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -4052,6 +4052,19 @@ h1.page-title {
 .pagination .nav-links > *.prev,
 .comments-pagination .nav-links > *.prev {
 	margin-left: auto;
+}
+
+@media only screen and (max-width: 591px) {
+	.pagination .nav-links,
+	.comments-pagination .nav-links {
+		text-align: center;
+	}
+	.pagination .nav-links .next,
+	.pagination .nav-links .prev,
+	.comments-pagination .nav-links .next,
+	.comments-pagination .nav-links .prev {
+		display: block;
+	}
 }
 
 .comments-pagination {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4057,13 +4057,18 @@ h1.page-title {
 @media only screen and (max-width: 591px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
-		text-align: center;
+		display: flex;
+		flex-wrap: wrap;
 	}
-	.pagination .nav-links .next,
-	.pagination .nav-links .prev,
-	.comments-pagination .nav-links .next,
-	.comments-pagination .nav-links .prev {
-		display: block;
+	.pagination .page-numbers,
+	.comments-pagination .page-numbers {
+		display: none;
+	}
+	.pagination .page-numbers.prev, .pagination .page-numbers.next,
+	.comments-pagination .page-numbers.prev,
+	.comments-pagination .page-numbers.next {
+		display: inline-block;
+		flex: 0 1 auto;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -4066,13 +4066,18 @@ h1.page-title {
 @media only screen and (max-width: 591px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
-		text-align: center;
+		display: flex;
+		flex-wrap: wrap;
 	}
-	.pagination .nav-links .next,
-	.pagination .nav-links .prev,
-	.comments-pagination .nav-links .next,
-	.comments-pagination .nav-links .prev {
-		display: block;
+	.pagination .page-numbers,
+	.comments-pagination .page-numbers {
+		display: none;
+	}
+	.pagination .page-numbers.prev, .pagination .page-numbers.next,
+	.comments-pagination .page-numbers.prev,
+	.comments-pagination .page-numbers.next {
+		display: inline-block;
+		flex: 0 1 auto;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -3934,7 +3934,7 @@ h1.page-title {
 	color: var(--global--color-primary);
 }
 
-@media only screen and (min-width: 482px) {
+@media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -4061,6 +4061,19 @@ h1.page-title {
 .pagination .nav-links > *.prev,
 .comments-pagination .nav-links > *.prev {
 	margin-right: auto;
+}
+
+@media only screen and (max-width: 591px) {
+	.pagination .nav-links,
+	.comments-pagination .nav-links {
+		text-align: center;
+	}
+	.pagination .nav-links .next,
+	.pagination .nav-links .prev,
+	.comments-pagination .nav-links .next,
+	.comments-pagination .nav-links .prev {
+		display: block;
+	}
 }
 
 .comments-pagination {


### PR DESCRIPTION
See #256 — Comment & post pagination links wrap around awkwardly on smaller screens. This PR fixes the wrapping issue by putting the "Older" & "Newer" links on their own lines. I've set the breakpoint to `tablet` because I was still seeing wrapping above the mobile size. Additionally, I noticed that the next/prev links are mislabelled — the "next page" is older content, and previous is newer.

Comments, small screen:
![Screen Shot 2020-10-05 at 5 32 11 PM](https://user-images.githubusercontent.com/541093/95134573-2033f500-0731-11eb-9f30-7b195f5ced16.png)

Posts, small screen:
![Screen Shot 2020-10-05 at 5 30 13 PM](https://user-images.githubusercontent.com/541093/95134575-21652200-0731-11eb-8848-ec2f6b8dd623.png)

Posts, large screen:
![Screen Shot 2020-10-05 at 5 30 25 PM](https://user-images.githubusercontent.com/541093/95134574-20cc8b80-0731-11eb-8826-fe29636a7307.png)
