### PR TITLE
Add customizer option for footer-copyright

### DIFF
--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -116,6 +116,35 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				)
 			);
 
+			$wp_customize->add_setting(
+				'footer_text',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => '<a href="' . esc_url( __( 'https://wordpress.org/', 'twentytwentyone' ) ) . '" class="imprint">' . esc_html__( 'Proudly powered by WordPress.', 'twentytwentyone' ) . '</a>',
+					'sanitize_callback' => 'wp_kses_post',
+					'transport'         => 'postMessage',
+				)
+			);
+
+			$wp_customize->add_control(
+				'footer_text',
+				array(
+					'type'    => 'textarea',
+					'section' => 'theme_settings',
+					'label'   => esc_html__( 'Footer text and copyright:', 'twentytwentyone' ),
+				)
+			);
+
+			// Add partial for footer_text.
+			$wp_customize->selective_refresh->add_partial(
+				'footer_text',
+				array(
+					'selector'            => '#footer-copyright',
+					'render_callback'     => 'twenty_twenty_one_the_footer_copyright',
+					'container_inclusive' => true,
+				)
+			);
+
 			// Background color.
 			// Include the custom control class.
 			include_once get_theme_file_path( 'classes/class-twenty-twenty-one-customize-color-control.php' ); // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/footer.php
+++ b/footer.php
@@ -34,21 +34,7 @@
 					<?php endif; ?>
 				<?php endif; ?>
 			</div><!-- .site-name -->
-			<div class="copyright">
-				<?php
-				/* translators: 1: Copyright date format, see https://www.php.net/manual/datetime.format.php, 2: Site name */
-				printf(
-					/* Translators: %1$s: Copyright date. %2$s: Site name. */
-					esc_html__( '&copy; %1$s %2$s', 'twentytwentyone' ),
-					esc_html( date_i18n( _x( 'Y', 'copyright date format', 'twentytwentyone' ) ) ),
-					esc_html( get_bloginfo( 'name' ) . '.' )
-				);
-				?>
-				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwentyone' ) ); ?>"  class="imprint">
-				<?php /* translators: %s: WordPress. */ printf( esc_html__( 'Proudly powered by %s.', 'twentytwentyone' ), 'WordPress' ); ?>
-				</a>
-			</div><!-- .copyright -->
-
+			<?php twenty_twenty_one_the_footer_copyright(); ?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -387,3 +387,20 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 		false
 	);
 }
+
+/**
+ * Print the footer copyright.
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function twenty_twenty_one_the_footer_copyright() {
+	echo '<div id="footer-copyright" class="copyright">';
+	$footer_text = get_theme_mod(
+		'footer_text',
+		'<a href="' . esc_url( __( 'https://wordpress.org/', 'twentytwentyone' ) ) . '" class="imprint">' . esc_html__( 'Proudly powered by WordPress.', 'twentytwentyone' ) . '</a>'
+	);
+	echo wp_kses_post( $footer_text );
+	echo '</div>';
+}


### PR DESCRIPTION
Fixes #401 

## Summary
Adds a new customizer option for the footer-copyright text and removes the copyright disclaimer & date.

## Relevant technical choices:
I opted for a new function to get the footer-copyright content. This way we can use that function both to render the content, and as a callback for the partial-refresh in the customizer setting.

## Test instructions

This PR can be tested by following these steps:
1. Go to the customizer > Theme Settings
2. Change the footer copyright text
3. Save and confirm everything works both in the customizer and on the frontent.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
