### PR TITLE
Primary Menu: Fix alignment and scrolling on mobile

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5057,7 +5057,10 @@ h1.page-title {
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 70px 20px 25px;
+	padding-top: calc(2rem + 47px);
+	padding-left: 20px;
+	padding-right: 20px;
+	padding-bottom: 25px;
 	background-color: #d1e4dd;
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -5070,11 +5073,9 @@ h1.page-title {
 		height: 100vh;
 		z-index: 499;
 	}
-}
-
-.admin-bar .primary-navigation > .primary-menu-container {
-	height: calc(100vh - 46px);
-	padding-top: 24px;
+	.admin-bar .primary-navigation > .primary-menu-container {
+		height: calc(100vh - 46px);
+	}
 }
 
 @media only screen and (max-width: 481px) {
@@ -5090,9 +5091,7 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.admin-bar .primary-navigation,
-.admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation .button {
+.admin-bar .primary-navigation {
 	top: 46px;
 }
 
@@ -5341,6 +5340,7 @@ h1.page-title {
 	.lock-scrolling .site {
 		position: fixed;
 		max-width: 100%;
+		width: 100%;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4973,10 +4973,10 @@ h1.page-title {
 .menu-button-container {
 	display: none;
 	justify-content: space-between;
-	left: 0;
 	position: absolute;
-	top: 0;
-	width: 100%;
+	right: 0;
+	padding-top: 42px;
+	padding-bottom: 8px;
 }
 
 .menu-button-container #primary-mobile-menu {
@@ -4992,10 +4992,6 @@ h1.page-title {
 	}
 }
 
-.admin-bar:not(.primary-navigation-open) .menu-button-container {
-	top: 42px;
-}
-
 .menu-button-container .button {
 	display: flex;
 	font-size: 1rem;
@@ -5003,7 +4999,6 @@ h1.page-title {
 	text-transform: uppercase;
 	background-color: transparent;
 	color: #28303d;
-	z-index: 500;
 }
 
 .menu-button-container .button .dropdown-icon {
@@ -5032,8 +5027,14 @@ h1.page-title {
 	display: flex;
 }
 
+.primary-navigation-open .menu-button-container {
+	width: 100%;
+	z-index: 500;
+	background-color: #d1e4dd;
+}
+
 .primary-navigation-open .menu-button-container #primary-mobile-menu {
-	display: flex;
+	position: static;
 }
 
 .primary-navigation {
@@ -5051,20 +5052,20 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 	.primary-navigation {
 		width: 100%;
+		position: fixed;
 	}
 }
 
 .primary-navigation > .primary-menu-container {
 	visibility: hidden;
 	opacity: 0;
-	position: fixed;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 80px 20px 25px;
+	padding: 110px 20px 25px;
 	background-color: #d1e4dd;
-	overflow-x: hidden;
+	overflow-x: scroll;
 	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(30px);
@@ -5072,8 +5073,14 @@ h1.page-title {
 
 @media only screen and (max-width: 481px) {
 	.primary-navigation > .primary-menu-container {
+		height: 100vh;
 		z-index: 499;
 	}
+}
+
+.admin-bar .primary-navigation > .primary-menu-container {
+	height: calc(100vh - 46px);
+	padding-top: 126px;
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {
@@ -5082,15 +5089,9 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.lock-scrolling .primary-navigation > .button {
-	position: fixed;
-	top: 0;
-	right: 0;
-}
-
 .admin-bar .primary-navigation,
 .admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation > .button {
+.admin-bar.lock-scrolling .primary-navigation .button {
 	top: 46px;
 }
 
@@ -5136,9 +5137,6 @@ h1.page-title {
 }
 
 @media only screen and (max-width: 481px) {
-	.primary-navigation > div > .menu-wrapper {
-		margin: 60px 0 0 0;
-	}
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-left: 0;
 	}

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1134,7 +1134,7 @@ hr.wp-block-separator.is-style-wide {
 }
 
 .site-header {
-	padding-top: 60px;
+	padding-top: 23px;
 	padding-bottom: 60px;
 }
 
@@ -4172,7 +4172,7 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 	letter-spacing: normal;
 	text-transform: uppercase;
 	line-height: 1.3;
-	margin-bottom: 15px;
+	margin-bottom: 5px;
 }
 
 .site-title a {
@@ -4975,15 +4975,14 @@ h1.page-title {
 	justify-content: space-between;
 	position: absolute;
 	right: 0;
-	padding-top: 42px;
+	padding-top: 15px;
 	padding-bottom: 8px;
 }
 
 .menu-button-container #primary-mobile-menu {
 	margin-left: auto;
 	padding: 10px 25px;
-	margin-top: 5px;
-	margin-right: 5px;
+	margin-right: 10px;
 }
 
 @media only screen and (max-width: 481px) {
@@ -4992,38 +4991,39 @@ h1.page-title {
 	}
 }
 
-.menu-button-container .button {
+.menu-button-container .button.button {
 	display: flex;
 	font-size: 1rem;
 	font-weight: 500;
 	text-transform: uppercase;
 	background-color: transparent;
+	border: none;
 	color: #28303d;
 }
 
-.menu-button-container .button .dropdown-icon {
+.menu-button-container .button.button .dropdown-icon {
 	display: flex;
 	align-items: center;
 }
 
-.menu-button-container .button .dropdown-icon .svg-icon {
+.menu-button-container .button.button .dropdown-icon .svg-icon {
 	margin-left: 5px;
 }
 
-.menu-button-container .button .dropdown-icon.open .svg-icon {
+.menu-button-container .button.button .dropdown-icon.open .svg-icon {
 	position: relative;
 	top: -1px;
 }
 
-.menu-button-container .button .dropdown-icon.close {
+.menu-button-container .button.button .dropdown-icon.close {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.open {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.open {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.close {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.close {
 	display: flex;
 }
 
@@ -5049,21 +5049,15 @@ h1.page-title {
 	margin-bottom: 0;
 }
 
-@media only screen and (max-width: 481px) {
-	.primary-navigation {
-		width: 100%;
-		position: fixed;
-	}
-}
-
 .primary-navigation > .primary-menu-container {
+	position: absolute;
 	visibility: hidden;
 	opacity: 0;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 110px 20px 25px;
+	padding: 70px 20px 25px;
 	background-color: #d1e4dd;
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -5080,7 +5074,14 @@ h1.page-title {
 
 .admin-bar .primary-navigation > .primary-menu-container {
 	height: calc(100vh - 46px);
-	padding-top: 126px;
+	padding-top: 24px;
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation-open .primary-navigation {
+		width: 100%;
+		position: fixed;
+	}
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {

--- a/assets/sass/03-generic/vertical-margins.scss
+++ b/assets/sass/03-generic/vertical-margins.scss
@@ -21,7 +21,7 @@
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(0.75 * var(--global--spacing-vertical));
 	padding-bottom: calc(2 * var(--global--spacing-vertical));
 
 	@include media(mobile) {

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -35,7 +35,7 @@
 	letter-spacing: normal;
 	text-transform: var(--branding--title--text-transform);
 	line-height: var(--global--line-height-heading);
-	margin-bottom: calc(var(--global--spacing-vertical) / 2);
+	margin-bottom: calc(var(--global--spacing-vertical) / 6);
 
 	a {
 		border-bottom: none;

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -399,5 +399,6 @@
 	.lock-scrolling .site {
 		position: fixed;
 		max-width: 100%;
+		width: 100%;
 	}
 }

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -107,11 +107,10 @@
 		@include media(mobile-only) {
 			height: 100vh;
 			z-index: 499;
-		}
 
-		.admin-bar & {
-			height: calc(100vh - 46px);
-			padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
+			.admin-bar & {
+				height: calc(100vh - 46px);
+			}
 		}
 	}
 

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -97,7 +97,11 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+		// Height of the menu-button-container using font size, line height, and total padding, plus 5px so the focus of the first item is visible.
+		padding-top: calc(var(--button--line-height) * var(--primary-nav--font-size-button) + 42px + 5px);
+		padding-left: var(--global--spacing-unit);
+		padding-right: var(--global--spacing-unit);
+		padding-bottom: var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
 		overflow-x: scroll;
 		overflow-y: auto;
@@ -131,9 +135,7 @@
 	}
 
 	// Adjust positions when logged-in
-	.admin-bar &,
-	.admin-bar & > .primary-menu-container,
-	.admin-bar.lock-scrolling & .button {
+	.admin-bar & {
 		top: 46px;
 	}
 

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -7,26 +7,27 @@
 	justify-content: space-between;
 	position: absolute;
 	right: 0;
-	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-top: calc(0.5 * var(--global--spacing-vertical));
 	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 
 	#primary-mobile-menu {
 		margin-left: auto;
 		padding: calc(var(--button--padding-vertical) - (0.25 * var(--global--spacing-unit))) calc(var(--button--padding-horizontal) - (0.25 * var(--global--spacing-unit)));
-		margin-top: calc(0.25 * var(--global--spacing-unit));
-		margin-right: calc(0.25 * var(--global--spacing-unit));
+		margin-right: calc(0.5 * var(--global--spacing-unit));
 	}
 
 	@include media(mobile-only) {
 		display: flex;
 	}
 
-	.button {
+	// Override specificty from default button styles.
+	.button.button {
 		display: flex;
 		font-size: var(--primary-nav--font-size-button);
 		font-weight: var(--primary-nav--font-weight-button);
 		text-transform: var(--branding--title--text-transform);
 		background-color: transparent;
+		border: none;
 		color: var(--primary-nav--color-link);
 
 		.dropdown-icon {
@@ -87,20 +88,16 @@
 	margin-top: 0;
 	margin-bottom: 0;
 
-	@include media(mobile-only) {
-		width: 100%;
-		position: fixed;
-	}
-
 	// Mobile menu closed
 	> .primary-menu-container {
+		position: absolute;
 		visibility: hidden;
 		opacity: 0;
 		top: 0;
 		right: 0;
 		bottom: 0;
 		left: 0;
-		padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+		padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
 		overflow-x: scroll;
 		overflow-y: auto;
@@ -114,12 +111,17 @@
 
 		.admin-bar & {
 			height: calc(100vh - 46px);
-			padding-top: calc(4 * var(--global--spacing-unit) + 46px);
+			padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
 		}
 	}
 
 	// Mobile menu open
 	.primary-navigation-open & {
+
+		@include media(mobile-only) {
+			width: 100%;
+			position: fixed;
+		}
 
 		> .primary-menu-container {
 			visibility: visible;

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -5,10 +5,10 @@
 .menu-button-container {
 	display: none;
 	justify-content: space-between;
-	left: 0;
 	position: absolute;
-	top: 0;
-	width: 100%;
+	right: 0;
+	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 
 	#primary-mobile-menu {
 		margin-left: auto;
@@ -21,10 +21,6 @@
 		display: flex;
 	}
 
-	.admin-bar:not(.primary-navigation-open) & {
-		top: calc(1.4 * var(--global--spacing-vertical));
-	}
-
 	.button {
 		display: flex;
 		font-size: var(--primary-nav--font-size-button);
@@ -32,7 +28,6 @@
 		text-transform: var(--branding--title--text-transform);
 		background-color: transparent;
 		color: var(--primary-nav--color-link);
-		z-index: 500;
 
 		.dropdown-icon {
 			display: flex;
@@ -71,9 +66,12 @@
 
 	// When the menu is open, hide the close button and show the hide button.
 	.primary-navigation-open & {
+		width: 100%;
+		z-index: 500;
+		background-color: var(--global--color-background);
 
 		#primary-mobile-menu {
-			display: flex;
+			position: static;
 		}
 	}
 }
@@ -91,26 +89,32 @@
 
 	@include media(mobile-only) {
 		width: 100%;
+		position: fixed;
 	}
 
 	// Mobile menu closed
 	> .primary-menu-container {
 		visibility: hidden;
 		opacity: 0;
-		position: fixed;
 		top: 0;
 		right: 0;
 		bottom: 0;
 		left: 0;
-		padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+		padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
-		overflow-x: hidden;
+		overflow-x: scroll;
 		overflow-y: auto;
 		transition: all .15s ease-in-out;
 		transform: translateY(var(--global--spacing-vertical));
 
 		@include media(mobile-only) {
+			height: 100vh;
 			z-index: 499;
+		}
+
+		.admin-bar & {
+			height: calc(100vh - 46px);
+			padding-top: calc(4 * var(--global--spacing-unit) + 46px);
 		}
 	}
 
@@ -125,17 +129,10 @@
 
 	}
 
-	// Adjust button postion when scrolling is locked
-	.lock-scrolling & > .button {
-		position: fixed;
-		top: 0;
-		right: 0;
-	}
-
 	// Adjust positions when logged-in
 	.admin-bar &,
 	.admin-bar & > .primary-menu-container,
-	.admin-bar.lock-scrolling & > .button {
+	.admin-bar.lock-scrolling & .button {
 		top: 46px;
 	}
 
@@ -188,7 +185,6 @@
 		position: relative;
 
 		@include media(mobile-only) {
-			margin: calc(2 * var(--global--spacing-vertical)) 0 0 0;
 
 			ul {
 				padding-left: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -853,7 +853,7 @@ template {
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(0.75 * var(--global--spacing-vertical));
 	padding-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
@@ -2900,7 +2900,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	letter-spacing: normal;
 	text-transform: var(--branding--title--text-transform);
 	line-height: var(--global--line-height-heading);
-	margin-bottom: calc(var(--global--spacing-vertical) / 2);
+	margin-bottom: calc(var(--global--spacing-vertical) / 6);
 }
 
 .site-title a {
@@ -3576,15 +3576,14 @@ h1.page-title {
 	justify-content: space-between;
 	position: absolute;
 	left: 0;
-	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-top: calc(0.5 * var(--global--spacing-vertical));
 	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 }
 
 .menu-button-container #primary-mobile-menu {
 	margin-right: auto;
 	padding: calc(var(--button--padding-vertical) - (0.25 * var(--global--spacing-unit))) calc(var(--button--padding-horizontal) - (0.25 * var(--global--spacing-unit)));
-	margin-top: calc(0.25 * var(--global--spacing-unit));
-	margin-left: calc(0.25 * var(--global--spacing-unit));
+	margin-left: calc(0.5 * var(--global--spacing-unit));
 }
 
 @media only screen and (max-width: 481px) {
@@ -3593,38 +3592,39 @@ h1.page-title {
 	}
 }
 
-.menu-button-container .button {
+.menu-button-container .button.button {
 	display: flex;
 	font-size: var(--primary-nav--font-size-button);
 	font-weight: var(--primary-nav--font-weight-button);
 	text-transform: var(--branding--title--text-transform);
 	background-color: transparent;
+	border: none;
 	color: var(--primary-nav--color-link);
 }
 
-.menu-button-container .button .dropdown-icon {
+.menu-button-container .button.button .dropdown-icon {
 	display: flex;
 	align-items: center;
 }
 
-.menu-button-container .button .dropdown-icon .svg-icon {
+.menu-button-container .button.button .dropdown-icon .svg-icon {
 	margin-right: calc(0.25 * var(--global--spacing-unit));
 }
 
-.menu-button-container .button .dropdown-icon.open .svg-icon {
+.menu-button-container .button.button .dropdown-icon.open .svg-icon {
 	position: relative;
 	top: -1px;
 }
 
-.menu-button-container .button .dropdown-icon.close {
+.menu-button-container .button.button .dropdown-icon.close {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.open {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.open {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.close {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.close {
 	display: flex;
 }
 
@@ -3650,21 +3650,15 @@ h1.page-title {
 	margin-bottom: 0;
 }
 
-@media only screen and (max-width: 481px) {
-	.primary-navigation {
-		width: 100%;
-		position: fixed;
-	}
-}
-
 .primary-navigation > .primary-menu-container {
+	position: absolute;
 	visibility: hidden;
 	opacity: 0;
 	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
-	padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -3681,7 +3675,14 @@ h1.page-title {
 
 .admin-bar .primary-navigation > .primary-menu-container {
 	height: calc(100vh - 46px);
-	padding-top: calc(4 * var(--global--spacing-unit) + 46px);
+	padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation-open .primary-navigation {
+		width: 100%;
+		position: fixed;
+	}
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3658,7 +3658,10 @@ h1.page-title {
 	left: 0;
 	bottom: 0;
 	right: 0;
-	padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding-top: calc(var(--button--line-height) * var(--primary-nav--font-size-button) + 42px + 5px);
+	padding-right: var(--global--spacing-unit);
+	padding-left: var(--global--spacing-unit);
+	padding-bottom: var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -3671,11 +3674,9 @@ h1.page-title {
 		height: 100vh;
 		z-index: 499;
 	}
-}
-
-.admin-bar .primary-navigation > .primary-menu-container {
-	height: calc(100vh - 46px);
-	padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
+	.admin-bar .primary-navigation > .primary-menu-container {
+		height: calc(100vh - 46px);
+	}
 }
 
 @media only screen and (max-width: 481px) {
@@ -3691,9 +3692,7 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.admin-bar .primary-navigation,
-.admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation .button {
+.admin-bar .primary-navigation {
 	top: 46px;
 }
 
@@ -3934,6 +3933,7 @@ h1.page-title {
 	.lock-scrolling .site {
 		position: fixed;
 		max-width: 100%;
+		width: 100%;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3574,10 +3574,10 @@ h1.page-title {
 .menu-button-container {
 	display: none;
 	justify-content: space-between;
-	right: 0;
 	position: absolute;
-	top: 0;
-	width: 100%;
+	left: 0;
+	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 }
 
 .menu-button-container #primary-mobile-menu {
@@ -3593,10 +3593,6 @@ h1.page-title {
 	}
 }
 
-.admin-bar:not(.primary-navigation-open) .menu-button-container {
-	top: calc(1.4 * var(--global--spacing-vertical));
-}
-
 .menu-button-container .button {
 	display: flex;
 	font-size: var(--primary-nav--font-size-button);
@@ -3604,7 +3600,6 @@ h1.page-title {
 	text-transform: var(--branding--title--text-transform);
 	background-color: transparent;
 	color: var(--primary-nav--color-link);
-	z-index: 500;
 }
 
 .menu-button-container .button .dropdown-icon {
@@ -3633,8 +3628,14 @@ h1.page-title {
 	display: flex;
 }
 
+.primary-navigation-open .menu-button-container {
+	width: 100%;
+	z-index: 500;
+	background-color: var(--global--color-background);
+}
+
 .primary-navigation-open .menu-button-container #primary-mobile-menu {
-	display: flex;
+	position: static;
 }
 
 .primary-navigation {
@@ -3652,20 +3653,20 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 	.primary-navigation {
 		width: 100%;
+		position: fixed;
 	}
 }
 
 .primary-navigation > .primary-menu-container {
 	visibility: hidden;
 	opacity: 0;
-	position: fixed;
 	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
-	padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	overflow-x: hidden;
+	overflow-x: scroll;
 	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
@@ -3673,8 +3674,14 @@ h1.page-title {
 
 @media only screen and (max-width: 481px) {
 	.primary-navigation > .primary-menu-container {
+		height: 100vh;
 		z-index: 499;
 	}
+}
+
+.admin-bar .primary-navigation > .primary-menu-container {
+	height: calc(100vh - 46px);
+	padding-top: calc(4 * var(--global--spacing-unit) + 46px);
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {
@@ -3683,15 +3690,9 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.lock-scrolling .primary-navigation > .button {
-	position: fixed;
-	top: 0;
-	left: 0;
-}
-
 .admin-bar .primary-navigation,
 .admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation > .button {
+.admin-bar.lock-scrolling .primary-navigation .button {
 	top: 46px;
 }
 
@@ -3737,9 +3738,6 @@ h1.page-title {
 }
 
 @media only screen and (max-width: 481px) {
-	.primary-navigation > div > .menu-wrapper {
-		margin: calc(2 * var(--global--spacing-vertical)) 0 0 0;
-	}
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-right: 0;
 	}

--- a/style.css
+++ b/style.css
@@ -3667,7 +3667,10 @@ h1.page-title {
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding-top: calc(var(--button--line-height) * var(--primary-nav--font-size-button) + 42px + 5px);
+	padding-left: var(--global--spacing-unit);
+	padding-right: var(--global--spacing-unit);
+	padding-bottom: var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -3680,11 +3683,9 @@ h1.page-title {
 		height: 100vh;
 		z-index: 499;
 	}
-}
-
-.admin-bar .primary-navigation > .primary-menu-container {
-	height: calc(100vh - 46px);
-	padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
+	.admin-bar .primary-navigation > .primary-menu-container {
+		height: calc(100vh - 46px);
+	}
 }
 
 @media only screen and (max-width: 481px) {
@@ -3700,9 +3701,7 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.admin-bar .primary-navigation,
-.admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation .button {
+.admin-bar .primary-navigation {
 	top: 46px;
 }
 
@@ -3943,6 +3942,7 @@ h1.page-title {
 	.lock-scrolling .site {
 		position: fixed;
 		max-width: 100%;
+		width: 100%;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -857,7 +857,7 @@ template {
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(0.75 * var(--global--spacing-vertical));
 	padding-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
@@ -2909,7 +2909,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	letter-spacing: normal;
 	text-transform: var(--branding--title--text-transform);
 	line-height: var(--global--line-height-heading);
-	margin-bottom: calc(var(--global--spacing-vertical) / 2);
+	margin-bottom: calc(var(--global--spacing-vertical) / 6);
 }
 
 .site-title a {
@@ -3585,15 +3585,14 @@ h1.page-title {
 	justify-content: space-between;
 	position: absolute;
 	right: 0;
-	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-top: calc(0.5 * var(--global--spacing-vertical));
 	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 }
 
 .menu-button-container #primary-mobile-menu {
 	margin-left: auto;
 	padding: calc(var(--button--padding-vertical) - (0.25 * var(--global--spacing-unit))) calc(var(--button--padding-horizontal) - (0.25 * var(--global--spacing-unit)));
-	margin-top: calc(0.25 * var(--global--spacing-unit));
-	margin-right: calc(0.25 * var(--global--spacing-unit));
+	margin-right: calc(0.5 * var(--global--spacing-unit));
 }
 
 @media only screen and (max-width: 481px) {
@@ -3602,38 +3601,39 @@ h1.page-title {
 	}
 }
 
-.menu-button-container .button {
+.menu-button-container .button.button {
 	display: flex;
 	font-size: var(--primary-nav--font-size-button);
 	font-weight: var(--primary-nav--font-weight-button);
 	text-transform: var(--branding--title--text-transform);
 	background-color: transparent;
+	border: none;
 	color: var(--primary-nav--color-link);
 }
 
-.menu-button-container .button .dropdown-icon {
+.menu-button-container .button.button .dropdown-icon {
 	display: flex;
 	align-items: center;
 }
 
-.menu-button-container .button .dropdown-icon .svg-icon {
+.menu-button-container .button.button .dropdown-icon .svg-icon {
 	margin-left: calc(0.25 * var(--global--spacing-unit));
 }
 
-.menu-button-container .button .dropdown-icon.open .svg-icon {
+.menu-button-container .button.button .dropdown-icon.open .svg-icon {
 	position: relative;
 	top: -1px;
 }
 
-.menu-button-container .button .dropdown-icon.close {
+.menu-button-container .button.button .dropdown-icon.close {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.open {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.open {
 	display: none;
 }
 
-.menu-button-container .button[aria-expanded*="true"] .dropdown-icon.close {
+.menu-button-container .button.button[aria-expanded*="true"] .dropdown-icon.close {
 	display: flex;
 }
 
@@ -3659,21 +3659,15 @@ h1.page-title {
 	margin-bottom: 0;
 }
 
-@media only screen and (max-width: 481px) {
-	.primary-navigation {
-		width: 100%;
-		position: fixed;
-	}
-}
-
 .primary-navigation > .primary-menu-container {
+	position: absolute;
 	visibility: hidden;
 	opacity: 0;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(3.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
 	overflow-x: scroll;
 	overflow-y: auto;
@@ -3690,7 +3684,14 @@ h1.page-title {
 
 .admin-bar .primary-navigation > .primary-menu-container {
 	height: calc(100vh - 46px);
-	padding-top: calc(4 * var(--global--spacing-unit) + 46px);
+	padding-top: calc(3.5 * var(--global--spacing-unit) - 46px);
+}
+
+@media only screen and (max-width: 481px) {
+	.primary-navigation-open .primary-navigation {
+		width: 100%;
+		position: fixed;
+	}
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {

--- a/style.css
+++ b/style.css
@@ -3583,10 +3583,10 @@ h1.page-title {
 .menu-button-container {
 	display: none;
 	justify-content: space-between;
-	left: 0;
 	position: absolute;
-	top: 0;
-	width: 100%;
+	right: 0;
+	padding-top: calc(1.4 * var(--global--spacing-vertical));
+	padding-bottom: calc(0.25 * var(--global--spacing-vertical));
 }
 
 .menu-button-container #primary-mobile-menu {
@@ -3602,10 +3602,6 @@ h1.page-title {
 	}
 }
 
-.admin-bar:not(.primary-navigation-open) .menu-button-container {
-	top: calc(1.4 * var(--global--spacing-vertical));
-}
-
 .menu-button-container .button {
 	display: flex;
 	font-size: var(--primary-nav--font-size-button);
@@ -3613,7 +3609,6 @@ h1.page-title {
 	text-transform: var(--branding--title--text-transform);
 	background-color: transparent;
 	color: var(--primary-nav--color-link);
-	z-index: 500;
 }
 
 .menu-button-container .button .dropdown-icon {
@@ -3642,8 +3637,14 @@ h1.page-title {
 	display: flex;
 }
 
+.primary-navigation-open .menu-button-container {
+	width: 100%;
+	z-index: 500;
+	background-color: var(--global--color-background);
+}
+
 .primary-navigation-open .menu-button-container #primary-mobile-menu {
-	display: flex;
+	position: static;
 }
 
 .primary-navigation {
@@ -3661,20 +3662,20 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 	.primary-navigation {
 		width: 100%;
+		position: fixed;
 	}
 }
 
 .primary-navigation > .primary-menu-container {
 	visibility: hidden;
 	opacity: 0;
-	position: fixed;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: calc(4 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(5.5 * var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	overflow-x: hidden;
+	overflow-x: scroll;
 	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
@@ -3682,8 +3683,14 @@ h1.page-title {
 
 @media only screen and (max-width: 481px) {
 	.primary-navigation > .primary-menu-container {
+		height: 100vh;
 		z-index: 499;
 	}
+}
+
+.admin-bar .primary-navigation > .primary-menu-container {
+	height: calc(100vh - 46px);
+	padding-top: calc(4 * var(--global--spacing-unit) + 46px);
 }
 
 .primary-navigation-open .primary-navigation > .primary-menu-container {
@@ -3692,15 +3699,9 @@ h1.page-title {
 	transform: translateY(0);
 }
 
-.lock-scrolling .primary-navigation > .button {
-	position: fixed;
-	top: 0;
-	right: 0;
-}
-
 .admin-bar .primary-navigation,
 .admin-bar .primary-navigation > .primary-menu-container,
-.admin-bar.lock-scrolling .primary-navigation > .button {
+.admin-bar.lock-scrolling .primary-navigation .button {
 	top: 46px;
 }
 
@@ -3746,9 +3747,6 @@ h1.page-title {
 }
 
 @media only screen and (max-width: 481px) {
-	.primary-navigation > div > .menu-wrapper {
-		margin: calc(2 * var(--global--spacing-vertical)) 0 0 0;
-	}
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-left: 0;
 	}


### PR DESCRIPTION
Fixes #189 — The menu/close button now stays fixed at the top of the screen, while long menu items can be scrolled through. Menu items move under the button container, so the text doesn't overlap anymore. This also fixes the content shift described in #216. 

|           | Logged in | Not logged in |
|-----------|-----------|---------------|
| initial   | ![Screen Shot 2020-10-05 at 8 20 21 PM](https://user-images.githubusercontent.com/541093/95145113-5a5cc100-0748-11eb-8d4f-d2e526d69e65.png) | ![Screen Shot 2020-10-05 at 8 16 21 PM](https://user-images.githubusercontent.com/541093/95144939-ec17fe80-0747-11eb-9106-62afe1336990.png) |
| menu open | ![Screen Shot 2020-10-05 at 8 20 55 PM](https://user-images.githubusercontent.com/541093/95145107-54ff7680-0748-11eb-85d1-990504479b78.png) | ![Screen Shot 2020-10-05 at 8 16 30 PM](https://user-images.githubusercontent.com/541093/95144968-ffc36500-0747-11eb-84f6-753f058e4bef.png) |
| scrolled  | ![Screen Shot 2020-10-05 at 8 21 02 PM](https://user-images.githubusercontent.com/541093/95145101-4e70ff00-0748-11eb-9c11-55cb59604d5f.png) | ![Screen Shot 2020-10-05 at 8 17 52 PM](https://user-images.githubusercontent.com/541093/95144978-05b94600-0748-11eb-9243-5b2ba642aec1.png) |

⚠️  I couldn't get my test site to work in Firefox or Safari, so this has _only been tested in Chrome/Mac._  I'll try to fix my setup, but until then other folks testing in other browsers or actually on mobile devices would be a big help. 


