### PR TITLE
Add spaces where needed for screen-readers

### DIFF
--- a/image.php
+++ b/image.php
@@ -68,8 +68,7 @@ while ( have_posts() ) {
 					sprintf(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
 						esc_html__( 'Edit %s', 'twentytwentyone' ),
-						// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
-						'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
+						'<span class="screen-reader-text">' . get_the_title() . '</span>'
 					),
 					'<span class="edit-link">',
 					'</span>'
@@ -94,8 +93,7 @@ while ( have_posts() ) {
 					sprintf(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
 						esc_html__( 'Edit %s', 'twentytwentyone' ),
-						// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
-						'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
+						'<span class="screen-reader-text">' . get_the_title() . '</span>'
 					),
 					'<span class="edit-link">',
 					'</span><br>'

--- a/image.php
+++ b/image.php
@@ -68,7 +68,8 @@ while ( have_posts() ) {
 					sprintf(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
 						esc_html__( 'Edit %s', 'twentytwentyone' ),
-						'<span class="screen-reader-text">' . get_the_title() . '</span>'
+						// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
+						'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
 					),
 					'<span class="edit-link">',
 					'</span>'
@@ -93,7 +94,8 @@ while ( have_posts() ) {
 					sprintf(
 						/* translators: %s: Name of current post. Only visible to screen readers. */
 						esc_html__( 'Edit %s', 'twentytwentyone' ),
-						'<span class="screen-reader-text">' . get_the_title() . '</span>'
+						// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
+						'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
 					),
 					'<span class="edit-link">',
 					'</span><br>'

--- a/image.php
+++ b/image.php
@@ -66,15 +66,8 @@ while ( have_posts() ) {
 				// Edit post link.
 				edit_post_link(
 					sprintf(
-						wp_kses(
-							/* translators: %s: Name of current post. Only visible to screen readers. */
-							__( 'Edit %s', 'twentytwentyone' ),
-							array(
-								'span' => array(
-									'class' => array(),
-								),
-							)
-						),
+						/* translators: %s: Name of current post. Only visible to screen readers. */
+						esc_html__( 'Edit %s', 'twentytwentyone' ),
 						'<span class="screen-reader-text">' . get_the_title() . '</span>'
 					),
 					'<span class="edit-link">',
@@ -98,15 +91,8 @@ while ( have_posts() ) {
 				// Edit post link.
 				edit_post_link(
 					sprintf(
-						wp_kses(
-							/* translators: %s: Name of current post. Only visible to screen readers. */
-							__( 'Edit %s', 'twentytwentyone' ),
-							array(
-								'span' => array(
-									'class' => array(),
-								),
-							)
-						),
+						/* translators: %s: Name of current post. Only visible to screen readers. */
+						esc_html__( 'Edit %s', 'twentytwentyone' ),
 						'<span class="screen-reader-text">' . get_the_title() . '</span>'
 					),
 					'<span class="edit-link">',

--- a/image.php
+++ b/image.php
@@ -57,7 +57,7 @@ while ( have_posts() ) {
 			if ( wp_get_post_parent_id( $post ) ) {
 				echo '<span class="posted-on">';
 				printf(
-					/* translators: %s: parent post */
+					/* translators: %s: parent post. */
 					esc_html__( 'Published in %s', 'twentytwentyone' ),
 					'<a href="' . esc_url( get_the_permalink( wp_get_post_parent_id( $post ) ) ) . '">' . esc_html( get_the_title( wp_get_post_parent_id( $post ) ) ) . '</a>'
 				);

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -90,7 +90,8 @@ add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_nav_menu_social_icons
 function twenty_twenty_one_add_menu_description_args( $args, $item, $depth ) {
 	$args->link_after = '';
 	if ( 0 === $depth && isset( $item->description ) && $item->description ) {
-		$args->link_after = '<span class="menu-item-description"><span>' . $item->description . '</span></span>';
+		// The extra <span> element is here for styling purposes: Allows the description to not be underslined on hover.
+		$args->link_after = ' <span class="menu-item-description"><span>' . $item->description . '</span></span>';
 	}
 	return $args;
 }

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -91,7 +91,7 @@ function twenty_twenty_one_add_menu_description_args( $args, $item, $depth ) {
 	$args->link_after = '';
 	if ( 0 === $depth && isset( $item->description ) && $item->description ) {
 		// The extra <span> element is here for styling purposes: Allows the description to not be underslined on hover.
-		$args->link_after = ' <span class="menu-item-description"><span>' . $item->description . '</span></span>';
+		$args->link_after = '<p class="menu-item-description"><span>' . $item->description . '</span></p>';
 	}
 	return $args;
 }

--- a/inc/menu-functions.php
+++ b/inc/menu-functions.php
@@ -90,7 +90,7 @@ add_filter( 'walker_nav_menu_start_el', 'twenty_twenty_one_nav_menu_social_icons
 function twenty_twenty_one_add_menu_description_args( $args, $item, $depth ) {
 	$args->link_after = '';
 	if ( 0 === $depth && isset( $item->description ) && $item->description ) {
-		// The extra <span> element is here for styling purposes: Allows the description to not be underslined on hover.
+		// The extra <span> element is here for styling purposes: Allows the description to not be underlined on hover.
 		$args->link_after = '<p class="menu-item-description"><span>' . $item->description . '</span></p>';
 	}
 	return $args;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -200,7 +200,7 @@ function twenty_twenty_one_get_avatar_size() {
 function twenty_twenty_one_continue_reading_text() {
 	$continue_reading = sprintf(
 		/* translators: %s: Name of current post. */
-		wp_kses( esc_html__( 'Continue reading %s', 'twentytwentyone' ), array( 'span' => array( 'class' => array() ) ) ),
+		esc_html__( 'Continue reading %s', 'twentytwentyone' ),
 		the_title( '<span class="screen-reader-text">', '</span>', false )
 	);
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -151,7 +151,7 @@ function twenty_twenty_one_get_the_archive_title() {
 
 	if ( is_post_type_archive() ) {
 		return sprintf(
-			/* translators: %s: Post type singular name */
+			/* translators: %s: Post type singular name. */
 			esc_html__( '%s Archives', 'twentytwentyone' ),
 			get_post_type_object( get_queried_object()->name )->labels->singular_name
 		);
@@ -159,7 +159,7 @@ function twenty_twenty_one_get_the_archive_title() {
 
 	if ( is_tax() ) {
 		return sprintf(
-			/* translators: %s: Taxonomy singular name */
+			/* translators: %s: Taxonomy singular name. */
 			esc_html__( '%s Archives', 'twentytwentyone' ),
 			get_taxonomy( get_queried_object()->taxonomy )->labels->singular_name
 		);

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -80,8 +80,7 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
-					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span><br>'
@@ -124,8 +123,7 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
-					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -78,15 +78,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			// Edit post link.
 			edit_post_link(
 				sprintf(
-					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers. */
-						__( 'Edit %s', 'twentytwentyone' ),
-						array(
-							'span' => array(
-								'class' => array(),
-							),
-						)
-					),
+					/* translators: %s: Name of current post. Only visible to screen readers. */
+					esc_html__( 'Edit %s', 'twentytwentyone' ),
 					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
@@ -128,15 +121,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 			// Edit post link.
 			edit_post_link(
 				sprintf(
-					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers. */
-						__( 'Edit %s', 'twentytwentyone' ),
-						array(
-							'span' => array(
-								'class' => array(),
-							),
-						)
-					),
+					/* translators: %s: Name of current post. Only visible to screen readers. */
+					esc_html__( 'Edit %s', 'twentytwentyone' ),
 					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -80,7 +80,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					'<span class="screen-reader-text">' . get_the_title() . '</span>'
+					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
+					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
 				),
 				'<span class="edit-link">',
 				'</span><br>'
@@ -123,7 +124,8 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					'<span class="screen-reader-text">' . get_the_title() . '</span>'
+					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
+					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'twenty_twenty_one_posted_on' ) ) {
 		);
 		echo '<span class="posted-on">';
 		printf(
-			/* translators: %s: publish date */
+			/* translators: %s: publish date. */
 			esc_html__( 'Published %s', 'twentytwentyone' ),
 			$time_string // phpcs:ignore WordPress.Security.EscapeOutput
 		);

--- a/single.php
+++ b/single.php
@@ -34,43 +34,25 @@ while ( have_posts() ) :
 
 	if ( is_singular( 'post' ) ) {
 
-		// The next-post link - visual representation.
-		$next_text  = '<span class="meta-nav" aria-hidden="true">';
+		// The next-post link.
+		$next_text  = '<p class="meta-nav">';
 		$next_text .= sprintf(
 			/* Translators: %s: The arrow. */
 			esc_html__( 'Next Post %s', 'twentytwentyone' ),
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
 		);
-		$next_text .= '</span>';
-		$next_text .= '<span class="post-title" aria-hidden="true">%title</span>';
-
-		// The next-post link - screen-reader representation.
-		$next_text .= '<span class="screen-reader-text">';
-		$next_text .= sprintf(
-			/* Translators: $s: The post-title. */
-			esc_html__( 'Next post: "%s"', 'twentytwentyone' ),
-			'%title'
-		);
-		$next_text .= '</span>';
+		$next_text .= '</p>';
+		$next_text .= '<p class="post-title">%title</p>';
 
 		// The previous-post link - visual representation.
-		$prev_text  = '<span class="meta-nav" aria-hidden="true">';
+		$prev_text  = '<p class="meta-nav">';
 		$prev_text .= sprintf(
 			/* Translators: %s: The arrow. */
 			esc_html__( '%s Previous Post', 'twentytwentyone' ),
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' )
 		);
-		$prev_text .= '</span>';
-		$prev_text .= '<span class="post-title" aria-hidden="true">%title</span>';
-
-		// The next-post link - screen-reader representation.
-		$prev_text .= '<span class="screen-reader-text">';
-		$prev_text .= sprintf(
-			/* Translators: $s: The post-title. */
-			esc_html__( 'Previous post: "%s"', 'twentytwentyone' ),
-			'%title'
-		);
-		$prev_text .= '</span>';
+		$prev_text .= '</p>';
+		$prev_text .= '<p class="post-title">%title</p>';
 
 		the_post_navigation(
 			array(

--- a/single.php
+++ b/single.php
@@ -42,9 +42,8 @@ while ( have_posts() ) :
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
 		);
 		$next_text .= '</span>';
-		/* Translators: There is a space at the end, after the colon. */
-		$next_text .= '<span class="screen-reader-text">' . esc_html__( 'Next post: ', 'twentytwentyone' ) . '</span>';
-		$next_text .= '<span class="post-title">%title</span>';
+		$next_text .= '<span class="screen-reader-text">' . esc_html__( 'Next post:', 'twentytwentyone' ) . '</span>';
+		$next_text .= '<span class="post-title">&nbsp;%title</span>';
 
 		// The previous-post link.
 		$prev_text  = '<span class="meta-nav" aria-hidden="true">';
@@ -54,9 +53,8 @@ while ( have_posts() ) :
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' )
 		);
 		$prev_text .= '</span>';
-		/* Translators: There is a space at the end, after the colon. */
-		$prev_text .= '<span class="screen-reader-text">' . esc_html__( 'Previous post: ', 'twentytwentyone' ) . '</span>';
-		$prev_text .= '<span class="post-title">%title</span>';
+		$prev_text .= '<span class="screen-reader-text">' . esc_html__( 'Previous post:', 'twentytwentyone' ) . '</span>';
+		$prev_text .= '<span class="post-title">&nbsp;%title</span>';
 
 		the_post_navigation(
 			array(

--- a/single.php
+++ b/single.php
@@ -33,18 +33,35 @@ while ( have_posts() ) :
 	}
 
 	if ( is_singular( 'post' ) ) {
-		// Previous/next post navigation.
-		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
-		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
+
+		// The next-post link.
+		$next_text  = '<span class="meta-nav" aria-hidden="true">';
+		$next_text .= sprintf(
+			/* Translators: %s: The arrow. */
+			esc_html__( 'Next Post %s', 'twentytwentyone' ),
+			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
+		);
+		$next_text .= '</span>';
+		/* Translators: There is a space at the end, after the colon. */
+		$next_text .= '<span class="screen-reader-text">' . esc_html__( 'Next post: ', 'twentytwentyone' ) . '</span>';
+		$next_text .= '<span class="post-title">%title</span>';
+
+		// The previous-post link.
+		$prev_text  = '<span class="meta-nav" aria-hidden="true">';
+		$prev_text .= sprintf(
+			/* Translators: %s: The arrow. */
+			esc_html__( '%s Previous Post', 'twentytwentyone' ),
+			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' )
+		);
+		$prev_text .= '</span>';
+		/* Translators: There is a space at the end, after the colon. */
+		$prev_text .= '<span class="screen-reader-text">' . esc_html__( 'Previous post: ', 'twentytwentyone' ) . '</span>';
+		$prev_text .= '<span class="post-title">%title</span>';
+
 		the_post_navigation(
 			array(
-				'next_text' => '<span class="meta-nav" aria-hidden="true">' .
-				esc_html__( 'Next Post', 'twentytwentyone' ) . $twentytwentyone_next . '</span> ' .
-				'<span class="screen-reader-text">' . esc_html__( 'Next post:', 'twentytwentyone' ) . '</span>' .
-				'<span class="post-title">%title</span>',
-				'prev_text' => '<span class="meta-nav" aria-hidden="true"> ' . $twentytwentyone_prev . esc_html__( 'Previous Post', 'twentytwentyone' ) . '</span> ' .
-				'<span class="screen-reader-text">' . esc_html__( 'Previous post:', 'twentytwentyone' ) . '</span>' .
-				'<span class="post-title">%title</span>',
+				'next_text' => $next_text,
+				'prev_text' => $prev_text,
 			)
 		);
 	}

--- a/single.php
+++ b/single.php
@@ -21,7 +21,7 @@ while ( have_posts() ) :
 		// Parent post navigation.
 		the_post_navigation(
 			array(
-				/* translators: %s: parent post link */
+				/* translators: %s: parent post link. */
 				'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'twentytwentyone' ), '%title' ),
 			)
 		);

--- a/single.php
+++ b/single.php
@@ -34,30 +34,13 @@ while ( have_posts() ) :
 
 	if ( is_singular( 'post' ) ) {
 
-		// The next-post link.
-		$next_text  = '<p class="meta-nav">';
-		$next_text .= sprintf(
-			/* Translators: %s: The arrow. */
-			esc_html__( 'Next Post %s', 'twentytwentyone' ),
-			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
-		);
-		$next_text .= '</p>';
-		$next_text .= '<p class="post-title">%title</p>';
-
-		// The previous-post link - visual representation.
-		$prev_text  = '<p class="meta-nav">';
-		$prev_text .= sprintf(
-			/* Translators: %s: The arrow. */
-			esc_html__( '%s Previous Post', 'twentytwentyone' ),
-			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' )
-		);
-		$prev_text .= '</p>';
-		$prev_text .= '<p class="post-title">%title</p>';
-
+		// Previous/next post navigation icons.
+		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
+		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
 		the_post_navigation(
 			array(
-				'next_text' => $next_text,
-				'prev_text' => $prev_text,
+				'next_text' => '<p class="meta-nav">' . esc_html__( 'Next Post', 'twentytwentyone' ) . $twentytwentyone_next . '</p><p class="post-title">%title</p>',
+				'prev_text' => '<p class="meta-nav">' . $twentytwentyone_prev . esc_html__( 'Previous Post', 'twentytwentyone' ) . '</p><p class="post-title">%title</p>',
 			)
 		);
 	}

--- a/single.php
+++ b/single.php
@@ -33,8 +33,7 @@ while ( have_posts() ) :
 	}
 
 	if ( is_singular( 'post' ) ) {
-
-		// Previous/next post navigation icons.
+		// Previous/next post navigation.
 		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
 		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
 		the_post_navigation(

--- a/single.php
+++ b/single.php
@@ -34,7 +34,7 @@ while ( have_posts() ) :
 
 	if ( is_singular( 'post' ) ) {
 
-		// The next-post link.
+		// The next-post link - visual representation.
 		$next_text  = '<span class="meta-nav" aria-hidden="true">';
 		$next_text .= sprintf(
 			/* Translators: %s: The arrow. */
@@ -42,10 +42,18 @@ while ( have_posts() ) :
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
 		);
 		$next_text .= '</span>';
-		$next_text .= '<span class="screen-reader-text">' . esc_html__( 'Next post:', 'twentytwentyone' ) . '</span>';
-		$next_text .= '<span class="post-title">&nbsp;%title</span>';
+		$next_text .= '<span class="post-title" aria-hidden="true">%title</span>';
 
-		// The previous-post link.
+		// The next-post link - screen-reader representation.
+		$next_text .= '<span class="screen-reader-text">';
+		$next_text .= sprintf(
+			/* Translators: $s: The post-title. */
+			esc_html__( 'Next post: "%s"', 'twentytwentyone' ),
+			'%title'
+		);
+		$next_text .= '</span>';
+
+		// The previous-post link - visual representation.
 		$prev_text  = '<span class="meta-nav" aria-hidden="true">';
 		$prev_text .= sprintf(
 			/* Translators: %s: The arrow. */
@@ -53,8 +61,16 @@ while ( have_posts() ) :
 			is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' )
 		);
 		$prev_text .= '</span>';
-		$prev_text .= '<span class="screen-reader-text">' . esc_html__( 'Previous post:', 'twentytwentyone' ) . '</span>';
-		$prev_text .= '<span class="post-title">&nbsp;%title</span>';
+		$prev_text .= '<span class="post-title" aria-hidden="true">%title</span>';
+
+		// The next-post link - screen-reader representation.
+		$prev_text .= '<span class="screen-reader-text">';
+		$prev_text .= sprintf(
+			/* Translators: $s: The post-title. */
+			esc_html__( 'Previous post: "%s"', 'twentytwentyone' ),
+			'%title'
+		);
+		$prev_text .= '</span>';
 
 		the_post_navigation(
 			array(

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -40,8 +40,7 @@
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
-					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -38,7 +38,7 @@
 			<?php
 			edit_post_link(
 				sprintf(
-					/* translators: %s: Name of current post. Only visible to screen readers */
+					/* translators: %s: Name of current post. Only visible to screen readers. */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
 					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
 					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -38,16 +38,9 @@
 			<?php
 			edit_post_link(
 				sprintf(
-					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers */
-						__( 'Edit <span class="screen-reader-text">%s</span>', 'twentytwentyone' ),
-						array(
-							'span' => array(
-								'class' => array(),
-							),
-						)
-					),
-					get_the_title()
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					esc_html__( 'Edit %s', 'twentytwentyone' ),
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -40,7 +40,8 @@
 				sprintf(
 					/* translators: %s: Name of current post. Only visible to screen readers */
 					esc_html__( 'Edit %s', 'twentytwentyone' ),
-					'<span class="screen-reader-text">' . get_the_title() . '</span>'
+					// We're adding &nbsp; before and after to accomodate both LTR & RTL, as NVDA doesn't add the space.
+					'<span class="screen-reader-text">&nbsp;' . get_the_title() . '&nbsp;</span>'
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -12,11 +12,11 @@
 	<div class="author-bio <?php echo get_option( 'show_avatars' ) ? 'show-avatars' : ''; ?>">
 		<?php echo get_avatar( get_the_author_meta( 'ID' ), '85' ); ?>
 		<div class="author-bio-content">
-			<h2 class="author-title"><?php printf( /* translators: 1: Author name */ esc_html__( 'By %s', 'twentytwentyone' ), get_the_author() ); ?></h2>
+			<h2 class="author-title"><?php printf( /* translators: 1: Author name. */ esc_html__( 'By %s', 'twentytwentyone' ), get_the_author() ); ?></h2>
 			<p class="author-description"> <?php the_author_meta( 'description' ); ?></p><!-- .author-description -->
 			<?php
 			printf(
-				/* translators: 1: Link to authors posts. 2: Author name */
+				/* translators: 1: Link to authors posts. 2: Author name. */
 				'<a class="author-link" href="%1$s" rel="author">' . esc_html__( 'View all of %2$s\'s posts.', 'twentytwentyone' ) . '</a>',
 				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 				get_the_author()


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #517 

## Summary

Added spaces where needed.
While doing so, I fixed code that didn't make sense (for example removed a few `wp_kses` calls) or was just hard to read & understand.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
