### PR TITLE
Aligns the arrow icons. Fixes #308

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5717,6 +5717,15 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+}
+
+.navigation .nav-previous .svg-icon {
+	top: -3px;
+}
+
+.navigation .nav-next .svg-icon {
+	top: -1px;
 }
 
 .post-navigation {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5720,11 +5720,13 @@ h1.page-title {
 	position: relative;
 }
 
-.navigation .nav-previous .svg-icon {
+.navigation .nav-previous .svg-icon,
+.navigation .prev .svg-icon {
 	top: -3px;
 }
 
-.navigation .nav-next .svg-icon {
+.navigation .nav-next .svg-icon,
+.navigation .next .svg-icon {
 	top: -1px;
 }
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -46,6 +46,15 @@
 		display: inline-block;
 		fill: currentColor;
 		vertical-align: middle;
+		position: relative;
+	}
+
+	.nav-previous .svg-icon {
+		top: -3px;
+	}
+
+	.nav-next .svg-icon {
+		top: -1px;
 	}
 }
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -49,11 +49,13 @@
 		position: relative;
 	}
 
-	.nav-previous .svg-icon {
+	.nav-previous .svg-icon,
+	.prev .svg-icon {
 		top: -3px;
 	}
 
-	.nav-next .svg-icon {
+	.nav-next .svg-icon,
+	.next .svg-icon {
 		top: -1px;
 	}
 }

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -51,7 +51,7 @@
 
 	.nav-previous .svg-icon,
 	.prev .svg-icon {
-		top: -3px;
+		top: -2px;
 	}
 
 	.nav-next .svg-icon,

--- a/classes/class-twenty-twenty-one-svg-icons.php
+++ b/classes/class-twenty-twenty-one-svg-icons.php
@@ -31,7 +31,7 @@ class Twenty_Twenty_One_SVG_Icons {
 	 * @var array
 	 */
 	protected static $icons = array(
-		'arrow_right' => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 11V9h12l-4-4 1-2 7 7-7 7-1-2 4-4H2z" fill="currentColor"/></svg>',
+		'arrow_right' => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m4 13v-2h12l-4-4 1-2 7 7-7 7-1-2 4-4z" fill="currentColor"/></svg>',
 		'arrow_left'  => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 13v-2H8l4-4-1-2-7 7 7 7 1-2-4-4z" fill="currentColor"/></svg>',
 		'close'       => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 10.9394L5.53033 4.46973L4.46967 5.53039L10.9393 12.0001L4.46967 18.4697L5.53033 19.5304L12 13.0607L18.4697 19.5304L19.5303 18.4697L13.0607 12.0001L19.5303 5.53039L18.4697 4.46973L12 10.9394Z" fill="currentColor"/></svg>',
 		'menu'        => '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 6H19.5V7.5H4.5V6ZM4.5 12H19.5V13.5H4.5V12ZM19.5 18H4.5V19.5H19.5V18Z" fill="currentColor"/></svg>',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4226,6 +4226,15 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+}
+
+.navigation .nav-previous .svg-icon {
+	top: -3px;
+}
+
+.navigation .nav-next .svg-icon {
+	top: -1px;
 }
 
 .post-navigation {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4229,11 +4229,13 @@ h1.page-title {
 	position: relative;
 }
 
-.navigation .nav-previous .svg-icon {
+.navigation .nav-previous .svg-icon,
+.navigation .prev .svg-icon {
 	top: -3px;
 }
 
-.navigation .nav-next .svg-icon {
+.navigation .nav-next .svg-icon,
+.navigation .next .svg-icon {
 	top: -1px;
 }
 

--- a/style.css
+++ b/style.css
@@ -4238,11 +4238,13 @@ h1.page-title {
 	position: relative;
 }
 
-.navigation .nav-previous .svg-icon {
+.navigation .nav-previous .svg-icon,
+.navigation .prev .svg-icon {
 	top: -3px;
 }
 
-.navigation .nav-next .svg-icon {
+.navigation .nav-next .svg-icon,
+.navigation .next .svg-icon {
 	top: -1px;
 }
 

--- a/style.css
+++ b/style.css
@@ -4235,6 +4235,15 @@ h1.page-title {
 	display: inline-block;
 	fill: currentColor;
 	vertical-align: middle;
+	position: relative;
+}
+
+.navigation .nav-previous .svg-icon {
+	top: -3px;
+}
+
+.navigation .nav-next .svg-icon {
+	top: -1px;
 }
 
 .post-navigation {


### PR DESCRIPTION
Fixes #308

## Summary
I pulled from the main repo to get all the latest changes and the `arrow-right` SVG icon was vertically misaligned again, so I fixed that. Then I did the CSS vertical alignment proposed by @melchoyce [here](https://github.com/WordPress/twentytwentyone/pull/339#issuecomment-705713376).

## Relevant technical choices:
I don't believe the technical choices affect anything outside of the scope of this issue.

## Test instructions

This PR can be tested by following these steps:
1. Apply the changes of the PR to an active Twenty Twenty One theme
2. Go to the homepage
3. Check for the arrows on the navigation before the footer (Older posts, Newer posts)
4. Go to a post or page
5. Check for the arrows on the navigation before the footer (Previous Post, Next Post)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
