### PR TITLE
Remove the theme switch from the upgrade notice

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,6 @@
 // This theme requires WordPress 5.3 or later.
 if ( version_compare( $GLOBALS['wp_version'], '5.3', '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
-	return;
 }
 
 if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -12,17 +12,13 @@
  */
 
 /**
- * Prevent switching to the theme on old versions of WordPress.
- *
- * Switches to the default theme.
+ * Display upgrade notice on theme switch.
  *
  * @since 1.0.0
  *
  * @return void
  */
 function twenty_twenty_one_switch_theme() {
-	switch_theme( WP_DEFAULT_THEME );
-	unset( $_GET['activated'] ); // phpcs:ignore WordPress.Security.NonceVerification
 	add_action( 'admin_notices', 'twenty_twenty_one_upgrade_notice' );
 }
 add_action( 'after_switch_theme', 'twenty_twenty_one_switch_theme' );


### PR DESCRIPTION
Fixes #446 

## Summary
Discussion on https://github.com/WordPress/twentytwentyone/pull/450

## Test instructions

This PR can be tested by following these steps:
* Deactivate the theme if it is already active
* Move the minimum version up, to a version higher than your current, say 5.6.
* Activate the theme
* See notice
* View the front, make sure it's not broken.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
