### PR TITLE
Clean up the block patterns & block styles files

### DIFF
--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -37,7 +37,7 @@ if ( function_exists( 'register_block_pattern' ) ) {
 		)
 	);
 
-	// Links Area
+	// Links Area.
 	register_block_pattern(
 		'twentytwentyone/links-area',
 		array(

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -26,28 +26,18 @@ if ( function_exists( 'register_block_pattern_category' ) ) {
  */
 if ( function_exists( 'register_block_pattern' ) ) {
 
+	// Large Text.
 	register_block_pattern(
-		'twentytwentyone/two-images-showcase',
+		'twentytwentyone/large-text',
 		array(
-			'title'         => esc_html__( 'Two Images Showcase', 'twentytwentyone' ),
+			'title'         => esc_html__( 'Large Text', 'twentytwentyone' ),
 			'categories'    => array( 'twentytwentyone' ),
 			'viewportWidth' => 1440,
-			'description'   => _x( 'A Media & Text block with a big image on the left and a smaller one with bordered frame on the right.', 'Block pattern description', 'twentytwentyone' ),
-			'content'       => '<!-- wp:media-text {"mediaId":1747,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/la_mousme.jpg","mediaType":"image"} --><div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/la_mousme.jpg" alt="' . esc_attr__( '&quot;La Mousmé&quot; by Vincent Van Gogh (1888)', 'twentytwentyone' ) . '" size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:image {"align":"center","width":400,"height":512,"sizeSlug":"large","className":"is-style-twentytwentyone-image-frame"} --><figure class="wp-block-image aligncenter size-large is-resized is-style-twentytwentyone-image-frame"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/the_berceuse_woman-rocking_a_cradle.jpg" alt="' . esc_attr__( '&quot;The Berceuse, Woman Rocking a Cradle&quot; by Vincent Van Gogh (1889)', 'twentytwentyone' ) . '" width="400" height="512"/></figure><!-- /wp:image --></div></div><!-- /wp:media-text -->',
+			'content'       => '<!-- wp:columns {"align":"wide"} --><div class="wp-block-columns alignwide"><!-- wp:column {"width":98} --><div class="wp-block-column" style="flex-basis:98%"><!-- wp:paragraph {"fontSize":"gigantic","style":{"typography":{"lineHeight":"1.1"}}} --><p class="has-gigantic-font-size" style="line-height:1.1">' . esc_html__( 'A new portfolio default theme for WordPress', 'twentytwentyone' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column {"width":2} --><div class="wp-block-column" style="flex-basis:2%"></div><!-- /wp:column --></div><!-- /wp:columns --><!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
 		)
 	);
 
-	register_block_pattern(
-		'twentytwentyone/media-text-article-title',
-		array(
-			'title'         => esc_html__( 'Media & Text Article Title', 'twentytwentyone' ),
-			'categories'    => array( 'twentytwentyone' ),
-			'viewportWidth' => 1440,
-			'description'   => _x( 'A Media & Text block with a big image on the left and a heading on the right. The heading is followed by a separator and a description paragraph.', 'Block pattern description', 'twentytwentyone' ),
-			'content'       => '<!-- wp:media-text {"mediaId":1752,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/the_poplars_at_saint_remy.jpg","mediaType":"image","className":"is-style-twentytwentyone-border"} --><div class="wp-block-media-text alignwide is-stacked-on-mobile is-style-twentytwentyone-border"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/the_poplars_at_saint_remy.jpg" alt="' . esc_attr__( '&quot;The Poplars at Saint-Rémy&quot; by Vincent Van Gogh (1889)', 'twentytwentyone' ) . '" class="wp-image-1752"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"align":"center"} --><h2 class="has-text-align-center">' . wp_kses_post( __( 'The Poplars at<br>Saint-Rémy', 'twentytwentyone' ) ) . '</h2><!-- /wp:heading --><!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator --><!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size">' . wp_kses_post( __( 'Vincent van Gogh<br>(Dutch, 1853-1890)', 'twentytwentyone' ) ) . '</p><!-- /wp:paragraph --></div></div><!-- /wp:media-text -->',
-		)
-	);
-
+	// Links Area
 	register_block_pattern(
 		'twentytwentyone/links-area',
 		array(
@@ -59,13 +49,27 @@ if ( function_exists( 'register_block_pattern' ) ) {
 		)
 	);
 
+	// Media & Text Article Title.
 	register_block_pattern(
-		'twentytwentyone/large-text',
+		'twentytwentyone/media-text-article-title',
 		array(
-			'title'         => esc_html__( 'Large Text', 'twentytwentyone' ),
+			'title'         => esc_html__( 'Media & Text Article Title', 'twentytwentyone' ),
 			'categories'    => array( 'twentytwentyone' ),
 			'viewportWidth' => 1440,
-			'content'       => '<!-- wp:columns {"align":"wide"} --><div class="wp-block-columns alignwide"><!-- wp:column {"width":98} --><div class="wp-block-column" style="flex-basis:98%"><!-- wp:paragraph {"fontSize":"gigantic","style":{"typography":{"lineHeight":"1.1"}}} --><p class="has-gigantic-font-size" style="line-height:1.1">' . esc_html__( 'A new portfolio default theme for WordPress', 'twentytwentyone' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column {"width":2} --><div class="wp-block-column" style="flex-basis:2%"></div><!-- /wp:column --></div><!-- /wp:columns --><!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
+			'description'   => _x( 'A Media & Text block with a big image on the left and a heading on the right. The heading is followed by a separator and a description paragraph.', 'Block pattern description', 'twentytwentyone' ),
+			'content'       => '<!-- wp:media-text {"mediaId":1752,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/the_poplars_at_saint_remy.jpg","mediaType":"image","className":"is-style-twentytwentyone-border"} --><div class="wp-block-media-text alignwide is-stacked-on-mobile is-style-twentytwentyone-border"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/the_poplars_at_saint_remy.jpg" alt="' . esc_attr__( '&quot;The Poplars at Saint-Rémy&quot; by Vincent Van Gogh (1889)', 'twentytwentyone' ) . '" class="wp-image-1752"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"align":"center"} --><h2 class="has-text-align-center">' . wp_kses_post( __( 'The Poplars at<br>Saint-Rémy', 'twentytwentyone' ) ) . '</h2><!-- /wp:heading --><!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator --><!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size">' . wp_kses_post( __( 'Vincent van Gogh<br>(Dutch, 1853-1890)', 'twentytwentyone' ) ) . '</p><!-- /wp:paragraph --></div></div><!-- /wp:media-text -->',
+		)
+	);
+
+	// Two Images Showcase.
+	register_block_pattern(
+		'twentytwentyone/two-images-showcase',
+		array(
+			'title'         => esc_html__( 'Two Images Showcase', 'twentytwentyone' ),
+			'categories'    => array( 'twentytwentyone' ),
+			'viewportWidth' => 1440,
+			'description'   => _x( 'A Media & Text block with a big image on the left and a smaller one with bordered frame on the right.', 'Block pattern description', 'twentytwentyone' ),
+			'content'       => '<!-- wp:media-text {"mediaId":1747,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/la_mousme.jpg","mediaType":"image"} --><div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/la_mousme.jpg" alt="' . esc_attr__( '&quot;La Mousmé&quot; by Vincent Van Gogh (1888)', 'twentytwentyone' ) . '" size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:image {"align":"center","width":400,"height":512,"sizeSlug":"large","className":"is-style-twentytwentyone-image-frame"} --><figure class="wp-block-image aligncenter size-large is-resized is-style-twentytwentyone-image-frame"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/the_berceuse_woman-rocking_a_cradle.jpg" alt="' . esc_attr__( '&quot;The Berceuse, Woman Rocking a Cradle&quot; by Vincent Van Gogh (1889)', 'twentytwentyone' ) . '" width="400" height="512"/></figure><!-- /wp:image --></div></div><!-- /wp:media-text -->',
 		)
 	);
 }

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -18,43 +18,39 @@ if ( function_exists( 'register_block_style' ) ) {
 	 * @return void
 	 */
 	function twenty_twenty_one_register_block_styles() {
-		register_block_style(
-			'core/image',
-			array(
-				'name'  => 'twentytwentyone-image-frame',
-				'label' => esc_html__( 'Bordered Frame', 'twentytwentyone' ),
-			)
-		);
-
-		register_block_style(
-			'core/image',
-			array(
-				'name'  => 'twentytwentyone-border',
-				'label' => esc_html__( 'Bordered', 'twentytwentyone' ),
-			)
-		);
-
+		// Cover: Borders.
 		register_block_style(
 			'core/cover',
 			array(
 				'name'  => 'twentytwentyone-border',
-				'label' => esc_html__( 'Bordered', 'twentytwentyone' ),
+				'label' => esc_html__( 'Borders', 'twentytwentyone' ),
 			)
 		);
 
+		// Group: Borders.
 		register_block_style(
 			'core/group',
 			array(
 				'name'  => 'twentytwentyone-border',
-				'label' => esc_html__( 'Bordered', 'twentytwentyone' ),
+				'label' => esc_html__( 'Borders', 'twentytwentyone' ),
 			)
 		);
 
+		// Image: Borders.
 		register_block_style(
-			'core/media-text',
+			'core/image',
 			array(
 				'name'  => 'twentytwentyone-border',
-				'label' => esc_html__( 'Bordered', 'twentytwentyone' ),
+				'label' => esc_html__( 'Borders', 'twentytwentyone' ),
+			)
+		);
+
+		// Image: Frame.
+		register_block_style(
+			'core/image',
+			array(
+				'name'  => 'twentytwentyone-image-frame',
+				'label' => esc_html__( 'Frame', 'twentytwentyone' ),
 			)
 		);
 
@@ -72,6 +68,15 @@ if ( function_exists( 'register_block_style' ) ) {
 			'core/latest-posts',
 			array(
 				'name'  => 'twentytwentyone-latest-posts-borders',
+				'label' => esc_html__( 'Borders', 'twentytwentyone' ),
+			)
+		);
+
+		// Media & Text: Borders.
+		register_block_style(
+			'core/media-text',
+			array(
+				'name'  => 'twentytwentyone-border',
 				'label' => esc_html__( 'Borders', 'twentytwentyone' ),
 			)
 		);


### PR DESCRIPTION
Minor code quality update to `block-patterns.php` and `block-styles.php`. As these are becoming more populated, this should help us stay organized: 

- Ensures each one is prefaced by a code comment with its title.
- Standardizes names a little more ("Borders" and "Dividers" instead of "Bordered" and "Dividers").
- Rearranges the file so these are defined in alphabetical order.

_(The diff makes this near-impossible to read, so it's probably easiest to just look at the updated files and verify the changes above. Aside from the standardized names, no other actual functions have been modified.)_