### PR TITLE
Hide page title on frontpage.

### DIFF
--- a/assets/sass/06-components/single.scss
+++ b/assets/sass/06-components/single.scss
@@ -4,6 +4,12 @@
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
+.home .entry-header {
+	border-bottom: none;
+	padding-bottom: 0;
+	margin-bottom: 0;
+}
+
 .singular .has-post-thumbnail .entry-header {
 	border-bottom: none;
 	padding-bottom: calc(1.3 * var(--global--spacing-vertical));

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -14,8 +14,13 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 	<header class="entry-header alignwide">
-		<?php get_template_part( 'template-parts/header/entry-header' ); ?>
-		<?php twenty_twenty_one_post_thumbnail(); ?>
+		<?php
+		if ( ! is_front_page() ) {
+			get_template_part( 'template-parts/header/entry-header' );
+		}
+
+			twenty_twenty_one_post_thumbnail();
+		?>
 	</header>
 
 	<div class="entry-content">

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -14,13 +14,10 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 	<header class="entry-header alignwide">
-		<?php
-		if ( ! is_front_page() ) {
-			get_template_part( 'template-parts/header/entry-header' );
-		}
-
-			twenty_twenty_one_post_thumbnail();
-		?>
+		<?php if ( ! is_front_page() ) : ?>
+			<?php get_template_part( 'template-parts/header/entry-header' ); ?>
+		<?php endif; ?>
+		<?php twenty_twenty_one_post_thumbnail(); ?>
 	</header>
 
 	<div class="entry-content">


### PR DESCRIPTION
Fixes #314 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
This PR hides the `template-parts/header/entry-header` if it's the front page.
- Implemented an if statement that does this check. 
- A bit of Sass that hides the border.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
## Test instructions
This PR can be tested by following these steps:
1. Set your front-page as a static page.
1. Set a post title.
1. Navigate to your front-page and you should not be able to see the title.
![Screenshot 2020-10-08 at 11 48 27](https://user-images.githubusercontent.com/49080649/95442926-3e316d80-095c-11eb-95cc-408a2d616ca0.png)


Don't forget to test the unhappy-paths!
## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively