### PR TITLE
Fixes the excerpt settings section name.

### DIFF
--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -85,9 +85,9 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			 * Add excerpt or full text selector to customizer
 			 */
 			$wp_customize->add_section(
-				'theme_settings',
+				'excerpt_settings',
 				array(
-					'title'    => esc_html__( 'Excerpt settings', 'twentytwentyone' ),
+					'title'    => esc_html__( 'Excerpt Settings', 'twentytwentyone' ),
 					'priority' => 120,
 				)
 			);
@@ -107,7 +107,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				'display_excerpt_or_full_post',
 				array(
 					'type'    => 'radio',
-					'section' => 'theme_settings',
+					'section' => 'excerpt_settings',
 					'label'   => esc_html__( 'On archive pages, posts show:', 'twentytwentyone' ),
 					'choices' => array(
 						'excerpt' => esc_html__( 'Summary', 'twentytwentyone' ),


### PR DESCRIPTION
See https://github.com/WordPress/twentytwentyone/pull/497#issuecomment-709347951

Fixes the section-name for consistency, and changes the section-ID to reflect the new name.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
