### PR TITLE
Rename navigations aria-label attributes

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -21,7 +21,7 @@
 		<?php get_template_part( 'template-parts/footer/footer-widgets' ); ?>
 
 		<?php if ( has_nav_menu( 'footer' ) ) : ?>
-			<nav aria-label="<?php esc_attr_e( 'Footer Navigation', 'twentytwentyone' ); ?>" class="footer-navigation">
+			<nav aria-label="<?php esc_attr_e( 'Secondary menu', 'twentytwentyone' ); ?>" class="footer-navigation">
 				<ul class="footer-navigation-wrapper">
 					<?php
 					wp_nav_menu(

--- a/header.php
+++ b/header.php
@@ -31,7 +31,7 @@
 		<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
 		<?php if ( has_nav_menu( 'primary' ) ) : ?>
-			<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary', 'twentytwentyone' ); ?>">
+			<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary menu', 'twentytwentyone' ); ?>">
 				<div class="menu-button-container">
 					<button id="primary-mobile-menu" class="button" aria-controls="primary-menu-list" aria-expanded="false">
 						<span class="dropdown-icon open"><?php esc_html_e( 'Menu', 'twentytwentyone' ); ?>


### PR DESCRIPTION
Fixes #470

## Summary
Renames the primary navigation aria-label to `Primary menu`, and the footer-navigation to `Secondary menu`.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
