### PR TITLE
exclude .skip-link from .site a:focus

### DIFF
--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -16,8 +16,11 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: none;
+
+	&:not(.skip-link) {
+		outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+		text-decoration: none;
+	}
 }
 
 // Enforce the custom link color even if a custom background color has been set.

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -17,9 +17,14 @@ a:hover {
 
 .site a:focus {
 
-	&:not(.skip-link) {
-		outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-		text-decoration: none;
+	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+	text-decoration: none;
+
+	&.skip-link {
+
+		/* Only visible in Windows High Contrast mode */
+		outline: 2px solid transparent;
+		outline-offset: -2px;
 	}
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #467 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
exclude .skip-link from .site a:focus
wrapped the `.site a:focus` css rules with a `:not()` pseudo-class 

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
