### PR TITLE
Excerpt on postspage toggle

### DIFF
--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -97,6 +97,9 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'capability' => 'edit_theme_options',
 					'default'    => 'excerpt',
+					'sanitize_callback' => function( $value ) {
+						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt'
+					},
 				)
 			);
 

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -88,7 +88,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			$wp_customize->add_section(
 				'theme_settings',
 				array(
-					'title'    => __( 'Theme settings', 'twentytwentyone' ),
+					'title'    => esc_html__( 'Theme settings', 'twentytwentyone' ),
 					'priority' => 30,
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -95,8 +95,8 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			$wp_customize->add_setting(
 				'display_excerpt_or_fullpost',
 				array(
-					'capability' => 'edit_theme_options',
-					'default'    => 'excerpt',
+					'capability'        => 'edit_theme_options',
+					'default'           => 'excerpt',
 					'sanitize_callback' => function( $value ) {
 						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt';
 					},

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -85,17 +85,20 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			 * Add excerpt or full text selector to customizer
 			 */
 
-			$wp_customize->add_section( 'theme_settings' , array(
-				'title'      => __('Theme settings','twentytwentyone'),
-				'priority'   => 30,
-			) );
+			$wp_customize->add_section(
+				'theme_settings',
+				array(
+					'title'    => __( 'Theme settings', 'twentytwentyone' ),
+					'priority' => 30,
+				)
+			);
 
 
 			$wp_customize->add_setting(
 				'display_excerpt_or_fullpost',
 				array(
-					'capability'        => 'edit_theme_options',
-					'default'           => 'excerpt',
+					'capability' => 'edit_theme_options',
+					'default'    => 'excerpt',
 				)
 			);
 
@@ -107,7 +110,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					'label'   => __( 'On the Posts page, post show:', 'twentytwentyone' ),
 					'choices' => array(
 						'excerpt' => 'Excerpt',
-						'full' 	  => 'Full text',
+						'full'    => 'Full text',
 					),
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'type'    => 'radio',
 					'section' => 'theme_settings',
-					'label'   => __( 'On the Posts page, post show:', 'twentytwentyone' ),
+					'label'   => esc_html__( 'On the Posts page, post show:', 'twentytwentyone' ),
 					'choices' => array(
 						'excerpt' => 'Excerpt',
 						'full'    => 'Full text',

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -109,8 +109,8 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					'section' => 'theme_settings',
 					'label'   => esc_html__( 'On the Posts page, post show:', 'twentytwentyone' ),
 					'choices' => array(
-						'excerpt' => 'Excerpt',
-						'full'    => 'Full text',
+						'excerpt' => esc_html__( 'Excerpt', 'twentytwentyone' ),
+						'full'    => esc_html__( 'Full text', 'twentytwentyone' ),
 					),
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -66,6 +66,37 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				)
 			);
 
+			/**
+			 * Add excerpt or full text selector to customizer
+			 */
+
+			$wp_customize->add_section( 'theme_settings' , array(
+				'title'      => __('Theme settings','twentytwentyone'),
+				'priority'   => 30,
+			) );
+
+
+			$wp_customize->add_setting(
+				'display_excerpt_or_fullpost',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => 'excerpt',
+				)
+			);
+
+			$wp_customize->add_control(
+				'display_excerpt_or_fullpost',
+				array(
+					'type'    => 'radio',
+					'section' => 'theme_settings',
+					'label'   => __( 'On the Posts page, post show:', 'twentytwentyone' ),
+					'choices' => array(
+						'excerpt' => 'Excerpt',
+						'full' 	  => 'Full text',
+					),
+				)
+			);
+
 			// Background color.
 			// Include the custom control class.
 			include_once get_theme_file_path( 'classes/class-twenty-twenty-one-customize-color-control.php' ); // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					'capability' => 'edit_theme_options',
 					'default'    => 'excerpt',
 					'sanitize_callback' => function( $value ) {
-						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt'
+						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt';
 					},
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -84,7 +84,6 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			/**
 			 * Add excerpt or full text selector to customizer
 			 */
-
 			$wp_customize->add_section(
 				'theme_settings',
 				array(
@@ -92,7 +91,6 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					'priority' => 30,
 				)
 			);
-
 
 			$wp_customize->add_setting(
 				'display_excerpt_or_fullpost',

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ if ( have_posts() ) {
 	while ( have_posts() ) {
 		the_post();
 
-		if ( get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) === 'excerpt' ) {
+		if ( 'excerpt' === get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) ) {
 			get_template_part( 'template-parts/content/content-excerpt' );
 		} else {
 			get_template_part( 'template-parts/content/content' );

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ if ( have_posts() ) {
 	while ( have_posts() ) {
 		the_post();
 
-		if( get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) === 'excerpt' ){
+		if ( get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) === 'excerpt' ) {
 			get_template_part( 'template-parts/content/content-excerpt' );
 		} else {
 			get_template_part( 'template-parts/content/content' );

--- a/index.php
+++ b/index.php
@@ -21,7 +21,12 @@ if ( have_posts() ) {
 	// Load posts loop.
 	while ( have_posts() ) {
 		the_post();
-		get_template_part( 'template-parts/content/content' );
+
+		if( get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) === 'excerpt' ){
+			get_template_part( 'template-parts/content/content-excerpt' );
+		} else {
+			get_template_part( 'template-parts/content/content' );
+		}
 	}
 
 	// Previous/next page navigation.


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentytwentyone/issues/129

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Add a section named `Theme settings` where you can toggle between excerpt or full text. Excerpt is set as default.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
n/a

## Test instructions
This PR can be tested by following these steps:

1. Make sure you have a posts page set in `Settings` -> `Reading`
1. Make sure you have posts with long enough of a content so that you can see the difference between excerpts and full text.
1. Go to `Appearance` -> `Customize`
1. Go to `Theme settings` and change the `On the Posts page, post show:` settings
1. Check on the Posts page if the content switch between showing excerpts or full text.

Don't forget to test the unhappy-paths!

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively