### PR TITLE
Image Attachment: Fix meta spacing on small screen

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4849,13 +4849,16 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	column-gap: 50px;
 }
 
-.single .site-main > article > .entry-footer .posted-by .posted-on,
-.single .site-main > article > .entry-footer .posted-by .byline {
-	display: block;
+.single .site-main > article > .entry-footer .post-taxonomies,
+.single .site-main > article > .entry-footer .full-size-link {
+	justify-content: flex-end;
+	text-align: right;
 }
 
-.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+.single .site-main > article > .entry-footer .posted-on,
+.single .site-main > article > .entry-footer .byline,
+.single .site-main > article > .entry-footer .cat-links,
+.single .site-main > article > .entry-footer .tags-links {
 	display: block;
 }
 
@@ -4863,25 +4866,13 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	.single .site-main > article > .entry-footer {
 		display: block;
 	}
-	.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-	.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+	.single .site-main > article > .entry-footer .full-size-link {
+		display: block;
+	}
+	.single .site-main > article > .entry-footer .post-taxonomies,
+	.single .site-main > article > .entry-footer .full-size-link {
 		text-align: left;
 	}
-}
-
-.single .site-main > article > .entry-footer > span {
-	margin-right: 0;
-}
-
-.single .site-main > article > .entry-footer .cat-links,
-.single .site-main > article > .entry-footer .tags-links,
-.single .site-main > article > .entry-footer .full-size-link {
-	justify-self: end;
-	text-align: right;
-}
-
-.single .site-main > article > .entry-footer .tags-links {
-	grid-column-start: 2;
 }
 
 /**

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4855,6 +4855,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: right;
 }
 
+.single .site-main > article > .entry-footer .full-size-link:first-child:last-child {
+	grid-column: span 2;
+}
+
 .single .site-main > article > .entry-footer .posted-on,
 .single .site-main > article > .entry-footer .byline,
 .single .site-main > article > .entry-footer .cat-links,

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -117,50 +117,31 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	grid-template-columns: repeat(2, 1fr);
 	column-gap: calc(2 * var(--global--spacing-horizontal));
 
-	.posted-by {
-
-		.posted-on,
-		.byline {
-			display: block;
-		}
+	.post-taxonomies,
+	.full-size-link {
+		justify-content: flex-end;
+		text-align: right;
 	}
 
-	.post-taxonomies {
-
-		.cat-links,
-		.tags-links {
-			display: block;
-		}
+	.posted-on,
+	.byline,
+	.cat-links,
+	.tags-links {
+		display: block;
 	}
 
 	@include media(mobile-only) {
 		display: block;
 
-		.post-taxonomies {
+		.full-size-link {
+			display: block;
+		}
 
-			.cat-links,
-			.tags-links {
-				text-align: left;
-			}
+		.post-taxonomies,
+		.full-size-link {
+			text-align: left;
 		}
 	}
-
-}
-
-.single .site-main > article > .entry-footer > span {
-	margin-right: 0;
-}
-
-.single .site-main > article > .entry-footer .cat-links,
-.single .site-main > article > .entry-footer .tags-links,
-.single .site-main > article > .entry-footer .full-size-link {
-	justify-self: end;
-	text-align: right;
-}
-
-// Place tag links in last grid column space
-.single .site-main > article > .entry-footer .tags-links {
-	grid-column-start: 2;
 }
 
 /**

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -123,6 +123,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 		text-align: right;
 	}
 
+	.full-size-link:first-child:last-child {
+		grid-column: span 2;
+	}
+
 	.posted-on,
 	.byline,
 	.cat-links,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3451,13 +3451,16 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	column-gap: calc(2 * var(--global--spacing-horizontal));
 }
 
-.single .site-main > article > .entry-footer .posted-by .posted-on,
-.single .site-main > article > .entry-footer .posted-by .byline {
-	display: block;
+.single .site-main > article > .entry-footer .post-taxonomies,
+.single .site-main > article > .entry-footer .full-size-link {
+	justify-content: flex-end;
+	text-align: left;
 }
 
-.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+.single .site-main > article > .entry-footer .posted-on,
+.single .site-main > article > .entry-footer .byline,
+.single .site-main > article > .entry-footer .cat-links,
+.single .site-main > article > .entry-footer .tags-links {
 	display: block;
 }
 
@@ -3465,25 +3468,13 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	.single .site-main > article > .entry-footer {
 		display: block;
 	}
-	.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-	.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+	.single .site-main > article > .entry-footer .full-size-link {
+		display: block;
+	}
+	.single .site-main > article > .entry-footer .post-taxonomies,
+	.single .site-main > article > .entry-footer .full-size-link {
 		text-align: right;
 	}
-}
-
-.single .site-main > article > .entry-footer > span {
-	margin-left: 0;
-}
-
-.single .site-main > article > .entry-footer .cat-links,
-.single .site-main > article > .entry-footer .tags-links,
-.single .site-main > article > .entry-footer .full-size-link {
-	justify-self: end;
-	text-align: left;
-}
-
-.single .site-main > article > .entry-footer .tags-links {
-	grid-column-start: 2;
 }
 
 /**

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3457,6 +3457,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: left;
 }
 
+.single .site-main > article > .entry-footer .full-size-link:first-child:last-child {
+	grid-column: span 2;
+}
+
 .single .site-main > article > .entry-footer .posted-on,
 .single .site-main > article > .entry-footer .byline,
 .single .site-main > article > .entry-footer .cat-links,

--- a/style.css
+++ b/style.css
@@ -3460,13 +3460,16 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	column-gap: calc(2 * var(--global--spacing-horizontal));
 }
 
-.single .site-main > article > .entry-footer .posted-by .posted-on,
-.single .site-main > article > .entry-footer .posted-by .byline {
-	display: block;
+.single .site-main > article > .entry-footer .post-taxonomies,
+.single .site-main > article > .entry-footer .full-size-link {
+	justify-content: flex-end;
+	text-align: right;
 }
 
-.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+.single .site-main > article > .entry-footer .posted-on,
+.single .site-main > article > .entry-footer .byline,
+.single .site-main > article > .entry-footer .cat-links,
+.single .site-main > article > .entry-footer .tags-links {
 	display: block;
 }
 
@@ -3474,25 +3477,13 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	.single .site-main > article > .entry-footer {
 		display: block;
 	}
-	.single .site-main > article > .entry-footer .post-taxonomies .cat-links,
-	.single .site-main > article > .entry-footer .post-taxonomies .tags-links {
+	.single .site-main > article > .entry-footer .full-size-link {
+		display: block;
+	}
+	.single .site-main > article > .entry-footer .post-taxonomies,
+	.single .site-main > article > .entry-footer .full-size-link {
 		text-align: left;
 	}
-}
-
-.single .site-main > article > .entry-footer > span {
-	margin-right: 0;
-}
-
-.single .site-main > article > .entry-footer .cat-links,
-.single .site-main > article > .entry-footer .tags-links,
-.single .site-main > article > .entry-footer .full-size-link {
-	justify-self: end;
-	text-align: right;
-}
-
-.single .site-main > article > .entry-footer .tags-links {
-	grid-column-start: 2;
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -3466,6 +3466,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	text-align: right;
 }
 
+.single .site-main > article > .entry-footer .full-size-link:first-child:last-child {
+	grid-column: span 2;
+}
+
 .single .site-main > article > .entry-footer .posted-on,
 .single .site-main > article > .entry-footer .byline,
 .single .site-main > article > .entry-footer .cat-links,


### PR DESCRIPTION
## Summary
Fix up the entry-meta on image attachment pages. This also flattens out some of the specificity of the existing meta CSS, but it shouldn't change anything visually.

| Before | After |
|-------|-------|
| ![Screen Shot 2020-10-15 at 16 02 03](https://user-images.githubusercontent.com/541093/96180187-11eb9300-0f00-11eb-9228-ea03ccb32c68.png) | ![Screen Shot 2020-10-15 at 16 02 56](https://user-images.githubusercontent.com/541093/96180257-29c31700-0f00-11eb-89ed-d845a3ce9529.png) |

## Test instructions

This PR can be tested by following these steps:
1. View an image's attachment page
2. Check that the meta below the image are aligned correctly— logged in, logged out, when the image is attached to a post or not
3. Check this on both small screens (<480) & large
3. Check that the meta alignment on regular posts hasn't changed

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
