### PR TITLE
Update large text block pattern to use a wide-width header

### DIFF
--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -33,7 +33,7 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'         => esc_html__( 'Large Text', 'twentytwentyone' ),
 			'categories'    => array( 'twentytwentyone' ),
 			'viewportWidth' => 1440,
-			'content'       => '<!-- wp:columns {"align":"wide"} --><div class="wp-block-columns alignwide"><!-- wp:column {"width":98} --><div class="wp-block-column" style="flex-basis:98%"><!-- wp:paragraph {"fontSize":"gigantic","style":{"typography":{"lineHeight":"1.1"}}} --><p class="has-gigantic-font-size" style="line-height:1.1">' . esc_html__( 'A new portfolio default theme for WordPress', 'twentytwentyone' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column {"width":2} --><div class="wp-block-column" style="flex-basis:2%"></div><!-- /wp:column --></div><!-- /wp:columns --><!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
+			'content'       => '<!-- wp:heading {"align":"wide","fontSize":"gigantic","style":{"typography":{"lineHeight":"1.1"}}} --><h2 class="alignwide has-text-align-wide has-gigantic-font-size" style="line-height:1.1">' . esc_html__( 'A new portfolio default theme for WordPress', 'twentytwentyone' ) . '</h2><!-- /wp:heading -->',
 		)
 	);
 


### PR DESCRIPTION
This removes the columns block hack that was in place previously. It's made possible with the addition of the wide/full alignment for headers, as added in https://github.com/WordPress/gutenberg/pull/25917, shipping in Gutenberg 9.2. 

I tested this with the plugin inactive as well, and it (surprisingly?) did not throw any error in the editor. 

![Screen Shot 2020-10-12 at 12 16 01 PM](https://user-images.githubusercontent.com/1202812/95768957-1d7f5580-0c85-11eb-8434-416c6ada14af.png)
