### PR TITLE
Ignore changes to .css files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 
 *.php text eol=lf
 *.js text eol=lf
-*.css text eol=lf
+*.css text eol=lf linguist-generated
 *.scss text eol=lf
 *.json text eol=lf
 


### PR DESCRIPTION
This change should make GitHub ignore the changes to CSS files when you're looking at pull requests and also make it ignore CSS for code stats purposes.