### PR TITLE
Fix styling for post-pagination

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5907,12 +5907,12 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.5rem;
 	font-weight: 600;
-	line-height: 1.3;
+	line-height: 1.7;
 }
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 5px 25px 0;
+		margin: 0 25px;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5951,14 +5951,14 @@ h1.page-title {
 }
 
 .post-navigation .meta-nav {
-	font-size: 1.5rem;
 	line-height: 1.7;
 	color: #28303d;
 }
 
 .post-navigation .post-title {
+	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.25rem;
+	font-size: 1.5rem;
 	font-weight: 600;
 	line-height: 1.3;
 }
@@ -5993,6 +5993,12 @@ h1.page-title {
 .post-navigation .nav-next:last-child,
 .post-navigation .nav-previous:last-child {
 	margin-bottom: 0;
+}
+
+.post-navigation .nav-next:hover .post-title,
+.post-navigation .nav-previous:hover .post-title {
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
 }
 
 .pagination {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5912,7 +5912,7 @@ h1.page-title {
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 0 25px;
+		margin: 5px 25px 0;
 	}
 }
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -82,9 +82,9 @@
 		font-family: var(--global--font-primary);
 		font-size: var(--global--font-size-lg);
 		font-weight: var(--pagination--font-weight-strong);
-		line-height: var(--heading--line-height);
+		line-height: var(--global--line-height-body);
 		@include media(desktop) {
-			margin: 5px var(--global--spacing-horizontal) 0;
+			margin: 0 var(--global--spacing-horizontal);
 		}
 	}
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -108,6 +108,7 @@
 		}
 
 		&:hover {
+
 			.post-title {
 				text-decoration: underline;
 				text-decoration-thickness: 1px;

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -84,7 +84,7 @@
 		font-weight: var(--pagination--font-weight-strong);
 		line-height: var(--heading--line-height);
 		@include media(desktop) {
-			margin: 0 var(--global--spacing-horizontal);
+			margin: 5px var(--global--spacing-horizontal) 0;
 		}
 	}
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -73,14 +73,14 @@
 	@extend %responsive-alignwide-width;
 
 	.meta-nav {
-		font-size: var(--global--font-size-lg);
 		line-height: var(--global--line-height-body);
 		color: var(--global--color-primary);
 	}
 
 	.post-title {
+		display: inline-block;
 		font-family: var(--global--font-primary);
-		font-size: var(--global--font-size-base);
+		font-size: var(--global--font-size-lg);
 		font-weight: var(--pagination--font-weight-strong);
 		line-height: var(--heading--line-height);
 		@include media(desktop) {
@@ -105,6 +105,13 @@
 
 		&:last-child {
 			margin-bottom: 0;
+		}
+
+		&:hover {
+			.post-title {
+				text-decoration: underline;
+				text-decoration-thickness: 1px;
+			}
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4379,14 +4379,14 @@ h1.page-title {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-lg);
 	line-height: var(--global--line-height-body);
 	color: var(--global--color-primary);
 }
 
 .post-navigation .post-title {
+	display: inline-block;
 	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-base);
+	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
 	line-height: var(--heading--line-height);
 }
@@ -4417,6 +4417,12 @@ h1.page-title {
 .post-navigation .nav-next:last-child,
 .post-navigation .nav-previous:last-child {
 	margin-bottom: 0;
+}
+
+.post-navigation .nav-next:hover .post-title,
+.post-navigation .nav-previous:hover .post-title {
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
 }
 
 .pagination,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4342,7 +4342,7 @@ h1.page-title {
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 0 var(--global--spacing-horizontal);
+		margin: 5px var(--global--spacing-horizontal) 0;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4337,12 +4337,12 @@ h1.page-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-body);
 }
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 5px var(--global--spacing-horizontal) 0;
+		margin: 0 var(--global--spacing-horizontal);
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -4346,12 +4346,12 @@ h1.page-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-body);
 }
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 5px var(--global--spacing-horizontal) 0;
+		margin: 0 var(--global--spacing-horizontal);
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -4388,14 +4388,14 @@ h1.page-title {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-lg);
 	line-height: var(--global--line-height-body);
 	color: var(--global--color-primary);
 }
 
 .post-navigation .post-title {
+	display: inline-block;
 	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-base);
+	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
 	line-height: var(--heading--line-height);
 }
@@ -4426,6 +4426,12 @@ h1.page-title {
 .post-navigation .nav-next:last-child,
 .post-navigation .nav-previous:last-child {
 	margin-bottom: 0;
+}
+
+.post-navigation .nav-next:hover .post-title,
+.post-navigation .nav-previous:hover .post-title {
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
 }
 
 .pagination,

--- a/style.css
+++ b/style.css
@@ -4351,7 +4351,7 @@ h1.page-title {
 
 @media only screen and (min-width: 822px) {
 	.post-navigation .post-title {
-		margin: 0 var(--global--spacing-horizontal);
+		margin: 5px var(--global--spacing-horizontal) 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #499 

## Summary

Fixes font-sizes for post-navigation.

## Relevant technical choices:

After I changed the font-size, I noticed that if the title is too long it flows to the next screen but doesn't have the margin so it looks a bit funky:

![Screenshot_2020-10-15 Template Sticky – My Blog](https://user-images.githubusercontent.com/588688/96128534-2890ea80-0efe-11eb-8250-7ba483e99ca1.png)
Note that this is not directly related to this commit, it was just easier to spot now.

To fix that, I added `display:inline-block` to the elements and now it looks OK:

![Screenshot_2020-10-15 Template Sticky – My Blog(1)](https://user-images.githubusercontent.com/588688/96128606-3d6d7e00-0efe-11eb-8c67-ef5fdbd022de.png)

However, that change caused the title to not be underlined on hover, so I had to specifically add the hover styles.

##x Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
