### PR TITLE
Reduce bold font weight to match the editor

### DIFF
--- a/assets/sass/04-elements/misc.scss
+++ b/assets/sass/04-elements/misc.scss
@@ -1,7 +1,7 @@
 /* Over here, place any elements that do not need to have their own file. */
 b,
 strong {
-	font-weight: bold;
+	font-weight: 600;
 }
 
 dfn,


### PR DESCRIPTION
In the editor, the b and strong font weight is set to 600. On the front, this is set to bold, 700.

This PR reduces the b and strong font weight to 600 to match the editor.

