### PR TITLE
add margin auto

### DIFF
--- a/assets/sass/05-blocks/quote/_editor.scss
+++ b/assets/sass/05-blocks/quote/_editor.scss
@@ -1,7 +1,7 @@
 .wp-block-quote {
 	border-left-color: var(--quote--border-color);
 	border-left-width: var(--quote--border-width);
-	margin: var(--global--spacing-vertical) 0;
+	margin: var(--global--spacing-vertical) auto;
 	padding-left: var(--global--spacing-horizontal);
 
 	p {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #468 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Added margin auto to center the block.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Create a new post.
1. add a block-quote.
1. Check if the alignment is correct in the editor.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

</details>

<details>
<summary>Desktop (Large)</summary>

</details>


<details>
<summary>Tablet (Medium)</summary>

</details>


<details>
<summary>Mobile (Small)</summary>

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
