### PR TITLE
excerpt/full should apply to archives too

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -19,16 +19,8 @@ get_header();
 	</header><!-- .page-header -->
 
 	<?php while ( have_posts() ) : ?>
-		<?php
-		the_post();
-
-		/*
-		 * Include the Post-Format-specific template for the content.
-		 * If you want to override this in a child theme, then include a file
-		 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-		 */
-		get_template_part( 'template-parts/content/content-excerpt', get_post_format() );
-		?>
+		<?php the_post(); ?>
+		<?php get_template_part( 'template-parts/content/content', get_theme_mod( 'display_excerpt_or_full_post', 'excerpt' ) ); ?>
 	<?php endwhile; ?>
 
 	<?php twenty_twenty_one_the_posts_navigation(); ?>

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'type'    => 'radio',
 					'section' => 'theme_settings',
-					'label'   => esc_html__( 'On the Posts page, post show:', 'twentytwentyone' ),
+					'label'   => esc_html__( 'On archive pages, posts show:', 'twentytwentyone' ),
 					'choices' => array(
 						'excerpt' => esc_html__( 'Excerpt', 'twentytwentyone' ),
 						'full'    => esc_html__( 'Full text', 'twentytwentyone' ),


### PR DESCRIPTION
Fixes #454

## Summary
Change the description of the theme-mod to make it clear this applies to all archives, and apply to archive.php.
Previously part of https://github.com/WordPress/twentytwentyone/pull/416, was later removed.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
