### PR TITLE
add export-ignore files & folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,26 @@
 *.jpg binary
 
 *.map linguist-generated
+
+.editorconfig export-ignore
+.eslintignore export-ignore
+.eslintrc export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.stylelintignore export-ignore
+.stylelintrc.json export-ignore
+.wp-env.json export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+CONTRIBUTING.md export-ignore
+CONTRIBUTORS.md export-ignore
+package-lock.json export-ignore
+package.json export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore
+postcss.config.js export-ignore
+README.md export-ignore
+style.css.map export-ignore
+.github/ export-ignore
+assets/css/*.map export-ignore
+assets/sass/ export-ignore


### PR DESCRIPTION
Makes it easier to get a working copy of the theme without all the dev files.
The package is then ready for inclusion in wp-core directly from the download link

![Screenshot_2020-10-16 WordPress twentytwentyone](https://user-images.githubusercontent.com/588688/96226125-d651d700-0f9a-11eb-98bd-94b3a59a490d.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
