### PR TITLE
Improve UI of password protected posts

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -80,27 +80,27 @@
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:active {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -219,51 +219,51 @@ input[type="reset"]:after,
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -1063,23 +1063,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -1089,21 +1089,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2628,11 +2628,11 @@ a:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -3423,12 +3423,14 @@ p.has-text-color a {
 }
 
 .post-password-form__input {
+	flex-grow: 1;
 	margin-top: 10px;
-	margin-right: -3px;
+	margin-right: 17px;
 }
 
 .post-password-form__submit {
 	margin-top: 10px;
+	margin-left: 10px;
 }
 
 .wp-block-pullquote {
@@ -4326,21 +4328,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4389,21 +4391,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3430,7 +3430,12 @@ p.has-text-color a {
 
 .post-password-form__submit {
 	margin-top: 10px;
-	margin-left: 10px;
+}
+
+@media only screen and (min-width: 592px) {
+	.post-password-form__submit {
+		margin-left: 10px;
+	}
 }
 
 .wp-block-pullquote {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3412,6 +3412,10 @@ p.has-text-color a {
 	color: #28303d;
 }
 
+.post-password-message {
+	font-size: 1.5rem;
+}
+
 .post-password-form {
 	display: flex;
 	flex-wrap: wrap;

--- a/assets/sass/05-blocks/password/_style.scss
+++ b/assets/sass/05-blocks/password/_style.scss
@@ -17,7 +17,7 @@
 		margin-top: calc(var(--global--spacing-vertical) / 3);
 		
 		@include media(tablet) {
-			margin-left: 10px;
+			margin-left: calc(0.4 * var(--global--spacing-horizontal));
 		}
 	}
 }

--- a/assets/sass/05-blocks/password/_style.scss
+++ b/assets/sass/05-blocks/password/_style.scss
@@ -15,6 +15,9 @@
 
 	&__submit {
 		margin-top: calc(var(--global--spacing-vertical) / 3);
-		margin-left: 10px;
+		
+		@include media(tablet) {
+			margin-left: 10px;
+		}
 	}
 }

--- a/assets/sass/05-blocks/password/_style.scss
+++ b/assets/sass/05-blocks/password/_style.scss
@@ -8,11 +8,13 @@
 	}
 
 	&__input {
+		flex-grow: 1;
 		margin-top: calc(var(--global--spacing-vertical) / 3);
-		margin-right: calc(-1 * var(--button--border-width));
+		margin-right: calc(0.66 * var(--global--spacing-horizontal));
 	}
 
 	&__submit {
 		margin-top: calc(var(--global--spacing-vertical) / 3);
+		margin-left: 10px;
 	}
 }

