### PR TITLE
Try the default outline

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -383,7 +383,6 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid #28303d;
 	text-decoration: none;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2086,7 +2086,6 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid #28303d;
 	text-decoration: none;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1819,6 +1819,7 @@ select {
 }
 
 select:focus {
+	outline-offset: 4px;
 	outline: 1px solid #39414d;
 }
 
@@ -1864,6 +1865,7 @@ License: MIT.
 	}
 	input[type="checkbox"]:focus {
 		outline: 1px solid #39414d;
+		outline-offset: 4px;
 		background: #fff;
 	}
 	input[type="checkbox"]:after {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1670,90 +1670,105 @@ input[type="color"] {
 input[type="text"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="email"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="url"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="password"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="search"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="number"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="tel"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="date"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="month"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="week"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="time"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="datetime"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="datetime-local"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 input[type="color"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 
 .site textarea:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
+	outline-offset: 4px;
 	background: #fff;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1791,7 +1791,7 @@ input[type="color"]:disabled,
 }
 
 input[type="search"]:focus {
-	outline-offset: 0;
+	outline-offset: -6px;
 }
 
 input[type="date"] {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -464,7 +464,6 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -65,6 +65,7 @@ select {
 	background-position: right var(--form--spacing-unit) top 60%;
 
 	&:focus {
+		outline-offset: 4px;
 		outline: 1px solid var(--form--border-color);
 	}
 }
@@ -106,6 +107,7 @@ License: MIT.
 
 		&:focus {
 			outline: 1px solid var(--form--border-color);
+			outline-offset: 4px;
 			background: var(--global--color-white);
 		}
 

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -23,6 +23,7 @@ input[type="color"],
 	&:focus {
 		color: var(--form--color-text);
 		outline: 1px solid var(--form--border-color);
+		outline-offset: 4px;
 		background: var(--global--color-white);
 	}
 

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -37,7 +37,7 @@ input[type="color"],
 input[type="search"] {
 
 	&:focus {
-		outline-offset: 0;
+		outline-offset: -6px;
 	}
 }
 

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -16,7 +16,6 @@ a:hover {
 }
 
 .site a:focus {
-	//outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -16,7 +16,7 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+	//outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1496,7 +1496,6 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1216,7 +1216,7 @@ input[type="color"]:disabled,
 }
 
 input[type="search"]:focus {
-	outline-offset: 0;
+	outline-offset: -6px;
 }
 
 input[type="date"] {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1244,6 +1244,7 @@ select {
 }
 
 select:focus {
+	outline-offset: 4px;
 	outline: 1px solid var(--form--border-color);
 }
 
@@ -1280,6 +1281,7 @@ License: MIT.
 	}
 	input[type="checkbox"]:focus {
 		outline: 1px solid var(--form--border-color);
+		outline-offset: 4px;
 		background: var(--global--color-white);
 	}
 	input[type="checkbox"]:after {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1193,6 +1193,7 @@ input[type="color"]:focus,
 .site textarea:focus {
 	color: var(--form--color-text);
 	outline: 1px solid var(--form--border-color);
+	outline-offset: 4px;
 	background: var(--global--color-white);
 }
 

--- a/style.css
+++ b/style.css
@@ -1500,7 +1500,6 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -1248,6 +1248,7 @@ select {
 }
 
 select:focus {
+	outline-offset: 4px;
 	outline: 1px solid var(--form--border-color);
 }
 
@@ -1284,6 +1285,7 @@ License: MIT.
 	}
 	input[type="checkbox"]:focus {
 		outline: 1px solid var(--form--border-color);
+		outline-offset: 4px;
 		background: var(--global--color-white);
 	}
 	input[type="checkbox"]:after {

--- a/style.css
+++ b/style.css
@@ -1197,6 +1197,7 @@ input[type="color"]:focus,
 .site textarea:focus {
 	color: var(--form--color-text);
 	outline: 1px solid var(--form--border-color);
+	outline-offset: 4px;
 	background: var(--global--color-white);
 }
 

--- a/style.css
+++ b/style.css
@@ -1220,7 +1220,7 @@ input[type="color"]:disabled,
 }
 
 input[type="search"]:focus {
-	outline-offset: 0;
+	outline-offset: -6px;
 }
 
 input[type="date"] {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
This is a test of  #444 where the default outlines are used for links.
And for #458

## Summary
Removes the 2px solid outline.

## Relevant technical choices:


## Test instructions

This PR can be tested by following these steps:
1. Use tab to move between links and other focusable elements
1.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Firefox on PC, Windows 10
![outline-black](https://user-images.githubusercontent.com/7422055/96145828-e9669780-0f05-11eb-894e-821b50b266f3.png)
![outline](https://user-images.githubusercontent.com/7422055/96145832-e9669780-0f05-11eb-9035-bee2148a83da.png)

![overlap-outline2](https://user-images.githubusercontent.com/7422055/96145753-d358d700-0f05-11eb-851a-1b1b818e66a4.png)

![overlap-outline](https://user-images.githubusercontent.com/7422055/96145757-d48a0400-0f05-11eb-85c4-c0495624e45f.png)

Chrome on PC Windows 10
![outline-chrome](https://user-images.githubusercontent.com/7422055/96145811-e53a7a00-0f05-11eb-8669-10109c50b0de.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [ ] I have checked that this code does not affect the accessibility negatively
