### PR TITLE
Rename display_excerpt_or_fullpost option

### DIFF
--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			);
 
 			$wp_customize->add_setting(
-				'display_excerpt_or_fullpost',
+				'display_excerpt_or_full_post',
 				array(
 					'capability'        => 'edit_theme_options',
 					'default'           => 'excerpt',
@@ -104,7 +104,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			);
 
 			$wp_customize->add_control(
-				'display_excerpt_or_fullpost',
+				'display_excerpt_or_full_post',
 				array(
 					'type'    => 'radio',
 					'section' => 'theme_settings',

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ if ( have_posts() ) {
 	while ( have_posts() ) {
 		the_post();
 
-		if ( 'excerpt' === get_theme_mod( 'display_excerpt_or_fullpost', 'excerpt' ) ) {
+		if ( 'excerpt' === get_theme_mod( 'display_excerpt_or_full_post', 'excerpt' ) ) {
 			get_template_part( 'template-parts/content/content-excerpt' );
 		} else {
 			get_template_part( 'template-parts/content/content' );


### PR DESCRIPTION
See https://github.com/WordPress/twentytwentyone/pull/354#pullrequestreview-505345960

## Summary
Rename option from `display_excerpt_or_fullpost` to `display_excerpt_or_full_post`.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
