### PR TITLE
add margin-top for other formats

### DIFF
--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -43,4 +43,3 @@ h1.page-title {
 	}
 }
 
-

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -17,7 +17,8 @@ h1.page-title {
 }
 
 .archive,
-.search {
+.search,
+.blog {
 
 	.content-area {
 
@@ -29,5 +30,17 @@ h1.page-title {
 				font-size: var(--global--font-size-lg);
 			}
 		}
+
+	}
+
+	.format-image,
+	.format-gallery,
+	.format-video {
+
+		.entry-content {
+			margin-top: calc(2 * var(--global--spacing-vertical));
+		}
 	}
 }
+
+


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #443 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Added `margin-top: calc(2 * var(--global--spacing-vertical));` for the post-formats: Image, Gallery and Video While being entry content.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Create a post with a featured image
1. Create a post with image content and set the post format to image.
1. Go to the front and view the blog or archive.
1. Compare the two posts and see that the spacing DOES match.
1. Do the same for post formats video and gallery.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

</details>

<details>
<summary>Desktop (Large)</summary>

</details>


<details>
<summary>Tablet (Medium)</summary>

</details>


<details>
<summary>Mobile (Small)</summary>

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
