### PR TITLE
Fix avatar overlap. Fixes #330

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4852,6 +4852,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -119,6 +119,7 @@
 			hyphens: auto;
 			word-wrap: break-word;
 			word-break: break-word;
+			display: inline-block;
 		}
 
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3478,6 +3478,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/style.css
+++ b/style.css
@@ -3487,6 +3487,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {


### PR DESCRIPTION
Changes `.comment-meta .comment-author .fn` to `inline-block`, fixing #330 .