### PR TITLE
Fix "Edit [Post Name]" links in NVDA

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -119,9 +119,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			$categories_list = get_the_category_list( __( ', ', 'twentytwentyone' ) );
 			if ( $categories_list ) {
 				printf(
-					/* translators: 1: posted in label, 2: list of categories. */
-					'<span class="cat-links">%1$s %2$s</span>',
-					esc_html__( 'Categorized as', 'twentytwentyone' ),
+					/* translators: %s: list of tags. */
+					'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'twentytwentyone' ) . '</span>',
 					$categories_list // phpcs:ignore WordPress.Security.EscapeOutput
 				);
 			}
@@ -130,9 +129,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			$tags_list = get_the_tag_list( '', __( ', ', 'twentytwentyone' ) );
 			if ( $tags_list ) {
 				printf(
-					/* translators: %1$s: posted in label, %2$s: list of tags. */
-					'<span class="tags-links">%1$s %2$s</span>',
-					esc_html__( 'Tagged', 'twentytwentyone' ),
+					/* translators: %s: list of tags. */
+					'<span class="tags-links">' . esc_html__( 'Tagged %s', 'twentytwentyone' ) . '</span>',
 					$tags_list // phpcs:ignore WordPress.Security.EscapeOutput
 				);
 			}
@@ -144,9 +142,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			$categories_list = get_the_category_list( __( ', ', 'twentytwentyone' ) );
 			if ( $categories_list ) {
 				printf(
-					/* translators: 1: posted in label, 2: list of categories. */
-					'<span class="cat-links">%1$s %2$s</span>',
-					esc_html__( 'Categorized as', 'twentytwentyone' ),
+					/* translators: %s: list of tags. */
+					'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'twentytwentyone' ) . '</span>',
 					$categories_list // phpcs:ignore WordPress.Security.EscapeOutput
 				);
 			}
@@ -173,9 +170,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			$tags_list = get_the_tag_list( '', __( ', ', 'twentytwentyone' ) );
 			if ( $tags_list ) {
 				printf(
-					/* translators: 1: posted in label, 2: list of tags. */
-					'<span class="tags-links">%1$s %2$s</span>',
-					esc_html__( 'Tagged', 'twentytwentyone' ),
+					/* translators: %s: list of tags. */
+					'<span class="tags-links">' . esc_html__( 'Tagged %s', 'twentytwentyone' ) . '</span>',
 					$tags_list // phpcs:ignore WordPress.Security.EscapeOutput
 				);
 			}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -102,14 +102,14 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					wp_kses(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
-						__( 'Edit<span class="screen-reader-text"> %s</span>', 'twentytwentyone' ),
+						__( 'Edit %s', 'twentytwentyone' ),
 						array(
 							'span' => array(
 								'class' => array(),
 							),
 						)
 					),
-					get_the_title()
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span><br>'
@@ -156,14 +156,14 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					wp_kses(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
-						__( 'Edit<span class="screen-reader-text"> %s</span>', 'twentytwentyone' ),
+						__( 'Edit %s', 'twentytwentyone' ),
 						array(
 							'span' => array(
 								'class' => array(),
 							),
 						)
 					),
-					get_the_title()
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'


### PR DESCRIPTION
Fixes #386

## Summary
When using Windows + Firefox + NVDA, the "Edit" link merged edit with the post name, so it was read as "EditPost Name". If the post title starts with a capital letter, this is not an issue (NVDA reads it separately), but you can use the Speech Viewer to see the lack of space, or test with a lowercase post title ("any post title"), and it'll read "Editany post title".

(This also fixes the strings for categories & tags since I was in the neighborhood)

## Relevant technical choices:
It seems that the initial string is stripped out of the span, so I've moved it out to the edit link. This doesn't create any extra visible space in my testing.

## Test instructions

This PR can be tested by following these steps:
1. Create a post with a lowercase title
2. Load it on the frontend
3. Read through it using NVDA, when you hit the edit link, the title should be announced correctly.

Note: This is not an issue in VoiceOver.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
