### PR TITLE
Solve dotted underline issue in Chrome

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -377,6 +377,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2076,6 +2076,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -458,6 +458,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -11,6 +11,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1490,6 +1490,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {

--- a/style.css
+++ b/style.css
@@ -1494,6 +1494,7 @@ a {
 
 a:hover {
 	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 }
 
 .site a:focus {


### PR DESCRIPTION
Props to @pattonwebz 

Before and after:
![dot](https://user-images.githubusercontent.com/7422055/95181563-bfa1c800-07c3-11eb-99e2-d65605af7ef9.png)

![dot-after](https://user-images.githubusercontent.com/7422055/95181633-d6e0b580-07c3-11eb-9d34-dab84f881947.png)