--- a/assets/sass/05-blocks/password/_style.scss
+++ b/assets/sass/05-blocks/password/_style.scss
@@ -15,7 +15,6 @@
 
 	&__submit {
 		margin-top: calc(var(--global--spacing-vertical) / 3);
-		
 		@include media(tablet) {
 			margin-left: calc(0.4 * var(--global--spacing-horizontal));
 		}

--- a/assets/sass/05-blocks/password/_style.scss
+++ b/assets/sass/05-blocks/password/_style.scss
@@ -1,3 +1,7 @@
+.post-password-message {
+	font-size: var(--global--font-size-lg);
+}
+
 .post-password-form {
 	display: flex;
 	flex-wrap: wrap;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -455,7 +455,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 function twenty_twenty_one_password_form( $post = 0 ) {
 	$post   = get_post( $post );
 	$label  = 'pwbox-' . ( empty( $post->ID ) ? wp_rand() : $post->ID );
-	$output = '<p>' . esc_html__( 'This content is password protected. Please enter a password to view.', 'twentytwentyone' ) . '</p>
+	$output = '<p class="post-password-message">' . esc_html__( 'This content is password protected. Please enter a password to view.', 'twentytwentyone' ) . '</p>
 	<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form" method="post">
 	<label class="post-password-form__label" for="' . esc_attr( $label ) . '">' . esc_html__( 'Password', 'twentytwentyone' ) . '</label><input class="post-password-form__input" name="post_password" id="' . esc_attr( $label ) . '" type="password" size="20" /><input type="submit" class="post-password-form__submit" name="' . esc_attr__( 'Submit', 'twentytwentyone' ) . '" value="' . esc_attr_x( 'Enter', 'post password form', 'twentytwentyone' ) . '" /></form>
 	';

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -455,9 +455,9 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 function twenty_twenty_one_password_form( $post = 0 ) {
 	$post   = get_post( $post );
 	$label  = 'pwbox-' . ( empty( $post->ID ) ? wp_rand() : $post->ID );
-	$output = '<p>' . esc_html__( 'This content is password protected. To view it please enter your password below:', 'twentytwentyone' ) . '</p>
+	$output = '<p>' . esc_html__( 'This content is password protected. Please enter a password to view.', 'twentytwentyone' ) . '</p>
 	<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form" method="post">
-	<label class="post-password-form__label" for="' . esc_attr( $label ) . '">' . esc_html__( 'Password:', 'twentytwentyone' ) . '</label><input class="post-password-form__input" name="post_password" id="' . esc_attr( $label ) . '" type="password" size="20" /><input type="submit" class="post-password-form__submit" name="' . esc_attr__( 'Submit', 'twentytwentyone' ) . '" value="' . esc_attr_x( 'Enter', 'post password form', 'twentytwentyone' ) . '" /></form>
+	<label class="post-password-form__label" for="' . esc_attr( $label ) . '">' . esc_html__( 'Password', 'twentytwentyone' ) . '</label><input class="post-password-form__input" name="post_password" id="' . esc_attr( $label ) . '" type="password" size="20" /><input type="submit" class="post-password-form__submit" name="' . esc_attr__( 'Submit', 'twentytwentyone' ) . '" value="' . esc_attr_x( 'Enter', 'post password form', 'twentytwentyone' ) . '" /></form>
 	';
 	return $output;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2415,7 +2415,7 @@ p.has-text-color a {
 
 @media only screen and (min-width: 592px) {
 	.post-password-form__submit {
-		margin-right: 10px;
+		margin-right: calc(0.4 * var(--global--spacing-horizontal));
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2404,12 +2404,14 @@ p.has-text-color a {
 }
 
 .post-password-form__input {
+	flex-grow: 1;
 	margin-top: calc(var(--global--spacing-vertical) / 3);
-	margin-left: calc(-1 * var(--button--border-width));
+	margin-left: calc(0.66 * var(--global--spacing-horizontal));
 }
 
 .post-password-form__submit {
 	margin-top: calc(var(--global--spacing-vertical) / 3);
+	margin-right: 10px;
 }
 
 .wp-block-pullquote {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2393,6 +2393,10 @@ p.has-text-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
+.post-password-message {
+	font-size: var(--global--font-size-lg);
+}
+
 .post-password-form {
 	display: flex;
 	flex-wrap: wrap;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2411,7 +2411,12 @@ p.has-text-color a {
 
 .post-password-form__submit {
 	margin-top: calc(var(--global--spacing-vertical) / 3);
-	margin-right: 10px;
+}
+
+@media only screen and (min-width: 592px) {
+	.post-password-form__submit {
+		margin-right: 10px;
+	}
 }
 
 .wp-block-pullquote {

--- a/style.css
+++ b/style.css
@@ -2415,7 +2415,12 @@ p.has-text-color a {
 
 .post-password-form__submit {
 	margin-top: calc(var(--global--spacing-vertical) / 3);
-	margin-left: 10px;
+}
+
+@media only screen and (min-width: 592px) {
+	.post-password-form__submit {
+		margin-left: 10px;
+	}
 }
 
 .wp-block-pullquote {

--- a/style.css
+++ b/style.css
@@ -2397,6 +2397,10 @@ p.has-text-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
+.post-password-message {
+	font-size: var(--global--font-size-lg);
+}
+
 .post-password-form {
 	display: flex;
 	flex-wrap: wrap;

--- a/style.css
+++ b/style.css
@@ -2419,7 +2419,7 @@ p.has-text-color a {
 
 @media only screen and (min-width: 592px) {
 	.post-password-form__submit {
-		margin-left: 10px;
+		margin-left: calc(0.4 * var(--global--spacing-horizontal));
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -2408,12 +2408,14 @@ p.has-text-color a {
 }
 
 .post-password-form__input {
+	flex-grow: 1;
 	margin-top: calc(var(--global--spacing-vertical) / 3);
-	margin-right: calc(-1 * var(--button--border-width));
+	margin-right: calc(0.66 * var(--global--spacing-horizontal));
 }
 
 .post-password-form__submit {
 	margin-top: calc(var(--global--spacing-vertical) / 3);
+	margin-left: 10px;
 }
 
 .wp-block-pullquote {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes: #515 

## Summary
Wider input field to match other text inputs in the theme.
Updated copy: This content is password protected. Please enter a password to view.
Remove the `:` from the password form label to match other form labels in the theme.
Use the same spacing between the input field and button as the other forms in the theme.

## Screenshots

![screenshot-twentyone local-2020 10 16-11_56_41](https://user-images.githubusercontent.com/25550562/96220630-b1636100-0fa6-11eb-99ce-443b14810bcf.png)


If this is a visual change please include screenshots of the change at various screen sizes.