### PR TITLE
Add div around read more block

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -201,7 +201,7 @@ function twenty_twenty_one_continue_reading_link() {
 			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
 		);
 
-		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a>';
+		return '<div><a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a></div>';
 	}
 }
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -208,12 +208,6 @@ function twenty_twenty_one_continue_reading_text() {
 function twenty_twenty_one_continue_reading_link_excerpt() {
 
 	if ( ! is_admin() ) {
-		$continue_reading = sprintf(
-			/* translators: %s: Name of current post. */
-			wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
-			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
-		);
-
 		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a>';
 	}
 }
@@ -227,12 +221,6 @@ add_filter( 'excerpt_more', 'twenty_twenty_one_continue_reading_link_excerpt' );
 function twenty_twenty_one_continue_reading_link() {
 
 	if ( ! is_admin() ) {
-		$continue_reading = sprintf(
-			/* translators: %s: Name of current post. */
-			wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
-			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
-		);
-
 		return '<div class="more-link-container"><a class="more-link" href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></div>';
 	}
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -190,7 +190,7 @@ function twenty_twenty_one_get_avatar_size() {
 }
 
 /**
- * Create the continue reading link.
+ * Create the continue reading link for excerpt.
  */
 function twenty_twenty_one_continue_reading_link_excerpt() {
 
@@ -208,6 +208,9 @@ function twenty_twenty_one_continue_reading_link_excerpt() {
 // Filter the excerpt more link.
 add_filter( 'excerpt_more', 'twenty_twenty_one_continue_reading_link_excerpt' );
 
+/**
+ * Create the continue reading link.
+ */
 function twenty_twenty_one_continue_reading_link() {
 
 	if ( ! is_admin() ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -190,6 +190,19 @@ function twenty_twenty_one_get_avatar_size() {
 }
 
 /**
+ * Creates continue reading text
+ */
+function twenty_twenty_one_continue_reading_text() {
+	$continue_reading = sprintf(
+		/* translators: %s: Name of current post. */
+		wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
+		the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
+	);
+
+	return $continue_reading;
+}
+
+/**
  * Create the continue reading link for excerpt.
  */
 function twenty_twenty_one_continue_reading_link_excerpt() {
@@ -201,7 +214,7 @@ function twenty_twenty_one_continue_reading_link_excerpt() {
 			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
 		);
 
-		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a>';
+		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a>';
 	}
 }
 
@@ -220,7 +233,7 @@ function twenty_twenty_one_continue_reading_link() {
 			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
 		);
 
-		return '<div><a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a></div>';
+		return '<div class="more-link-container"><a class="more-link" href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></div>';
 	}
 }
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -224,10 +224,6 @@ function twenty_twenty_one_continue_reading_link() {
 // Filter the excerpt more link.
 add_filter( 'the_content_more_link', 'twenty_twenty_one_continue_reading_link' );
 
-// Filter the content more link.
-add_filter( 'the_content_more_link', 'twenty_twenty_one_continue_reading_link' );
-
-
 if ( ! function_exists( 'twenty_twenty_one_post_title' ) ) {
 	/**
 	 * Add a title to posts that are missing titles.

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -192,6 +192,22 @@ function twenty_twenty_one_get_avatar_size() {
 /**
  * Create the continue reading link.
  */
+function twenty_twenty_one_continue_reading_link_excerpt() {
+
+	if ( ! is_admin() ) {
+		$continue_reading = sprintf(
+			/* translators: %s: Name of current post. */
+			wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
+			the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
+		);
+
+		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a>';
+	}
+}
+
+// Filter the excerpt more link.
+add_filter( 'excerpt_more', 'twenty_twenty_one_continue_reading_link_excerpt' );
+
 function twenty_twenty_one_continue_reading_link() {
 
 	if ( ! is_admin() ) {
@@ -206,7 +222,7 @@ function twenty_twenty_one_continue_reading_link() {
 }
 
 // Filter the excerpt more link.
-add_filter( 'excerpt_more', 'twenty_twenty_one_continue_reading_link' );
+add_filter( 'the_content_more_link', 'twenty_twenty_one_continue_reading_link' );
 
 // Filter the content more link.
 add_filter( 'the_content_more_link', 'twenty_twenty_one_continue_reading_link' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -196,7 +196,7 @@ function twenty_twenty_one_continue_reading_text() {
 	$continue_reading = sprintf(
 		/* translators: %s: Name of current post. */
 		wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
-		the_title( '<span class="screen-reader-text">' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
+		the_title( '<span class="screen-reader-text">&nbsp;' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
 	);
 
 	return $continue_reading;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/206

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Places the read more link in the same alignment as the content

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a read more to a post
1. Check if it aligns with the content

<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
