### PR TITLE
Update "read more" text to "Continue reading"

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -195,8 +195,8 @@ function twenty_twenty_one_get_avatar_size() {
 function twenty_twenty_one_continue_reading_text() {
 	$continue_reading = sprintf(
 		/* translators: %s: Name of current post. */
-		wp_kses( esc_html__( 'Read more %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
-		the_title( '<span class="screen-reader-text">&nbsp;' . esc_html__( 'about ', 'twentytwentyone' ), '</span>', false )
+		wp_kses( esc_html__( 'Continue reading %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
+		the_title( '<span class="screen-reader-text">', '</span>', false )
 	);
 
 	return $continue_reading;

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -22,15 +22,7 @@
 		<?php
 		the_content(
 			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentytwentyone' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
+				twenty_twenty_one_continue_reading_text(),
 				get_the_title()
 			)
 		);

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -26,15 +26,7 @@
 		<?php
 		the_content(
 			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentytwentyone' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
+				twenty_twenty_one_continue_reading_text(),
 				get_the_title()
 			)
 		);


### PR DESCRIPTION
Fixes #332

## Summary

The "Read more about Post Name" string is hard to translate correctly, so we're switching to "Continue reading Post Name".

## Test instructions

This PR can be tested by following these steps:
1. Set your site to use full posts in Customizer > Theme settings
2. Make a post with a "read more" break
3. View the post list, it should have a "Continue reading" link
    ![Screen Shot 2020-10-12 at 1 37 58 PM](https://user-images.githubusercontent.com/541093/95775308-2b86a380-0c90-11eb-85e4-0014cb792d99.png)
4. Switch your posts list to "excerpt"
5. If your content is long enough, your post should get cut off with the Continue reading link
    ![Screen Shot 2020-10-12 at 1 38 04 PM](https://user-images.githubusercontent.com/541093/95775467-7ef8f180-0c90-11eb-97c9-de6e99a03ed7.png)
6. Testing with a screen reader announces the titles correctly, without smushing "ReadingPost Name" (see #386 for example)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
