### PR TITLE
Post Formats: Fix embeds in audio & video formats

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -396,7 +396,8 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  *
  * @since 1.0.0
  *
- * @param string      $block_name The block name/type. Example: `core/image`.
+ * @param string      $block_name The full block type name, or a partial match.
+ *                                Example: `core/image`, `core-embed/*`.
  * @param string|null $content    The content we need to search in. Use null for get_the_content().
  * @param int         $instances  How many instances of the block we want to print. Defaults to 1.
  *
@@ -422,7 +423,16 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 		}
 
 		// Check if this the block we're looking for.
-		if ( $block_name === $block['blockName'] ) {
+		$is_matching_block = false;
+
+		// If the block ends with *, we should just try to match the first portion.
+		if ( '*' === $block_name[-1] ) {
+			$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
+		} else {
+			$is_matching_block = $block_name === $block['blockName'];
+		}
+
+		if ( $is_matching_block ) {
 			// Increment count.
 			$instances_count++;
 

--- a/template-parts/excerpt/excerpt-aside.php
+++ b/template-parts/excerpt/excerpt-aside.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Aside post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-audio.php
+++ b/template-parts/excerpt/excerpt-audio.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Audio post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-audio.php
+++ b/template-parts/excerpt/excerpt-audio.php
@@ -9,17 +9,13 @@
  * @since 1.0.0
  */
 
-// Print the 1st instance of an audio block.
-// If there was no audioblock, print the 1st audio-embed block.
-if (
-	! twenty_twenty_one_print_first_instance_of_block( 'core/embed', get_the_content() ) &&
-	! twenty_twenty_one_print_first_instance_of_block( 'core/audio', get_the_content() )
-) {
+$content = get_the_content();
 
-	// Fallback to the content.
-	the_content();
+if ( has_block( 'core/audio', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/audio', $content );
 } else {
-
-	// Add the excerpt.
-	the_excerpt();
+	twenty_twenty_one_print_first_instance_of_block( 'core-embed/*', $content );
 }
+
+// Add the excerpt.
+the_excerpt();

--- a/template-parts/excerpt/excerpt-audio.php
+++ b/template-parts/excerpt/excerpt-audio.php
@@ -13,6 +13,8 @@ $content = get_the_content();
 
 if ( has_block( 'core/audio', $content ) ) {
 	twenty_twenty_one_print_first_instance_of_block( 'core/audio', $content );
+} elseif ( has_block( 'core/embed', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/embed', $content );
 } else {
 	twenty_twenty_one_print_first_instance_of_block( 'core-embed/*', $content );
 }

--- a/template-parts/excerpt/excerpt-chat.php
+++ b/template-parts/excerpt/excerpt-chat.php
@@ -9,7 +9,6 @@
  * @since 1.0.0
  */
 
-// Print the 1st 2 paragraphs, or fallback to the excerpt.
-if ( ! twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content(), 2 ) ) {
-	the_excerpt();
-}
+twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content(), 2 );
+
+the_excerpt();

--- a/template-parts/excerpt/excerpt-chat.php
+++ b/template-parts/excerpt/excerpt-chat.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Chat post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-chat.php
+++ b/template-parts/excerpt/excerpt-chat.php
@@ -9,6 +9,12 @@
  * @since 1.0.0
  */
 
-twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content(), 2 );
+// If there are paragraph blocks, print up to two.
+// Otherwise this is legacy content, and we can post the excerpt.
+if ( has_block( 'core/paragraph', get_the_content() ) ) {
 
-the_excerpt();
+	twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content(), 2 );
+} else {
+
+	the_excerpt();
+}

--- a/template-parts/excerpt/excerpt-gallery.php
+++ b/template-parts/excerpt/excerpt-gallery.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Gallery post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-gallery.php
+++ b/template-parts/excerpt/excerpt-gallery.php
@@ -10,7 +10,9 @@
  */
 
 // Print the 1st gallery we can find.
-if ( twenty_twenty_one_print_first_instance_of_block( 'core/gallery', get_the_content() ) ) {
+if ( has_block( 'core/gallery', get_the_content() ) ) {
+
+	twenty_twenty_one_print_first_instance_of_block( 'core/gallery', get_the_content() );
 
 	// Add the excerpt.
 	the_excerpt();

--- a/template-parts/excerpt/excerpt-gallery.php
+++ b/template-parts/excerpt/excerpt-gallery.php
@@ -13,11 +13,6 @@
 if ( has_block( 'core/gallery', get_the_content() ) ) {
 
 	twenty_twenty_one_print_first_instance_of_block( 'core/gallery', get_the_content() );
-
-	// Add the excerpt.
-	the_excerpt();
-} else {
-
-	// Fallback to the content.
-	the_content();
 }
+
+the_excerpt();

--- a/template-parts/excerpt/excerpt-image.php
+++ b/template-parts/excerpt/excerpt-image.php
@@ -12,12 +12,14 @@
 // If there is no featured-image print the first image block we can find.
 if (
 	! twenty_twenty_one_can_show_post_thumbnail() &&
-	! twenty_twenty_one_print_first_instance_of_block( 'core/image', get_the_content() )
+	! has_block( 'core/image', get_the_content() )
 ) {
 
 	// Fallback to the content.
 	the_content();
 } else {
+
+	twenty_twenty_one_print_first_instance_of_block( 'core/image', get_the_content() );
 
 	// Add the excerpt.
 	the_excerpt();

--- a/template-parts/excerpt/excerpt-image.php
+++ b/template-parts/excerpt/excerpt-image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Image post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-image.php
+++ b/template-parts/excerpt/excerpt-image.php
@@ -9,18 +9,13 @@
  * @since 1.0.0
  */
 
-// If there is no featured-image print the first image block we can find.
+// If there is no featured-image, print the first image block we can find.
 if (
 	! twenty_twenty_one_can_show_post_thumbnail() &&
-	! has_block( 'core/image', get_the_content() )
+	has_block( 'core/image', get_the_content() )
 ) {
 
-	// Fallback to the content.
-	the_content();
-} else {
-
 	twenty_twenty_one_print_first_instance_of_block( 'core/image', get_the_content() );
-
-	// Add the excerpt.
-	the_excerpt();
 }
+
+the_excerpt();

--- a/template-parts/excerpt/excerpt-link.php
+++ b/template-parts/excerpt/excerpt-link.php
@@ -10,6 +10,8 @@
  */
 
 // Print the 1st instance of a paragraph block. If none is found, print the content.
-if ( ! twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content() ) ) {
+if ( ! has_block( 'core/paragraph', get_the_content() ) ) {
 	the_content();
+} else {
+	twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content() );
 }

--- a/template-parts/excerpt/excerpt-link.php
+++ b/template-parts/excerpt/excerpt-link.php
@@ -10,8 +10,10 @@
  */
 
 // Print the 1st instance of a paragraph block. If none is found, print the content.
-if ( ! has_block( 'core/paragraph', get_the_content() ) ) {
-	the_content();
-} else {
+if ( has_block( 'core/paragraph', get_the_content() ) ) {
+
 	twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content() );
+} else {
+
+	the_content();
 }

--- a/template-parts/excerpt/excerpt-link.php
+++ b/template-parts/excerpt/excerpt-link.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Link post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-quote.php
+++ b/template-parts/excerpt/excerpt-quote.php
@@ -9,10 +9,13 @@
  * @since 1.0.0
  */
 
-// If there is no quote or pullquote print the excerpt.
-if (
-	! twenty_twenty_one_print_first_instance_of_block( 'core/quote', get_the_content() ) &&
-	! twenty_twenty_one_print_first_instance_of_block( 'core/pullquote', get_the_content() )
-) {
+$content = get_the_content();
+
+// If there is no quote or pullquote print the content.
+if ( has_block( 'core/quote', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/quote', $content );
+} else if ( has_block( 'core/pullquote', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/pullquote', $content );
+} else {
 	the_content();
 }

--- a/template-parts/excerpt/excerpt-quote.php
+++ b/template-parts/excerpt/excerpt-quote.php
@@ -17,5 +17,5 @@ if ( has_block( 'core/quote', $content ) ) {
 } elseif ( has_block( 'core/pullquote', $content ) ) {
 	twenty_twenty_one_print_first_instance_of_block( 'core/pullquote', $content );
 } else {
-	the_content();
+	the_excerpt();
 }

--- a/template-parts/excerpt/excerpt-quote.php
+++ b/template-parts/excerpt/excerpt-quote.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Quote post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-quote.php
+++ b/template-parts/excerpt/excerpt-quote.php
@@ -14,7 +14,7 @@ $content = get_the_content();
 // If there is no quote or pullquote print the content.
 if ( has_block( 'core/quote', $content ) ) {
 	twenty_twenty_one_print_first_instance_of_block( 'core/quote', $content );
-} else if ( has_block( 'core/pullquote', $content ) ) {
+} elseif ( has_block( 'core/pullquote', $content ) ) {
 	twenty_twenty_one_print_first_instance_of_block( 'core/pullquote', $content );
 } else {
 	the_content();

--- a/template-parts/excerpt/excerpt-status.php
+++ b/template-parts/excerpt/excerpt-status.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Status post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *

--- a/template-parts/excerpt/excerpt-video.php
+++ b/template-parts/excerpt/excerpt-video.php
@@ -13,6 +13,8 @@ $content = get_the_content();
 
 if ( has_block( 'core/video', $content ) ) {
 	twenty_twenty_one_print_first_instance_of_block( 'core/video', $content );
+} elseif ( has_block( 'core/embed', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/embed', $content );
 } else {
 	twenty_twenty_one_print_first_instance_of_block( 'core-embed/*', $content );
 }

--- a/template-parts/excerpt/excerpt-video.php
+++ b/template-parts/excerpt/excerpt-video.php
@@ -9,16 +9,13 @@
  * @since 1.0.0
  */
 
-// Print the 1st video we can find.
-if (
-	! twenty_twenty_one_print_first_instance_of_block( 'core/embed', get_the_content() ) &&
-	! twenty_twenty_one_print_first_instance_of_block( 'core/video', get_the_content() )
-) {
+$content = get_the_content();
 
-	// Fallback to the content if no block was found.
-	the_content();
+if ( has_block( 'core/video', $content ) ) {
+	twenty_twenty_one_print_first_instance_of_block( 'core/video', $content );
 } else {
-
-	// Add the excerpt.
-	the_excerpt();
+	twenty_twenty_one_print_first_instance_of_block( 'core-embed/*', $content );
 }
+
+// Add the excerpt.
+the_excerpt();

--- a/template-parts/excerpt/excerpt-video.php
+++ b/template-parts/excerpt/excerpt-video.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Show the excerpt.
+ * Show the appropriate content for the Video post format.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *


### PR DESCRIPTION
See #391 — This iterates on the post formats code a little. First, it fixes an issue with embeds, and then it swaps the `excerpt-*` templates to use `has_block` to check for blocks, rather than having the conditional also be responsible for outputting the content.

Embed block issue: Once created, embed blocks appear to use `core-embed/spotify`, `core-embed/youtube` etc, so the detection of `core/embed` isn't working. This introduces a rough wildcard match. Now we can pass in `core-embed/*` to `twenty_twenty_one_print_first_instance_of_block`, and it'll return the first embed.

The `has_block` change was introduced to avoid confusion when looking at the template code. It's not immediately clear where the block content is printed out, since it's happening in the conditional. This change cleans up the conditionals so they're more understandable.

(Happy to split this PR in two for each change if anyone asks, I was already here so ended up doing both in one 😬 )

## Test instructions

This PR can be tested by following these steps:
1. Create an audio or video post using an embed
2. Add some extra content to the post, maybe add an excerpt
3. View your post in an archive, it should display the embed and the excerpt
4. View the post (singular view), it should show the full post content

---

1. Try creating other post formats
2. They should each display using the logic on #367

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
