### PR TITLE
Update menu widget and line height

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -28,6 +28,7 @@
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */
+	/* Widgets */
 }
 
 /* Button extends */

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -119,6 +119,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */
+	/* Widgets */
 }
 
 /* Button extends */
@@ -5594,8 +5595,16 @@ h1.page-title {
 	padding: 0;
 }
 
+.widget-area ul li {
+	line-height: 1.9;
+}
+
 .widget-area ul.sub-menu {
 	margin-left: 13px;
+}
+
+.widget-area ul .sub-menu-toggle {
+	display: none;
 }
 
 .widget-area a {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -211,6 +211,11 @@
 	--table--stripes-background-color: var(--global--color-light-gray);
 	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
+	/* Widgets */
+	--widget--line-height-list: 1.9;
+	--widget--line-height-title: 1.4;
+	--widget--font-weight-title: 700;
+	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
 @media only screen and (min-width: 652px) {

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -239,6 +239,13 @@ $baseline-unit: 10px;
 	--table--stripes-background-color: var(--global--color-light-gray);
 	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
+
+	/* Widgets */
+	--widget--line-height-list: 1.9;
+	--widget--line-height-title: 1.4;
+	--widget--font-weight-title: 700;
+	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+
 }
 
 @media only screen and (min-width: 652px) { // Not using the mixin because it's compiled after this file

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -12,8 +12,16 @@
 		list-style-type: none;
 		padding: 0;
 
+		li {
+			line-height: var(--widget--line-height-list);
+		}
+
 		&.sub-menu {
-			margin-left: var(--primary-nav--padding);
+			margin-left: var(--widget--spacing-menu);
+		}
+
+		.sub-menu-toggle {
+			display: none;
 		}
 	}
 
@@ -46,8 +54,8 @@
 
 .widget-title {
 	font-size: var(--global--font-size-sm);
-	font-weight: 700;
-	line-height: 1.4;
+	font-weight: var(--widget--font-weight-title);
+	line-height: var(--widget--line-height-title);
 }
 
 // Search widget styles

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -302,6 +302,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--table--stripes-background-color: var(--global--color-light-gray);
 	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
+	/* Widgets */
+	--widget--line-height-list: 1.9;
+	--widget--line-height-title: 1.4;
+	--widget--font-weight-title: 700;
+	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
 @media only screen and (min-width: 652px) {
@@ -4142,8 +4147,16 @@ h1.page-title {
 	padding: 0;
 }
 
+.widget-area ul li {
+	line-height: var(--widget--line-height-list);
+}
+
 .widget-area ul.sub-menu {
-	margin-right: var(--primary-nav--padding);
+	margin-right: var(--widget--spacing-menu);
+}
+
+.widget-area ul .sub-menu-toggle {
+	display: none;
 }
 
 .widget-area a {
@@ -4171,8 +4184,8 @@ h1.page-title {
 
 .widget-title {
 	font-size: var(--global--font-size-sm);
-	font-weight: 700;
-	line-height: 1.4;
+	font-weight: var(--widget--font-weight-title);
+	line-height: var(--widget--line-height-title);
 }
 
 .search-form {

--- a/style.css
+++ b/style.css
@@ -302,6 +302,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--table--stripes-background-color: var(--global--color-light-gray);
 	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
+	/* Widgets */
+	--widget--line-height-list: 1.9;
+	--widget--line-height-title: 1.4;
+	--widget--font-weight-title: 700;
+	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
 @media only screen and (min-width: 652px) {
@@ -4151,8 +4156,16 @@ h1.page-title {
 	padding: 0;
 }
 
+.widget-area ul li {
+	line-height: var(--widget--line-height-list);
+}
+
 .widget-area ul.sub-menu {
-	margin-left: var(--primary-nav--padding);
+	margin-left: var(--widget--spacing-menu);
+}
+
+.widget-area ul .sub-menu-toggle {
+	display: none;
 }
 
 .widget-area a {
@@ -4180,8 +4193,8 @@ h1.page-title {
 
 .widget-title {
 	font-size: var(--global--font-size-sm);
-	font-weight: 700;
-	line-height: 1.4;
+	font-weight: var(--widget--font-weight-title);
+	line-height: var(--widget--line-height-title);
 }
 
 .search-form {


### PR DESCRIPTION
Closes https://github.com/WordPress/twentytwentyone/issues/309

- [x] Sub-menu items are indented

- [x] The sub-menu button/icons do not show

Increases the line height of the widget lists
