### PR TITLE
Remove menu-description decoration on hover

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5757,6 +5757,10 @@ h1.page-title {
 	line-height: 1.7;
 }
 
+.primary-navigation .menu-item-description > span {
+	display: inline-block;
+}
+
 @media only screen and (max-width: 481px) {
 	.lock-scrolling .site {
 		position: fixed;

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -435,6 +435,10 @@
 		font-size: var(--global--font-size-xs);
 		text-transform: none;
 		line-height: 1.7;
+
+		> span {
+			display: inline-block;
+		}
 	}
 }
 

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -90,7 +90,7 @@ add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_nav_menu_social_icons
 function twenty_twenty_one_add_menu_description_args( $args, $item, $depth ) {
 	$args->link_after = '';
 	if ( 0 === $depth && isset( $item->description ) && $item->description ) {
-		$args->link_after = '<span class="menu-item-description">' . $item->description . '</span>';
+		$args->link_after = '<span class="menu-item-description"><span>' . $item->description . '</span></span>';
 	}
 	return $args;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4200,6 +4200,10 @@ h1.page-title {
 	line-height: 1.7;
 }
 
+.primary-navigation .menu-item-description > span {
+	display: inline-block;
+}
+
 @media only screen and (max-width: 481px) {
 	.lock-scrolling .site {
 		position: fixed;

--- a/style.css
+++ b/style.css
@@ -4209,6 +4209,10 @@ h1.page-title {
 	line-height: 1.7;
 }
 
+.primary-navigation .menu-item-description > span {
+	display: inline-block;
+}
+
 @media only screen and (max-width: 481px) {
 	.lock-scrolling .site {
 		position: fixed;


### PR DESCRIPTION
See https://github.com/WordPress/twentytwentyone/pull/424#issuecomment-709328324 for details

![Screenshot_2020-10-15 My Blog](https://user-images.githubusercontent.com/588688/96148617-1a989500-0f11-11eb-9267-27fadc91a10d.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
