### PR TITLE
Set the text-decoration-thickness to 1px

### DIFF
--- a/assets/sass/03-generic/normalize.scss
+++ b/assets/sass/03-generic/normalize.scss
@@ -75,6 +75,7 @@ pre {
 
 a {
 	background-color: transparent;
+	text-decoration-thickness: 1px;
 }
 
 /**


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #377 

## Summary
Set the text-decoration-thickness to 1px for browsers that support it.

## Test instructions

This PR can be tested by following these steps:
1. 
1. 
1. 
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
