### PR TITLE
Aligns the arrow icons. Fixes #308

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5475,6 +5475,8 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+	top: -2px;
 }
 
 .post-navigation {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4852,7 +4852,6 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
-	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4852,6 +4852,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -119,6 +119,7 @@
 			hyphens: auto;
 			word-wrap: break-word;
 			word-break: break-word;
+			display: inline-block;
 		}
 
 	}

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -119,7 +119,6 @@
 			hyphens: auto;
 			word-wrap: break-word;
 			word-break: break-word;
-			display: inline-block;
 		}
 
 	}

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -46,6 +46,8 @@
 		display: inline-block;
 		fill: currentColor;
 		vertical-align: middle;
+		position: relative;
+		top: -2px;
 	}
 }
 

--- a/classes/class-twenty-twenty-one-svg-icons.php
+++ b/classes/class-twenty-twenty-one-svg-icons.php
@@ -58,7 +58,7 @@ class Twenty_Twenty_One_SVG_Icons {
 	 * @var array
 	 */
 	public static $ui_icons = array(
-		'arrow_right' => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 11V9h12l-4-4 1-2 7 7-7 7-1-2 4-4H2z" fill="currentColor"/></svg>',
+		'arrow_right' => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m4 13v-2h12l-4-4 1-2 7 7-7 7-1-2 4-4z" fill="currentColor"/></svg>',
 		'arrow_left'  => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 13v-2H8l4-4-1-2-7 7 7 7 1-2-4-4z" fill="currentColor"/></svg>',
 		'close'       => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 10.9394L5.53033 4.46973L4.46967 5.53039L10.9393 12.0001L4.46967 18.4697L5.53033 19.5304L12 13.0607L18.4697 19.5304L19.5303 18.4697L13.0607 12.0001L19.5303 5.53039L18.4697 4.46973L12 10.9394Z" fill="currentColor"/></svg>',
 		'menu'        => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 6H19.5V7.5H4.5V6ZM4.5 12H19.5V13.5H4.5V12ZM19.5 18H4.5V19.5H19.5V18Z" fill="currentColor"/></svg>',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3478,7 +3478,6 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
-	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3478,6 +3478,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4049,6 +4049,8 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+	top: -2px;
 }
 
 .post-navigation {

--- a/style.css
+++ b/style.css
@@ -3487,7 +3487,6 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
-	display: inline-block;
 }
 
 .comment-meta .comment-metadata {

--- a/style.css
+++ b/style.css
@@ -4058,6 +4058,8 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+	top: -2px;
 }
 
 .post-navigation {

--- a/style.css
+++ b/style.css
@@ -3487,6 +3487,7 @@ h1.page-title {
 	hyphens: auto;
 	word-wrap: break-word;
 	word-break: break-word;
+	display: inline-block;
 }
 
 .comment-meta .comment-metadata {


### PR DESCRIPTION
The `arrow_right` SVG was incorrectly vertically aligned as showed in the image below:

![arrow_right-vertical_align](https://user-images.githubusercontent.com/3619476/95409700-96cf1f00-08f8-11eb-8778-a3598d97072f.png)

I did a simple edit of the icon on Inkscape to fix that, and applied `position: relative` with a `top: -2px` positioning on the `svg` element (28 pixels from the height of the parent element, minus 24 pixels of the height of the SVG).