### PR TITLE
Added dark theme preference

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -32,6 +32,17 @@
 	/* Widgets */
 }
 
+@media (prefers-color-scheme: dark) {
+	:root .has-default-light-palette-background {
+		background-color: #28303d;
+	}
+	@media (prefers-color-scheme: dark){
+		:root .has-default-light-palette-background{
+		background-color: #28303d;
+		}
+	}
+}
+
 /* Button extends */
 .wp-block-button__link {
 	line-height: 1.5;
@@ -46,26 +57,6 @@
 	text-decoration: none;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link{
-	color: #28303d;
-	}
-}
 .wp-block-file .wp-block-file__button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -78,26 +69,6 @@
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	color: #28303d;
-	}
 }
 .wp-block-search .wp-block-search__button {
 	line-height: 1.5;
@@ -112,26 +83,6 @@
 	text-decoration: none;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button{
-	color: #28303d;
-	}
-}
 
 .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
 	content: "";
@@ -141,27 +92,27 @@
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .wp-block-button__link:active {
@@ -169,33 +120,9 @@
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link:active{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file .wp-block-file__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:active{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-search .wp-block-search__button:active {
@@ -203,27 +130,9 @@
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:active{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-button__link:hover {
 	color: #39414d;
 	background: transparent;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link:hover{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-file .wp-block-file__button:hover {
@@ -231,21 +140,9 @@
 	background: transparent;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:hover{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-search .wp-block-search__button:hover {
 	color: #39414d;
 	background: transparent;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:hover{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
@@ -259,34 +156,16 @@
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link:disabled{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file .wp-block-file__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:disabled{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-search .wp-block-search__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:disabled{
-	color: #f0f0f0;
-	}
 }
 
 /**
@@ -362,22 +241,10 @@ blockquote cite {
 	letter-spacing: normal;
 }
 
-@media (prefers-color-scheme: dark){
-	blockquote cite{
-	color: #f0f0f0;
-	}
-}
-
 blockquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	letter-spacing: normal;
-}
-
-@media (prefers-color-scheme: dark){
-	blockquote footer{
-	color: #f0f0f0;
-	}
 }
 
 blockquote > * {
@@ -457,11 +324,6 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
-@media (prefers-color-scheme: dark){
-	figcaption{
-	color: #f0f0f0;
-	}
-}
 .wp-caption {
 	color: #28303d;
 	font-size: 1rem;
@@ -470,11 +332,6 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
-@media (prefers-color-scheme: dark){
-	.wp-caption{
-	color: #f0f0f0;
-	}
-}
 .wp-caption-text {
 	color: #28303d;
 	font-size: 1rem;
@@ -482,11 +339,6 @@ figcaption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
-}
-@media (prefers-color-scheme: dark){
-	.wp-caption-text{
-	color: #f0f0f0;
-	}
 }
 
 .alignleft figcaption,
@@ -525,18 +377,6 @@ select {
 	background-position: right 10px top 60%;
 }
 
-@media (prefers-color-scheme: dark){
-	select{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	select{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and
@@ -547,16 +387,6 @@ a {
 	color: #28303d;
 	text-underline-offset: 3px;
 	text-decoration-skip-ink: all;
-}
-@media (prefers-color-scheme: dark){
-	a{
-	color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	a{
-	color: #f0f0f0;
-	}
 }
 
 a:hover {
@@ -569,18 +399,6 @@ a:hover {
 	text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark){
-	.site a:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site a:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
@@ -591,32 +409,8 @@ a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button__link.is-style-outline {
@@ -625,42 +419,18 @@ a:hover {
 	border: 3px solid currentColor;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline{
-	color: #f0f0f0;
-	}
-}
-
 .is-style-outline .wp-block-button__link {
 	color: #39414d;
 	background: transparent;
 	border: 3px solid currentColor;
 }
 
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-button__link.is-style-outline:visited {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:visited{
-	color: #f0f0f0;
-	}
-}
-
 .is-style-outline .wp-block-button__link:visited {
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:visited{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button__link.is-style-outline:active {
@@ -669,58 +439,10 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:active{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:active{
-	background-color: #f0f0f0;
-	}
-}
-
 .wp-block-button__link.is-style-outline:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button__link.is-style-outline:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .is-style-outline .wp-block-button__link:active {
@@ -729,58 +451,10 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:active{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:active{
-	background-color: #f0f0f0;
-	}
-}
-
 .is-style-outline .wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus,
@@ -798,12 +472,6 @@ a:hover {
 .is-selected.is-style-outline .wp-block-button__link:hover {
 	background-color: transparent;
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.is-selected.is-style-outline .wp-block-button__link:hover{
-	color: #f0f0f0;
-	}
 }
 
 .is-style-outline .wp-block-button__link[style*="radius"],
@@ -851,128 +519,32 @@ a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover .block-editor-block-list__block .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .block-editor-block-list__block .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .block-editor-block-list__block .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover-image .wp-block-cover__inner-container .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover-image .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover-image .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover-image .block-editor-block-list__block .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .block-editor-block-list__block .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .block-editor-block-list__block .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container {
@@ -1056,32 +628,8 @@ a:hover {
 	border: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-cover-image.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-columns .wp-block,
@@ -1099,91 +647,41 @@ a:hover {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;
@@ -1257,18 +755,6 @@ a:hover {
 .wp-block-group.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
 	padding: 30px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-group.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-group.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-group .wp-block-group__inner-container *:last-child {
@@ -1716,28 +1202,8 @@ h6 {
 .wp-block-image.is-style-twentytwentyone-border img {
 	border: 3px solid #28303d;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-border img{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-border img{
-	border: 3px solid #f0f0f0;
-	}
-}
 .wp-block-image.is-style-twentytwentyone-image-frame img {
 	border: 3px solid #28303d;
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-image-frame img{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-image-frame img{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-image.is-style-twentytwentyone-image-frame img {
@@ -1807,22 +1273,10 @@ h6 {
 	line-height: 1.7;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts .wp-block-latest-posts__post-author{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts .wp-block-latest-posts__post-date{
-	color: #f0f0f0;
-	}
 }
 
 [class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
@@ -1849,30 +1303,6 @@ h6 {
 	border-bottom: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-bottom: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-bottom: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
@@ -1880,35 +1310,11 @@ h6 {
 	margin-bottom: 30px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
 	margin-top: 30px;
 	margin-bottom: 30px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li:last-child,
@@ -1920,24 +1326,6 @@ h6 {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid {
 	box-shadow: inset 0 -1px 0 0 #28303d;
 	border-bottom: 2px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	border-bottom: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	border-bottom: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	box-shadow: inset 0 -1px 0 0 #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid li {
@@ -1971,18 +1359,6 @@ h6 {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li {
 	border: 3px solid #28303d;
 	padding: 30px 25px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li:last-child {
@@ -2083,27 +1459,9 @@ dt {
 	border: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-media-text.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-media-text.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-navigation .wp-block-navigation__container {
 	background: #d1e4dd;
 	padding: 0;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation .wp-block-navigation__container{
-	background: #28303d;
-	}
 }
 
 .wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
@@ -2124,20 +1482,8 @@ dt {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -2165,24 +1511,6 @@ p.has-background {
 	border-bottom-width: 3px;
 	color: #28303d;
 	position: relative;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	border-bottom-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	border-top-color: #f0f0f0;
-	}
 }
 
 .wp-block-pullquote::before {
@@ -2221,12 +1549,6 @@ p.has-background {
 	text-transform: none;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote .wp-block-pullquote__citation{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-pullquote cite {
 	color: #28303d;
 	font-size: 1rem;
@@ -2234,23 +1556,11 @@ p.has-background {
 	text-transform: none;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote cite{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-pullquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	font-style: normal;
 	text-transform: none;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote footer{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {
@@ -2264,24 +1574,6 @@ p.has-background {
 	border-width: 3px;
 	border-style: solid;
 	border-color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	border-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	background-color: #28303d;
-	}
 }
 
 @media (min-width: 600px) {
@@ -2338,12 +1630,6 @@ p.has-background {
 	padding-left: 25px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote{
-	border-left-color: #f0f0f0;
-	}
-}
-
 .wp-block-quote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
@@ -2359,36 +1645,12 @@ p.has-background {
 	margin-bottom: 30px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large{
-	border-left: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large{
-	border-left: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-quote.is-style-large {
 	border-left: 1px solid #39414d;
 	padding-left: 25px;
 	/* Resetting margins to match _block-container.scss */
 	margin-top: 30px;
 	margin-bottom: 30px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large{
-	border-left: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large{
-	border-left: 1px solid #f0f0f0;
-	}
 }
 
 .wp-block-quote.is-large p {
@@ -2408,49 +1670,13 @@ p.has-background {
 	border-right: 1px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-quote.is-style-large.has-text-align-right {
 	border-left: none;
 	border-right: 1px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-quote.has-text-align-right {
 	border-right: 1px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
 }
 
 .wp-block-quote.has-text-align-center {
@@ -2467,12 +1693,6 @@ p.has-background {
 .wp-block-quote .wp-block-quote__citation {
 	color: #28303d;
 	font-size: 1rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote .wp-block-quote__citation{
-	color: #f0f0f0;
-	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -2558,22 +1778,10 @@ p.has-background {
 	line-height: 1.7;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-rss .wp-block-rss__item-author{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-rss .wp-block-rss__item-publish-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-rss .wp-block-rss__item-publish-date{
-	color: #f0f0f0;
-	}
 }
 
 [class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
@@ -2639,26 +1847,8 @@ p.has-background {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-search .wp-block-search__input:focus {
 	border-color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input:focus{
-	border-color: #f0f0f0;
-	}
 }
 
 .wp-block-search .wp-block-search__button {
@@ -2668,27 +1858,9 @@ p.has-background {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-search .wp-block-search__button:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__button:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .wp-block-separator {
@@ -2697,74 +1869,26 @@ p.has-background {
 	opacity: 1;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-separator{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-separator{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 hr {
 	border-bottom: 1px solid #28303d;
 	clear: both;
 	opacity: 1;
 }
 
-@media (prefers-color-scheme: dark){
-	hr{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	hr{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-separator[style*="text-align:right"] {
 	border-right-color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-separator[style*="text-align:right"]{
-	border-right-color: #f0f0f0;
-	}
 }
 
 .wp-block-separator[style*="text-align: right"] {
 	border-right-color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-separator[style*="text-align: right"]{
-	border-right-color: #f0f0f0;
-	}
-}
-
 hr[style*="text-align:right"] {
 	border-right-color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	hr[style*="text-align:right"]{
-	border-right-color: #f0f0f0;
-	}
-}
-
 hr[style*="text-align: right"] {
 	border-right-color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	hr[style*="text-align: right"]{
-	border-right-color: #f0f0f0;
-	}
 }
 
 .wp-block-separator:not(.is-style-dots),
@@ -2801,20 +1925,8 @@ hr.is-style-dots.has-text-color:before {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-separator.is-style-dots:before{
-	color: #f0f0f0;
-	}
-}
-
 hr.is-style-dots:before {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	hr.is-style-dots:before{
-	color: #f0f0f0;
-	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-separator,
@@ -2837,12 +1949,6 @@ hr {
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-social-links.is-style-twentytwentyone-social-icons-color button{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
@@ -3135,11 +2241,6 @@ pre.wp-block-verse {
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
-@media (prefers-color-scheme: dark){
-	.wp-block.editor-post-title__block{
-	border-bottom: 3px solid #f0f0f0;
-	}
-}
 
 .wp-block.editor-post-title__block .editor-post-title__input {
 	color: #39414d;
@@ -3155,12 +2256,6 @@ pre.wp-block-verse {
 	}
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block.editor-post-title__block .editor-post-title__input{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block.block-editor-default-block-appender > textarea {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
@@ -3170,20 +2265,8 @@ pre.wp-block-verse {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-primary-color[class]{
-	color: #f0f0f0;
-	}
-}
-
 .has-secondary-color[class] {
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-secondary-color[class]{
-	color: #f0f0f0;
-	}
 }
 
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
@@ -3202,33 +2285,9 @@ pre.wp-block-verse {
 	color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-primary-background-color[class]{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-primary-background-color[class]{
-	background-color: #f0f0f0;
-	}
-}
-
 .has-secondary-background-color[class] {
 	background-color: #39414d;
 	color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-secondary-background-color[class]{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-secondary-background-color[class]{
-	background-color: #f0f0f0;
-	}
 }
 
 .has-white-background-color[class] {
@@ -3236,21 +2295,9 @@ pre.wp-block-verse {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-white-background-color[class]{
-	color: #f0f0f0;
-	}
-}
-
 .has-black-background-color[class] {
 	background-color: #000;
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-black-background-color[class]{
-	color: #f0f0f0;
-	}
 }
 
 /**
@@ -3371,32 +2418,8 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
-@media (prefers-color-scheme: dark){
-	body{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	body{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block a:hover {
@@ -3408,48 +2431,12 @@ body {
 	text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block a:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block a:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
 .has-background:not(.has-background-background-color) .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 button,

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -15,7 +15,6 @@
 	/* Headings */
 	/* Mint, default body background */
 	/* Used for borders (separators) */
-	/* OS dark theme preference */
 	/* Spacing */
 	/* Elevation */
 	/* Forms */
@@ -32,12 +31,13 @@
 	/* Widgets */
 }
 
+/* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	:root .has-default-light-palette-background {
+	html.has-default-light-palette-background body {
 		background-color: #28303d;
 	}
 	@media (prefers-color-scheme: dark){
-		:root .has-default-light-palette-background{
+		html.has-default-light-palette-background body{
 		background-color: #28303d;
 		}
 	}

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -15,6 +15,7 @@
 	/* Headings */
 	/* Mint, default body background */
 	/* Used for borders (separators) */
+	/* OS dark theme preference */
 	/* Spacing */
 	/* Elevation */
 	/* Forms */
@@ -45,6 +46,26 @@
 	text-decoration: none;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link{
+	color: #28303d;
+	}
+}
 .wp-block-file .wp-block-file__button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -57,6 +78,26 @@
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	color: #28303d;
+	}
 }
 .wp-block-search .wp-block-search__button {
 	line-height: 1.5;
@@ -71,6 +112,26 @@
 	text-decoration: none;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button{
+	color: #28303d;
+	}
+}
 
 .wp-block-button__link:before, .wp-block-file .wp-block-file__button:before, .wp-block-search .wp-block-search__button:before, .wp-block-button__link:after, .wp-block-file .wp-block-file__button:after, .wp-block-search .wp-block-search__button:after {
 	content: "";
@@ -80,27 +141,27 @@
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:active {
@@ -108,9 +169,33 @@
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link:active{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file .wp-block-file__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:active{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-search .wp-block-search__button:active {
@@ -118,9 +203,27 @@
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:active{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-button__link:hover {
 	color: #39414d;
 	background: transparent;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link:hover{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-file .wp-block-file__button:hover {
@@ -128,9 +231,21 @@
 	background: transparent;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:hover{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-search .wp-block-search__button:hover {
 	color: #39414d;
 	background: transparent;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:hover{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button__link:focus, .wp-block-file .wp-block-file__button:focus, .wp-block-search .wp-block-search__button:focus, .has-focus.wp-block-button__link, .wp-block-file .has-focus.wp-block-file__button, .wp-block-search .has-focus.wp-block-search__button {
@@ -144,16 +259,34 @@
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link:disabled{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file .wp-block-file__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:disabled{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-search .wp-block-search__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:disabled{
+	color: #f0f0f0;
+	}
 }
 
 /**
@@ -229,10 +362,22 @@ blockquote cite {
 	letter-spacing: normal;
 }
 
+@media (prefers-color-scheme: dark){
+	blockquote cite{
+	color: #f0f0f0;
+	}
+}
+
 blockquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	letter-spacing: normal;
+}
+
+@media (prefers-color-scheme: dark){
+	blockquote footer{
+	color: #f0f0f0;
+	}
 }
 
 blockquote > * {
@@ -312,6 +457,11 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
+@media (prefers-color-scheme: dark){
+	figcaption{
+	color: #f0f0f0;
+	}
+}
 .wp-caption {
 	color: #28303d;
 	font-size: 1rem;
@@ -320,6 +470,11 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
+@media (prefers-color-scheme: dark){
+	.wp-caption{
+	color: #f0f0f0;
+	}
+}
 .wp-caption-text {
 	color: #28303d;
 	font-size: 1rem;
@@ -327,6 +482,11 @@ figcaption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
+}
+@media (prefers-color-scheme: dark){
+	.wp-caption-text{
+	color: #f0f0f0;
+	}
 }
 
 .alignleft figcaption,
@@ -365,6 +525,18 @@ select {
 	background-position: right 10px top 60%;
 }
 
+@media (prefers-color-scheme: dark){
+	select{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	select{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and
@@ -375,6 +547,16 @@ a {
 	color: #28303d;
 	text-underline-offset: 3px;
 	text-decoration-skip-ink: all;
+}
+@media (prefers-color-scheme: dark){
+	a{
+	color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	a{
+	color: #f0f0f0;
+	}
 }
 
 a:hover {
@@ -387,6 +569,18 @@ a:hover {
 	text-decoration: none;
 }
 
+@media (prefers-color-scheme: dark){
+	.site a:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site a:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
@@ -397,8 +591,32 @@ a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button__link.is-style-outline {
@@ -407,18 +625,42 @@ a:hover {
 	border: 3px solid currentColor;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline{
+	color: #f0f0f0;
+	}
+}
+
 .is-style-outline .wp-block-button__link {
 	color: #39414d;
 	background: transparent;
 	border: 3px solid currentColor;
 }
 
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-button__link.is-style-outline:visited {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:visited{
+	color: #f0f0f0;
+	}
+}
+
 .is-style-outline .wp-block-button__link:visited {
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:visited{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button__link.is-style-outline:active {
@@ -427,10 +669,58 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:active{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:active{
+	background-color: #f0f0f0;
+	}
+}
+
 .wp-block-button__link.is-style-outline:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button__link.is-style-outline:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .is-style-outline .wp-block-button__link:active {
@@ -439,10 +729,58 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:active{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:active{
+	background-color: #f0f0f0;
+	}
+}
+
 .is-style-outline .wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus,
@@ -460,6 +798,12 @@ a:hover {
 .is-selected.is-style-outline .wp-block-button__link:hover {
 	background-color: transparent;
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.is-selected.is-style-outline .wp-block-button__link:hover{
+	color: #f0f0f0;
+	}
 }
 
 .is-style-outline .wp-block-button__link[style*="radius"],
@@ -507,32 +851,128 @@ a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover .block-editor-block-list__block .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .block-editor-block-list__block .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .block-editor-block-list__block .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover-image .wp-block-cover__inner-container .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover-image .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover-image .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover-image .block-editor-block-list__block .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .block-editor-block-list__block .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .block-editor-block-list__block .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container {
@@ -616,8 +1056,32 @@ a:hover {
 	border: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-cover-image.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-columns .wp-block,
@@ -635,41 +1099,91 @@ a:hover {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;
@@ -743,6 +1257,18 @@ a:hover {
 .wp-block-group.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
 	padding: 30px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-group.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-group.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-group .wp-block-group__inner-container *:last-child {
@@ -1190,8 +1716,28 @@ h6 {
 .wp-block-image.is-style-twentytwentyone-border img {
 	border: 3px solid #28303d;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-border img{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-border img{
+	border: 3px solid #f0f0f0;
+	}
+}
 .wp-block-image.is-style-twentytwentyone-image-frame img {
 	border: 3px solid #28303d;
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-image-frame img{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-image-frame img{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-image.is-style-twentytwentyone-image-frame img {
@@ -1261,10 +1807,22 @@ h6 {
 	line-height: 1.7;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts .wp-block-latest-posts__post-author{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts .wp-block-latest-posts__post-date{
+	color: #f0f0f0;
+	}
 }
 
 [class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
@@ -1291,6 +1849,30 @@ h6 {
 	border-bottom: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-bottom: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-bottom: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
@@ -1298,11 +1880,35 @@ h6 {
 	margin-bottom: 30px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
 	margin-top: 30px;
 	margin-bottom: 30px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li:last-child,
@@ -1314,6 +1920,24 @@ h6 {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid {
 	box-shadow: inset 0 -1px 0 0 #28303d;
 	border-bottom: 2px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	border-bottom: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	border-bottom: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	box-shadow: inset 0 -1px 0 0 #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid li {
@@ -1347,6 +1971,18 @@ h6 {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li {
 	border: 3px solid #28303d;
 	padding: 30px 25px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li:last-child {
@@ -1447,9 +2083,27 @@ dt {
 	border: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-media-text.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-media-text.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-navigation .wp-block-navigation__container {
 	background: #d1e4dd;
 	padding: 0;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation .wp-block-navigation__container{
+	background: #28303d;
+	}
 }
 
 .wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
@@ -1470,8 +2124,20 @@ dt {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -1499,6 +2165,24 @@ p.has-background {
 	border-bottom-width: 3px;
 	color: #28303d;
 	position: relative;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	border-bottom-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	border-top-color: #f0f0f0;
+	}
 }
 
 .wp-block-pullquote::before {
@@ -1537,6 +2221,12 @@ p.has-background {
 	text-transform: none;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote .wp-block-pullquote__citation{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-pullquote cite {
 	color: #28303d;
 	font-size: 1rem;
@@ -1544,11 +2234,23 @@ p.has-background {
 	text-transform: none;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote cite{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-pullquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	font-style: normal;
 	text-transform: none;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote footer{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {
@@ -1562,6 +2264,24 @@ p.has-background {
 	border-width: 3px;
 	border-style: solid;
 	border-color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	border-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	background-color: #28303d;
+	}
 }
 
 @media (min-width: 600px) {
@@ -1618,6 +2338,12 @@ p.has-background {
 	padding-left: 25px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote{
+	border-left-color: #f0f0f0;
+	}
+}
+
 .wp-block-quote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
@@ -1633,12 +2359,36 @@ p.has-background {
 	margin-bottom: 30px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large{
+	border-left: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large{
+	border-left: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-quote.is-style-large {
 	border-left: 1px solid #39414d;
 	padding-left: 25px;
 	/* Resetting margins to match _block-container.scss */
 	margin-top: 30px;
 	margin-bottom: 30px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large{
+	border-left: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large{
+	border-left: 1px solid #f0f0f0;
+	}
 }
 
 .wp-block-quote.is-large p {
@@ -1658,13 +2408,49 @@ p.has-background {
 	border-right: 1px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-quote.is-style-large.has-text-align-right {
 	border-left: none;
 	border-right: 1px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-quote.has-text-align-right {
 	border-right: 1px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
 }
 
 .wp-block-quote.has-text-align-center {
@@ -1681,6 +2467,12 @@ p.has-background {
 .wp-block-quote .wp-block-quote__citation {
 	color: #28303d;
 	font-size: 1rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote .wp-block-quote__citation{
+	color: #f0f0f0;
+	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -1766,10 +2558,22 @@ p.has-background {
 	line-height: 1.7;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-rss .wp-block-rss__item-author{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-rss .wp-block-rss__item-publish-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-rss .wp-block-rss__item-publish-date{
+	color: #f0f0f0;
+	}
 }
 
 [class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
@@ -1835,8 +2639,26 @@ p.has-background {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-search .wp-block-search__input:focus {
 	border-color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input:focus{
+	border-color: #f0f0f0;
+	}
 }
 
 .wp-block-search .wp-block-search__button {
@@ -1846,9 +2668,27 @@ p.has-background {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-search .wp-block-search__button:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__button:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .wp-block-separator {
@@ -1857,26 +2697,74 @@ p.has-background {
 	opacity: 1;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-separator{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-separator{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 hr {
 	border-bottom: 1px solid #28303d;
 	clear: both;
 	opacity: 1;
 }
 
+@media (prefers-color-scheme: dark){
+	hr{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	hr{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-separator[style*="text-align:right"] {
 	border-right-color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-separator[style*="text-align:right"]{
+	border-right-color: #f0f0f0;
+	}
 }
 
 .wp-block-separator[style*="text-align: right"] {
 	border-right-color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-separator[style*="text-align: right"]{
+	border-right-color: #f0f0f0;
+	}
+}
+
 hr[style*="text-align:right"] {
 	border-right-color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	hr[style*="text-align:right"]{
+	border-right-color: #f0f0f0;
+	}
+}
+
 hr[style*="text-align: right"] {
 	border-right-color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	hr[style*="text-align: right"]{
+	border-right-color: #f0f0f0;
+	}
 }
 
 .wp-block-separator:not(.is-style-dots),
@@ -1913,8 +2801,20 @@ hr.is-style-dots.has-text-color:before {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-separator.is-style-dots:before{
+	color: #f0f0f0;
+	}
+}
+
 hr.is-style-dots:before {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	hr.is-style-dots:before{
+	color: #f0f0f0;
+	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-separator,
@@ -1937,6 +2837,12 @@ hr {
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-social-links.is-style-twentytwentyone-social-icons-color button{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
@@ -2229,6 +3135,11 @@ pre.wp-block-verse {
 	max-width: min(calc(100vw - 200px), 1240px);
 	}
 }
+@media (prefers-color-scheme: dark){
+	.wp-block.editor-post-title__block{
+	border-bottom: 3px solid #f0f0f0;
+	}
+}
 
 .wp-block.editor-post-title__block .editor-post-title__input {
 	color: #39414d;
@@ -2244,6 +3155,12 @@ pre.wp-block-verse {
 	}
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block.editor-post-title__block .editor-post-title__input{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block.block-editor-default-block-appender > textarea {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.25rem;
@@ -2253,8 +3170,20 @@ pre.wp-block-verse {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-primary-color[class]{
+	color: #f0f0f0;
+	}
+}
+
 .has-secondary-color[class] {
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-secondary-color[class]{
+	color: #f0f0f0;
+	}
 }
 
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
@@ -2273,9 +3202,33 @@ pre.wp-block-verse {
 	color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-primary-background-color[class]{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-primary-background-color[class]{
+	background-color: #f0f0f0;
+	}
+}
+
 .has-secondary-background-color[class] {
 	background-color: #39414d;
 	color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-secondary-background-color[class]{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-secondary-background-color[class]{
+	background-color: #f0f0f0;
+	}
 }
 
 .has-white-background-color[class] {
@@ -2283,9 +3236,21 @@ pre.wp-block-verse {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-white-background-color[class]{
+	color: #f0f0f0;
+	}
+}
+
 .has-black-background-color[class] {
 	background-color: #000;
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-black-background-color[class]{
+	color: #f0f0f0;
+	}
 }
 
 /**
@@ -2406,8 +3371,32 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
+@media (prefers-color-scheme: dark){
+	body{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	body{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block a:hover {
@@ -2419,12 +3408,48 @@ body {
 	text-decoration: none;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block a:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block a:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
 .has-background:not(.has-background-background-color) .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 button,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -107,6 +107,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Headings */
 	/* Mint, default body background */
 	/* Used for borders (separators) */
+	/* OS dark theme preference */
 	/* Spacing */
 	/* Elevation */
 	/* Forms */
@@ -137,6 +138,26 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	text-decoration: none;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
+	color: #28303d;
+	}
+}
 .site .button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -149,6 +170,26 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
+}
+@media (prefers-color-scheme: dark){
+	.site .button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site .button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site .button{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.site .button{
+	color: #28303d;
+	}
 }
 input[type="submit"] {
 	line-height: 1.5;
@@ -163,6 +204,26 @@ input[type="submit"] {
 	text-decoration: none;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	input[type="submit"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="submit"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="submit"]{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="submit"]{
+	color: #28303d;
+	}
+}
 input[type="reset"] {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -175,6 +236,26 @@ input[type="reset"] {
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
+}
+@media (prefers-color-scheme: dark){
+	input[type="reset"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="reset"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="reset"]{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	input[type="reset"]{
+	color: #28303d;
+	}
 }
 .wp-block-button .wp-block-button__link {
 	line-height: 1.5;
@@ -189,6 +270,26 @@ input[type="reset"] {
 	text-decoration: none;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link{
+	color: #28303d;
+	}
+}
 .wp-block-file .wp-block-file__button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -201,6 +302,26 @@ input[type="reset"] {
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	border: 3px solid #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	background-color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button{
+	color: #28303d;
+	}
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before,
@@ -219,51 +340,51 @@ input[type="reset"]:after,
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -271,9 +392,33 @@ input[type="reset"]:after {
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button){
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button){
+	color: #f0f0f0;
+	}
+}
+
 .site .button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.site .button:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site .button:active{
+	color: #f0f0f0;
+	}
 }
 
 input:active[type="submit"] {
@@ -281,9 +426,33 @@ input:active[type="submit"] {
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	input:active[type="submit"]{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input:active[type="submit"]{
+	color: #f0f0f0;
+	}
+}
+
 input:active[type="reset"] {
 	color: #39414d;
 	background-color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	input:active[type="reset"]{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input:active[type="reset"]{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button .wp-block-button__link:active {
@@ -291,9 +460,33 @@ input:active[type="reset"] {
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link:active{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file .wp-block-file__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:active{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:active{
+	color: #f0f0f0;
+	}
 }
 
 .site button.mejs-inner:hover:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -301,9 +494,21 @@ input:active[type="reset"] {
 	background: transparent;
 }
 
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:hover:not(.customize-partial-edit-shortcut-button):not(button){
+	color: #f0f0f0;
+	}
+}
+
 .site .button:hover {
 	color: #39414d;
 	background: transparent;
+}
+
+@media (prefers-color-scheme: dark){
+	.site .button:hover{
+	color: #f0f0f0;
+	}
 }
 
 input:hover[type="submit"] {
@@ -311,9 +516,21 @@ input:hover[type="submit"] {
 	background: transparent;
 }
 
+@media (prefers-color-scheme: dark){
+	input:hover[type="submit"]{
+	color: #f0f0f0;
+	}
+}
+
 input:hover[type="reset"] {
 	color: #39414d;
 	background: transparent;
+}
+
+@media (prefers-color-scheme: dark){
+	input:hover[type="reset"]{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button .wp-block-button__link:hover {
@@ -321,9 +538,21 @@ input:hover[type="reset"] {
 	background: transparent;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link:hover{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file .wp-block-file__button:hover {
 	color: #39414d;
 	background: transparent;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:hover{
+	color: #f0f0f0;
+	}
 }
 
 .site button.mejs-inner:focus:not(.customize-partial-edit-shortcut-button):not(button),
@@ -345,10 +574,22 @@ input.has-focus[type="reset"],
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site button.mejs-inner:disabled:not(.customize-partial-edit-shortcut-button):not(button){
+	color: #f0f0f0;
+	}
+}
+
 .site .button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site .button:disabled{
+	color: #f0f0f0;
+	}
 }
 
 input:disabled[type="submit"] {
@@ -357,10 +598,22 @@ input:disabled[type="submit"] {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	input:disabled[type="submit"]{
+	color: #f0f0f0;
+	}
+}
+
 input:disabled[type="reset"] {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	input:disabled[type="reset"]{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button .wp-block-button__link:disabled {
@@ -369,10 +622,22 @@ input:disabled[type="reset"] {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button .wp-block-button__link:disabled{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file .wp-block-file__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file .wp-block-file__button:disabled{
+	color: #f0f0f0;
+	}
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -1063,23 +1328,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -1089,21 +1354,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -1429,6 +1694,18 @@ body {
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	body{
+	background-color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	body{
+	color: #f0f0f0;
+	}
+}
+
 button {
 	cursor: pointer;
 }
@@ -1477,10 +1754,22 @@ blockquote cite {
 	letter-spacing: normal;
 }
 
+@media (prefers-color-scheme: dark){
+	blockquote cite{
+	color: #f0f0f0;
+	}
+}
+
 blockquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	letter-spacing: normal;
+}
+
+@media (prefers-color-scheme: dark){
+	blockquote footer{
+	color: #f0f0f0;
+	}
 }
 
 blockquote > * {
@@ -1541,6 +1830,18 @@ input[type="text"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="text"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="text"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="email"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1548,6 +1849,18 @@ input[type="email"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="email"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="email"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="url"] {
@@ -1559,6 +1872,18 @@ input[type="url"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="url"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="url"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="password"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1566,6 +1891,18 @@ input[type="password"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="password"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="password"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="search"] {
@@ -1577,6 +1914,18 @@ input[type="search"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="search"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="search"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="number"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1584,6 +1933,18 @@ input[type="number"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="number"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="number"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="tel"] {
@@ -1595,6 +1956,18 @@ input[type="tel"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="tel"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="tel"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="date"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1602,6 +1975,18 @@ input[type="date"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="date"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="date"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="month"] {
@@ -1613,6 +1998,18 @@ input[type="month"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="month"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="month"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="week"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1620,6 +2017,18 @@ input[type="week"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="week"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="week"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="time"] {
@@ -1631,6 +2040,18 @@ input[type="time"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="time"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="time"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="datetime"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1638,6 +2059,18 @@ input[type="datetime"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="datetime"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="datetime"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 input[type="datetime-local"] {
@@ -1649,6 +2082,18 @@ input[type="datetime-local"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="datetime-local"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="datetime-local"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="color"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1656,6 +2101,18 @@ input[type="color"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="color"]{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="color"]{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .site textarea {
@@ -1667,10 +2124,28 @@ input[type="color"] {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	.site textarea{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site textarea{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 input[type="text"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="text"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="email"]:focus {
@@ -1679,10 +2154,22 @@ input[type="email"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="email"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="url"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="url"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="password"]:focus {
@@ -1691,10 +2178,22 @@ input[type="password"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="password"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="search"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="search"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="number"]:focus {
@@ -1703,10 +2202,22 @@ input[type="number"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="number"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="tel"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="tel"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="date"]:focus {
@@ -1715,10 +2226,22 @@ input[type="date"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="date"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="month"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="month"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="week"]:focus {
@@ -1727,10 +2250,22 @@ input[type="week"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="week"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="time"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="time"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="datetime"]:focus {
@@ -1739,10 +2274,22 @@ input[type="datetime"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="datetime"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 input[type="datetime-local"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="datetime-local"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="color"]:focus {
@@ -1751,10 +2298,22 @@ input[type="color"]:focus {
 	background: #fff;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="color"]:focus{
+	outline: 1px solid #f0f0f0;
+	}
+}
+
 .site textarea:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
+}
+
+@media (prefers-color-scheme: dark){
+	.site textarea:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 input[type="text"]:disabled,
@@ -1803,8 +2362,26 @@ select {
 	background-position: right 10px top 60%;
 }
 
+@media (prefers-color-scheme: dark){
+	select{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	select{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 select:focus {
 	outline: 1px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	select:focus{
+	outline: 1px solid #f0f0f0;
+	}
 }
 
 textarea {
@@ -1833,6 +2410,16 @@ License: MIT.
 		border: 3px solid #39414d;
 		outline-offset: 0;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="checkbox"]{
+		border: 3px solid #f0f0f0;
+		}
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="checkbox"]{
+		border: 3px solid #f0f0f0;
+		}
+	}
 	input[type="radio"] {
 		-webkit-appearance: none;
 		-moz-appearance: none;
@@ -1843,6 +2430,16 @@ License: MIT.
 		border: 3px solid #39414d;
 		outline-offset: 0;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="radio"]{
+		border: 3px solid #f0f0f0;
+		}
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="radio"]{
+		border: 3px solid #f0f0f0;
+		}
+	}
 	input[type="checkbox"]:disabled,
 	input[type="radio"]:disabled {
 		opacity: 0.7;
@@ -1850,6 +2447,11 @@ License: MIT.
 	input[type="checkbox"]:focus {
 		outline: 1px solid #39414d;
 		background: #fff;
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="checkbox"]:focus{
+		outline: 1px solid #f0f0f0;
+		}
 	}
 	input[type="checkbox"]:after {
 		content: "";
@@ -1880,6 +2482,11 @@ License: MIT.
 		border: 4px solid #39414d;
 		outline: 1px dotted transparent;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="radio"]:focus{
+		border: 4px solid #f0f0f0;
+		}
+	}
 	input[type="radio"]:after {
 		content: "";
 		opacity: 0;
@@ -1897,11 +2504,21 @@ License: MIT.
 		border: 4px solid #39414d;
 		outline: 1px dotted transparent;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="radio"]:checked{
+		border: 4px solid #f0f0f0;
+		}
+	}
 	input[type="radio"]:checked:after {
 		opacity: 1;
 	}
 	input[type="radio"]:checked:focus {
 		box-shadow: 0 0 0 2px #39414d;
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="radio"]:checked:focus{
+		box-shadow: 0 0 0 2px #f0f0f0;
+		}
 	}
 }
 
@@ -1933,6 +2550,11 @@ input[type="radio"] + label {
 		border-radius: 6px;
 		outline-offset: 10px;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="range"]{
+		background: #f0f0f0;
+		}
+	}
 	input[type="range"]:disabled {
 		opacity: 0.7;
 	}
@@ -1945,6 +2567,16 @@ input[type="radio"] + label {
 		background: #d1e4dd;
 		cursor: pointer;
 	}
+	@media (prefers-color-scheme: dark){
+		input[type="range"]::-webkit-slider-thumb{
+		background: #28303d;
+		}
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="range"]::-webkit-slider-thumb{
+		border: 3px solid #f0f0f0;
+		}
+	}
 	input[type="range"]::-moz-range-thumb {
 		border: 3px solid #39414d;
 		height: 25px;
@@ -1952,6 +2584,16 @@ input[type="radio"] + label {
 		border-radius: 50%;
 		background: #d1e4dd;
 		cursor: pointer;
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="range"]::-moz-range-thumb{
+		background: #28303d;
+		}
+	}
+	@media (prefers-color-scheme: dark){
+		input[type="range"]::-moz-range-thumb{
+		border: 3px solid #f0f0f0;
+		}
 	}
 }
 
@@ -1966,14 +2608,32 @@ input[type="range"]::-ms-track {
 	cursor: pointer;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="range"]::-ms-track{
+	border-color: #28303d;
+	}
+}
+
 input[type="range"]::-ms-fill-upper {
 	background: #39414d;
 	border-radius: 6px;
 }
 
+@media (prefers-color-scheme: dark){
+	input[type="range"]::-ms-fill-upper{
+	background: #f0f0f0;
+	}
+}
+
 input[type="range"]::-ms-fill-lower {
 	background: #39414d;
 	border-radius: 6px;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="range"]::-ms-fill-lower{
+	background: #f0f0f0;
+	}
 }
 
 input[type="range"]::-ms-thumb {
@@ -1983,6 +2643,18 @@ input[type="range"]::-ms-thumb {
 	border-radius: 50%;
 	background: #d1e4dd;
 	cursor: pointer;
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="range"]::-ms-thumb{
+	background: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	input[type="range"]::-ms-thumb{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 img {
@@ -2013,6 +2685,11 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
+@media (prefers-color-scheme: dark){
+	figcaption{
+	color: #f0f0f0;
+	}
+}
 .wp-caption {
 	color: #28303d;
 	font-size: 1rem;
@@ -2021,6 +2698,11 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
+@media (prefers-color-scheme: dark){
+	.wp-caption{
+	color: #f0f0f0;
+	}
+}
 .wp-caption-text {
 	color: #28303d;
 	font-size: 1rem;
@@ -2028,6 +2710,11 @@ figcaption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
+}
+@media (prefers-color-scheme: dark){
+	.wp-caption-text{
+	color: #f0f0f0;
+	}
 }
 
 .alignleft figcaption,
@@ -2079,6 +2766,16 @@ a {
 	text-underline-offset: 3px;
 	text-decoration-skip-ink: all;
 }
+@media (prefers-color-scheme: dark){
+	a{
+	color: #f0f0f0;
+	}
+}
+@media (prefers-color-scheme: dark){
+	a{
+	color: #f0f0f0;
+	}
+}
 
 a:hover {
 	text-decoration-style: dotted;
@@ -2088,6 +2785,18 @@ a:hover {
 .site a:focus {
 	outline: 2px solid #28303d;
 	text-decoration: none;
+}
+
+@media (prefers-color-scheme: dark){
+	.site a:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site a:focus{
+	outline: 2px solid #f0f0f0;
+	}
 }
 
 .site a:focus.skip-link {
@@ -2100,14 +2809,43 @@ a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color) .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.has-background:not(.has-background-background-color).has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 /* Category 05 is all about adjusting the default block styles to the given layout. I only added three blocks as examples. */
 .wp-block-audio audio:focus {
 	outline-offset: 5px;
 	outline: 2px solid #28303d;
+}
+@media (prefers-color-scheme: dark){
+	.wp-block-audio audio:focus{
+	outline: 2px solid #f0f0f0;
+	}
 }
 
 /**
@@ -2122,19 +2860,41 @@ a:hover {
 	border: 3px solid currentColor;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link{
+	color: #f0f0f0;
+	}
+}
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: #39414d;
 	background: transparent;
 	border: 3px solid currentColor;
 	padding: 15px 30px;
 }
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link{
+	color: #f0f0f0;
+	}
+}
 
 .wp-block-button.is-style-outline.wp-block-button__link:visited {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:visited{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link:visited {
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:visited{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:active {
@@ -2143,10 +2903,58 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:active{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:active{
+	background-color: #f0f0f0;
+	}
+}
+
 .wp-block-button.is-style-outline.wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:active {
@@ -2155,10 +2963,58 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:active{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:active{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:active{
+	background-color: #f0f0f0;
+	}
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:hover{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:focus {
@@ -2168,11 +3024,35 @@ a:hover {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:focus{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link:focus{
+	outline: 2px dotted #f0f0f0;
+	}
+}
+
 .wp-block-button.is-style-outline.wp-block-button__link.has-focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted #39414d;
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link.has-focus{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline.wp-block-button__link.has-focus{
+	outline: 2px dotted #f0f0f0;
+	}
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:focus {
@@ -2182,11 +3062,35 @@ a:hover {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:focus{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link:focus{
+	outline: 2px dotted #f0f0f0;
+	}
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted #39414d;
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link.has-focus{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button.is-style-outline .wp-block-button__link.has-focus{
+	outline: 2px dotted #f0f0f0;
+	}
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {
@@ -2198,9 +3102,21 @@ a:hover {
 	outline: 2px dotted #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.is-style-outline .wp-block-button__link[style*="radius"]:focus{
+	outline: 2px dotted #f0f0f0;
+	}
+}
+
 .wp-block-button a.wp-block-button__link[style*="radius"]:focus {
 	outline-offset: 2px;
 	outline: 2px dotted #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-button a.wp-block-button__link[style*="radius"]:focus{
+	outline: 2px dotted #f0f0f0;
+	}
 }
 
 .wp-block-code {
@@ -2210,8 +3126,26 @@ a:hover {
 	border-color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-code{
+	border-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-code{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-code pre {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-code pre{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-columns .wp-block-column > * {
@@ -2268,41 +3202,91 @@ a:hover {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background){
+		background-color: #28303d;
+		}
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	@media (prefers-color-scheme: dark){
+		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background){
+		background-color: #28303d;
+		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;
@@ -2419,24 +3403,96 @@ a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover-image .wp-block-cover__inner-container .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover-image .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-cover-image .wp-block-cover-text .has-link-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container {
@@ -2595,8 +3651,32 @@ a:hover {
 	border: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-cover.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-cover-image.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-cover-image.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-file a.wp-block-file__button:active {
@@ -2604,9 +3684,21 @@ a:hover {
 	opacity: inherit;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-file a.wp-block-file__button:active{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file a.wp-block-file__button:focus {
 	color: #39414d;
 	opacity: inherit;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file a.wp-block-file__button:focus{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-file a.wp-block-file__button:hover {
@@ -2614,9 +3706,21 @@ a:hover {
 	opacity: inherit;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-file a.wp-block-file__button:hover{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-file a.wp-block-file__button:visited {
 	color: #39414d;
 	opacity: inherit;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-file a.wp-block-file__button:visited{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-file .wp-block-file__button {
@@ -2628,11 +3732,11 @@ a:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -2685,6 +3789,18 @@ a:hover {
 .wp-block-group.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
 	padding: 30px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-group.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-group.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 h1 {
@@ -2934,6 +4050,12 @@ h6 {
 	text-align: center;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-image figcaption{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-image .alignright {
 	margin-left: 25px;
 }
@@ -2963,8 +4085,32 @@ img {
 	border: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-border img{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-border img{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-image.is-style-twentytwentyone-image-frame img {
 	border: 3px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-image-frame img{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-image.is-style-twentytwentyone-image-frame img{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-image.is-style-twentytwentyone-image-frame img {
@@ -2998,6 +4144,12 @@ img {
 .wp-block-latest-comments .wp-block-latest-comments__comment-date {
 	color: #28303d;
 	font-size: 1.125rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-comments .wp-block-latest-comments__comment-date{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
@@ -3078,10 +4230,22 @@ img {
 	line-height: 1.7;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts .wp-block-latest-posts__post-author{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts .wp-block-latest-posts__post-date{
+	color: #f0f0f0;
+	}
 }
 
 [class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
@@ -3119,6 +4283,30 @@ img {
 	border-bottom: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-bottom: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-bottom: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
@@ -3126,11 +4314,35 @@ img {
 	margin-bottom: 30px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
 	margin-top: 30px;
 	margin-bottom: 30px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
+	border-bottom: 1px solid #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li:last-child,
@@ -3142,6 +4354,24 @@ img {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid {
 	box-shadow: inset 0 -1px 0 0 #28303d;
 	border-bottom: 2px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	border-bottom: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	border-bottom: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
+	box-shadow: inset 0 -1px 0 0 #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid li {
@@ -3175,6 +4405,18 @@ img {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li {
 	border: 3px solid #28303d;
 	padding: 30px 25px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
+	border: 3px solid #f0f0f0;
+	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li:last-child {
@@ -3323,6 +4565,18 @@ dd {
 	border: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-media-text.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-media-text.is-style-twentytwentyone-border{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-navigation .wp-block-navigation-link {
 	padding: 0;
 }
@@ -3380,20 +4634,50 @@ dd {
 	top: 100%;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container{
+	background: #28303d;
+	}
+}
+
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
 	background: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-background) .wp-block-navigation__container{
+	background: #28303d;
+	}
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
 	background: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container{
+	background: #28303d;
+	}
+}
+
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -3410,6 +4694,18 @@ p.has-background {
 
 p.has-text-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	p.has-text-color a{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	p.has-text-color a{
+	color: #f0f0f0;
+	}
 }
 
 .post-password-form {
@@ -3445,6 +4741,24 @@ p.has-text-color a {
 	/**
 	 * Block Options
 	 */
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	border-bottom-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote{
+	border-top-color: #f0f0f0;
+	}
 }
 
 .wp-block-pullquote::before {
@@ -3558,6 +4872,24 @@ p.has-text-color a {
 	border-color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	border-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-pullquote.is-style-solid-color{
+	background-color: #28303d;
+	}
+}
+
 @media (min-width: 600px) {
 	.wp-block-pullquote.is-style-solid-color {
 		padding: 100px;
@@ -3597,6 +4929,18 @@ p.has-text-color a {
 	 */
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote{
+	border-left: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote{
+	border-left: 1px solid #f0f0f0;
+	}
+}
+
 .wp-block-quote > * {
 	margin-top: 20px;
 	margin-bottom: 20px;
@@ -3622,14 +4966,32 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote .wp-block-quote__citation{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-quote cite {
 	color: #28303d;
 	font-size: 1rem;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote cite{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-quote footer {
 	color: #28303d;
 	font-size: 1rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote footer{
+	color: #f0f0f0;
+	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -3658,6 +5020,18 @@ p.has-text-color a {
 	border-right: 1px solid #39414d;
 	padding-left: 0;
 	padding-right: 25px;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.has-text-align-right{
+	border-right: 1px solid #f0f0f0;
+	}
 }
 
 .wp-block-quote.has-text-align-center {
@@ -3713,9 +5087,21 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large .wp-block-quote__citation{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-quote.is-style-large cite {
 	color: #28303d;
 	font-size: 1rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large cite{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-quote.is-style-large footer {
@@ -3723,9 +5109,21 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-style-large footer{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-quote.is-large .wp-block-quote__citation {
 	color: #28303d;
 	font-size: 1rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large .wp-block-quote__citation{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-quote.is-large cite {
@@ -3733,9 +5131,21 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large cite{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-quote.is-large footer {
 	color: #28303d;
 	font-size: 1rem;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-quote.is-large footer{
+	color: #f0f0f0;
+	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,
@@ -3821,10 +5231,22 @@ p.has-text-color a {
 	line-height: 1.7;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-rss .wp-block-rss__item-author{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-rss .wp-block-rss__item-publish-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-rss .wp-block-rss__item-publish-date{
+	color: #f0f0f0;
+	}
 }
 
 [class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
@@ -3889,9 +5311,27 @@ p.has-text-color a {
 	padding: 10px;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input{
+	border: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input{
+	border: 3px solid #f0f0f0;
+	}
+}
+
 .wp-block-search .wp-block-search__input:focus {
 	color: #28303d;
 	border-color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search .wp-block-search__input:focus{
+	border-color: #f0f0f0;
+	}
 }
 
 .wp-block-search button.wp-block-search__button {
@@ -3900,9 +5340,27 @@ p.has-text-color a {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.wp-block-search button.wp-block-search__button{
+	color: #f0f0f0;
+	}
+}
+
 .wp-block-search button.wp-block-search__button:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search button.wp-block-search__button:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-search button.wp-block-search__button:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .wp-block-search__button {
@@ -3917,11 +5375,35 @@ hr {
 	margin-right: auto;
 }
 
+@media (prefers-color-scheme: dark){
+	hr{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	hr{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 hr.wp-block-separator {
 	border-bottom: 1px solid #28303d;
 	/**
 		 * Block Options
 		 */
+}
+
+@media (prefers-color-scheme: dark){
+	hr.wp-block-separator{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	hr.wp-block-separator{
+	border-bottom: 1px solid #f0f0f0;
+	}
 }
 
 hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
@@ -3969,6 +5451,12 @@ hr.wp-block-separator.is-style-dots:before {
 	}
 }
 
+@media (prefers-color-scheme: dark){
+	hr.wp-block-separator.is-style-dots:before{
+	color: #f0f0f0;
+	}
+}
+
 .has-background:not(.has-background-background-color) hr.wp-block-separator,
 [class*="background-color"]:not(.has-background-background-color) hr.wp-block-separator,
 [style*="background-color"] hr.wp-block-separator,
@@ -3978,6 +5466,12 @@ hr.wp-block-separator.is-style-dots:before {
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-social-links.is-style-twentytwentyone-social-icons-color a{
+	color: #f0f0f0;
+	}
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
@@ -4142,6 +5636,12 @@ table.wp-calendar-table caption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
+}
+
+@media (prefers-color-scheme: dark){
+	.wp-block-video figcaption{
+	color: #f0f0f0;
+	}
 }
 
 * > figure > video {
@@ -4326,21 +5826,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4389,21 +5889,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4495,6 +5995,12 @@ table.wp-calendar-table caption {
 	margin-right: 140px;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-branding{
+	color: #f0f0f0;
+	}
+}
+
 .site-branding:last-child {
 	margin-right: 0;
 	width: 100%;
@@ -4518,6 +6024,12 @@ table.wp-calendar-table caption {
 	margin-bottom: 5px;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-title{
+	color: #f0f0f0;
+	}
+}
+
 .site-title a {
 	color: currentColor;
 	font-weight: normal;
@@ -4531,8 +6043,20 @@ table.wp-calendar-table caption {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-title a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .site-title a:focus {
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-title a:focus{
+	color: #f0f0f0;
+	}
 }
 
 @media only screen and (min-width: 482px) {
@@ -4554,6 +6078,12 @@ a.custom-logo-link {
 
 .site-title > a {
 	text-decoration-color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-title > a{
+	text-decoration-color: #f0f0f0;
+	}
 }
 
 .site-logo {
@@ -4658,6 +6188,18 @@ a.custom-logo-link {
 	border-top: 3px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info{
+	color: #f0f0f0;
+	}
+}
+
 .site-footer > .site-info .site-name {
 	text-transform: uppercase;
 	font-size: 1.5rem;
@@ -4682,30 +6224,72 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a{
+	color: #f0f0f0;
+	}
+}
+
 .site-footer > .site-info a:link {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a:link{
+	color: #f0f0f0;
+	}
 }
 
 .site-footer > .site-info a:visited {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a:visited{
+	color: #f0f0f0;
+	}
+}
+
 .site-footer > .site-info a:active {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a:active{
+	color: #f0f0f0;
+	}
 }
 
 .site-footer > .site-info a:hover {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .site-footer > .site-info a:focus {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-footer > .site-info a:focus{
+	color: #f0f0f0;
+	}
 }
 
 .singular .entry-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;
 	margin-bottom: 90px;
+}
+
+@media (prefers-color-scheme: dark){
+	.singular .entry-header{
+	border-bottom: 3px solid #f0f0f0;
+	}
 }
 
 .home .entry-header {
@@ -4729,6 +6313,18 @@ a.custom-logo-link {
 	padding: 5px 7px;
 }
 
+@media (prefers-color-scheme: dark){
+	.sticky-post{
+	background-color: #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.sticky-post{
+	color: #28303d;
+	}
+}
+
 .no-results.not-found > *:first-child {
 	margin-bottom: 90px;
 }
@@ -4747,6 +6343,12 @@ a.custom-logo-link {
 	}
 }
 
+@media (prefers-color-scheme: dark){
+	.entry-title{
+	color: #f0f0f0;
+	}
+}
+
 .entry-title a {
 	color: currentColor;
 	text-underline-offset: 0.15em;
@@ -4756,8 +6358,20 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.entry-title a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .entry-title a:focus {
 	color: #39414d;
+}
+
+@media (prefers-color-scheme: dark){
+	.entry-title a:focus{
+	color: #f0f0f0;
+	}
 }
 
 .entry-title a:active {
@@ -4816,6 +6430,12 @@ h1.entry-title {
 	display: block;
 }
 
+@media (prefers-color-scheme: dark){
+	.entry-footer{
+	color: #f0f0f0;
+	}
+}
+
 .entry-footer a {
 	color: currentColor;
 }
@@ -4824,8 +6444,20 @@ h1.entry-title {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.entry-footer a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .entry-footer a:focus {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.entry-footer a:focus{
+	color: #f0f0f0;
+	}
 }
 
 .entry-footer a:active {
@@ -4837,6 +6469,18 @@ h1.entry-title {
 	padding-top: 20px;
 	padding-bottom: 90px;
 	border-bottom: 1px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.site-main > article > .entry-footer{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.site-main > article > .entry-footer{
+	border-bottom: 1px solid #f0f0f0;
+	}
 }
 
 body:not(.single) .site-main > article:last-of-type .entry-footer {
@@ -4853,6 +6497,12 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	column-gap: 50px;
+}
+
+@media (prefers-color-scheme: dark){
+	.single .site-main > article > .entry-footer{
+	border-top: 3px solid #f0f0f0;
+	}
 }
 
 .single .site-main > article > .entry-footer .post-taxonomies,
@@ -4998,6 +6648,12 @@ h1.page-title {
 .page-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;
+}
+
+@media (prefers-color-scheme: dark){
+	.page-header{
+	border-bottom: 3px solid #f0f0f0;
+	}
 }
 
 .archive .content-area .format-aside .entry-content {
@@ -5225,6 +6881,12 @@ h1.page-title {
 	padding: 8px 0 9px 0;
 }
 
+@media (prefers-color-scheme: dark){
+	.comment-meta .comment-metadata{
+	color: #f0f0f0;
+	}
+}
+
 .comment-meta .comment-metadata .edit-link {
 	margin-left: 25px;
 }
@@ -5445,6 +7107,12 @@ h1.page-title {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.menu-button-container .button.button{
+	color: #f0f0f0;
+	}
+}
+
 .menu-button-container .button.button .dropdown-icon {
 	display: flex;
 	align-items: center;
@@ -5482,6 +7150,12 @@ h1.page-title {
 	background-color: #d1e4dd;
 }
 
+@media (prefers-color-scheme: dark){
+	.primary-navigation-open .menu-button-container{
+	background-color: #28303d;
+	}
+}
+
 .primary-navigation-open .menu-button-container #primary-mobile-menu {
 	position: static;
 }
@@ -5495,6 +7169,12 @@ h1.page-title {
 	line-height: 1.15;
 	margin-top: 0;
 	margin-bottom: 0;
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation{
+	color: #f0f0f0;
+	}
 }
 
 .primary-navigation > .primary-menu-container {
@@ -5514,6 +7194,12 @@ h1.page-title {
 	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(30px);
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation > .primary-menu-container{
+	background-color: #28303d;
+	}
 }
 
 @media only screen and (max-width: 481px) {
@@ -5636,6 +7322,18 @@ h1.page-title {
 	outline: 2px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus{
+	outline: 2px solid #f0f0f0;
+	}
+}
+
 @media only screen and (max-width: 481px) {
 	.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
 		display: none;
@@ -5692,6 +7390,11 @@ h1.page-title {
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 		background: #d1e4dd;
 	}
+	@media (prefers-color-scheme: dark){
+		.primary-navigation > div > .menu-wrapper > li > .sub-menu li{
+		background: #28303d;
+		}
+	}
 }
 
 .primary-navigation > div > .menu-wrapper > li > .sub-menu .sub-menu {
@@ -5700,6 +7403,12 @@ h1.page-title {
 
 .primary-navigation .primary-menu > .menu-item:hover > a {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation .primary-menu > .menu-item:hover > a{
+	color: #f0f0f0;
+	}
 }
 
 @media only screen and (min-width: 482px) {
@@ -5741,16 +7450,40 @@ h1.page-title {
 	fill: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.primary-navigation a + svg{
+	fill: #f0f0f0;
+	}
+}
+
 .primary-navigation a:hover {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation a:hover{
+	color: #f0f0f0;
+	}
 }
 
 .primary-navigation a:link {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.primary-navigation a:link{
+	color: #f0f0f0;
+	}
+}
+
 .primary-navigation a:visited {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.primary-navigation a:visited{
+	color: #f0f0f0;
+	}
 }
 
 .primary-navigation a:hover {
@@ -5860,6 +7593,12 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+@media (prefers-color-scheme: dark){
+	.footer-navigation{
+	color: #f0f0f0;
+	}
+}
+
 .footer-navigation-wrapper {
 	display: flex;
 	justify-content: center;
@@ -5879,16 +7618,40 @@ h1.page-title {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.footer-navigation-wrapper li a{
+	color: #f0f0f0;
+	}
+}
+
 .footer-navigation-wrapper li a:link {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.footer-navigation-wrapper li a:link{
+	color: #f0f0f0;
+	}
 }
 
 .footer-navigation-wrapper li a:visited {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.footer-navigation-wrapper li a:visited{
+	color: #f0f0f0;
+	}
+}
+
 .footer-navigation-wrapper li a:active {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.footer-navigation-wrapper li a:active{
+	color: #f0f0f0;
+	}
 }
 
 .footer-navigation-wrapper li a:hover {
@@ -5896,6 +7659,12 @@ h1.page-title {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.footer-navigation-wrapper li a:hover{
+	color: #f0f0f0;
+	}
 }
 
 .footer-navigation-wrapper li svg {
@@ -5915,10 +7684,21 @@ h1.page-title {
 .navigation {
 	color: #28303d;
 }
+@media (prefers-color-scheme: dark){
+	.navigation{
+	color: #f0f0f0;
+	}
+}
 
 .navigation a {
 	color: #28303d;
 	text-decoration: none;
+}
+
+@media (prefers-color-scheme: dark){
+	.navigation a{
+	color: #f0f0f0;
+	}
 }
 
 .navigation a:hover {
@@ -5926,12 +7706,30 @@ h1.page-title {
 	text-decoration: underline;
 }
 
+@media (prefers-color-scheme: dark){
+	.navigation a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .navigation a:focus {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.navigation a:focus{
+	color: #f0f0f0;
+	}
+}
+
 .navigation a:active {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.navigation a:active{
+	color: #f0f0f0;
+	}
 }
 
 .navigation .nav-links .nav-next a,
@@ -6005,6 +7803,12 @@ h1.page-title {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.post-navigation .meta-nav{
+	color: #f0f0f0;
+	}
+}
+
 .post-navigation .post-title {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -6057,10 +7861,22 @@ h1.page-title {
 	margin: 30px auto;
 }
 
+@media (prefers-color-scheme: dark){
+	.pagination{
+	border-top: 3px solid #f0f0f0;
+	}
+}
+
 .comments-pagination {
 	border-top: 3px solid #28303d;
 	padding-top: 30px;
 	margin: 30px auto;
+}
+
+@media (prefers-color-scheme: dark){
+	.comments-pagination{
+	border-top: 3px solid #f0f0f0;
+	}
 }
 
 @media only screen and (min-width: 822px) {
@@ -6081,6 +7897,12 @@ h1.page-title {
 	margin-right: 13px;
 }
 
+@media (prefers-color-scheme: dark){
+	.pagination .nav-links > *{
+	color: #f0f0f0;
+	}
+}
+
 .comments-pagination .nav-links > * {
 	color: #28303d;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -6090,12 +7912,30 @@ h1.page-title {
 	margin-right: 13px;
 }
 
+@media (prefers-color-scheme: dark){
+	.comments-pagination .nav-links > *{
+	color: #f0f0f0;
+	}
+}
+
 .pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.pagination .nav-links > *.current{
+	border-bottom: 1px solid #f0f0f0;
+	}
+}
+
 .comments-pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.comments-pagination .nav-links > *.current{
+	border-bottom: 1px solid #f0f0f0;
+	}
 }
 
 .pagination .nav-links > *:first-child,
@@ -6107,8 +7947,20 @@ h1.page-title {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.pagination .nav-links > *a:hover{
+	color: #f0f0f0;
+	}
+}
+
 .comments-pagination .nav-links > *a:hover {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.comments-pagination .nav-links > *a:hover{
+	color: #f0f0f0;
+	}
 }
 
 .pagination .nav-links > *:last-child,
@@ -6167,6 +8019,12 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+@media (prefers-color-scheme: dark){
+	.widget-area{
+	color: #f0f0f0;
+	}
+}
+
 @media only screen and (min-width: 822px) {
 	.widget-area {
 		display: grid;
@@ -6199,21 +8057,51 @@ h1.page-title {
 	text-decoration-color: currentColor;
 }
 
+@media (prefers-color-scheme: dark){
+	.widget-area a{
+	color: #f0f0f0;
+	}
+}
+
 .widget-area a:link {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.widget-area a:link{
+	color: #f0f0f0;
+	}
 }
 
 .widget-area a:visited {
 	color: #28303d;
 }
 
+@media (prefers-color-scheme: dark){
+	.widget-area a:visited{
+	color: #f0f0f0;
+	}
+}
+
 .widget-area a:active {
 	color: #28303d;
+}
+
+@media (prefers-color-scheme: dark){
+	.widget-area a:active{
+	color: #f0f0f0;
+	}
 }
 
 .widget-area a:hover {
 	color: #28303d;
 	text-decoration-style: dotted;
+}
+
+@media (prefers-color-scheme: dark){
+	.widget-area a:hover{
+	color: #f0f0f0;
+	}
 }
 
 .widget-area .wp-block-social-links.alignright {
@@ -6284,9 +8172,27 @@ h1.page-title {
 	color: #39414d;
 }
 
+@media (prefers-color-scheme: dark){
+	.widget_search > .search-form .search-submit{
+	color: #f0f0f0;
+	}
+}
+
 .widget_search > .search-form .search-submit:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
+}
+
+@media (prefers-color-scheme: dark){
+	.widget_search > .search-form .search-submit:hover{
+	color: #28303d;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	.widget_search > .search-form .search-submit:hover{
+	background-color: #f0f0f0;
+	}
 }
 
 .widget_rss a.rsswidget .rss-widget-icon {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -107,7 +107,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Headings */
 	/* Mint, default body background */
 	/* Used for borders (separators) */
-	/* OS dark theme preference */
 	/* Spacing */
 	/* Elevation */
 	/* Forms */
@@ -124,12 +123,13 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Widgets */
 }
 
+/* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	:root .has-default-light-palette-background {
+	html.has-default-light-palette-background body {
 		background-color: #28303d;
 	}
 	@media (prefers-color-scheme: dark){
-		:root .has-default-light-palette-background{
+		html.has-default-light-palette-background body{
 		background-color: #28303d;
 		}
 	}
@@ -6095,7 +6095,7 @@ h1.page-title {
 
 @media (prefers-color-scheme: dark){
 	.pagination .nav-links > *{
-	color: #28303d;
+	color: #f0f0f0;
 	}
 }
 
@@ -6110,7 +6110,7 @@ h1.page-title {
 
 @media (prefers-color-scheme: dark){
 	.comments-pagination .nav-links > *{
-	color: #28303d;
+	color: #f0f0f0;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -124,6 +124,17 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Widgets */
 }
 
+@media (prefers-color-scheme: dark) {
+	:root .has-default-light-palette-background {
+		background-color: #28303d;
+	}
+	@media (prefers-color-scheme: dark){
+		:root .has-default-light-palette-background{
+		background-color: #28303d;
+		}
+	}
+}
+
 /* Button extends */
 .site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button) {
 	line-height: 1.5;
@@ -138,26 +149,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	text-decoration: none;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:not(.customize-partial-edit-shortcut-button):not(button){
-	color: #28303d;
-	}
-}
 .site .button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -170,26 +161,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
-}
-@media (prefers-color-scheme: dark){
-	.site .button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site .button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site .button{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.site .button{
-	color: #28303d;
-	}
 }
 input[type="submit"] {
 	line-height: 1.5;
@@ -204,26 +175,6 @@ input[type="submit"] {
 	text-decoration: none;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	input[type="submit"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="submit"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="submit"]{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="submit"]{
-	color: #28303d;
-	}
-}
 input[type="reset"] {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -236,26 +187,6 @@ input[type="reset"] {
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
-}
-@media (prefers-color-scheme: dark){
-	input[type="reset"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="reset"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="reset"]{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	input[type="reset"]{
-	color: #28303d;
-	}
 }
 .wp-block-button .wp-block-button__link {
 	line-height: 1.5;
@@ -270,26 +201,6 @@ input[type="reset"] {
 	text-decoration: none;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link{
-	color: #28303d;
-	}
-}
 .wp-block-file .wp-block-file__button {
 	line-height: 1.5;
 	color: #d1e4dd;
@@ -302,26 +213,6 @@ input[type="reset"] {
 	border: 3px solid #39414d;
 	text-decoration: none;
 	padding: 15px 30px;
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	border: 3px solid #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	background-color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button{
-	color: #28303d;
-	}
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before,
@@ -340,51 +231,51 @@ input[type="reset"]:after,
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em + 0);
+	margin-bottom: -calc(1em - 0);
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em + 0);
+	margin-top: -calc(1em - 0);
 }
 
 .site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -392,33 +283,9 @@ input[type="reset"]:after {
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button){
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button){
-	color: #f0f0f0;
-	}
-}
-
 .site .button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.site .button:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site .button:active{
-	color: #f0f0f0;
-	}
 }
 
 input:active[type="submit"] {
@@ -426,33 +293,9 @@ input:active[type="submit"] {
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	input:active[type="submit"]{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input:active[type="submit"]{
-	color: #f0f0f0;
-	}
-}
-
 input:active[type="reset"] {
 	color: #39414d;
 	background-color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	input:active[type="reset"]{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input:active[type="reset"]{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button .wp-block-button__link:active {
@@ -460,33 +303,9 @@ input:active[type="reset"] {
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link:active{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file .wp-block-file__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:active{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:active{
-	color: #f0f0f0;
-	}
 }
 
 .site button.mejs-inner:hover:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -494,21 +313,9 @@ input:active[type="reset"] {
 	background: transparent;
 }
 
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:hover:not(.customize-partial-edit-shortcut-button):not(button){
-	color: #f0f0f0;
-	}
-}
-
 .site .button:hover {
 	color: #39414d;
 	background: transparent;
-}
-
-@media (prefers-color-scheme: dark){
-	.site .button:hover{
-	color: #f0f0f0;
-	}
 }
 
 input:hover[type="submit"] {
@@ -516,21 +323,9 @@ input:hover[type="submit"] {
 	background: transparent;
 }
 
-@media (prefers-color-scheme: dark){
-	input:hover[type="submit"]{
-	color: #f0f0f0;
-	}
-}
-
 input:hover[type="reset"] {
 	color: #39414d;
 	background: transparent;
-}
-
-@media (prefers-color-scheme: dark){
-	input:hover[type="reset"]{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button .wp-block-button__link:hover {
@@ -538,21 +333,9 @@ input:hover[type="reset"] {
 	background: transparent;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link:hover{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file .wp-block-file__button:hover {
 	color: #39414d;
 	background: transparent;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:hover{
-	color: #f0f0f0;
-	}
 }
 
 .site button.mejs-inner:focus:not(.customize-partial-edit-shortcut-button):not(button),
@@ -574,22 +357,10 @@ input.has-focus[type="reset"],
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site button.mejs-inner:disabled:not(.customize-partial-edit-shortcut-button):not(button){
-	color: #f0f0f0;
-	}
-}
-
 .site .button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site .button:disabled{
-	color: #f0f0f0;
-	}
 }
 
 input:disabled[type="submit"] {
@@ -598,22 +369,10 @@ input:disabled[type="submit"] {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	input:disabled[type="submit"]{
-	color: #f0f0f0;
-	}
-}
-
 input:disabled[type="reset"] {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	input:disabled[type="reset"]{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button .wp-block-button__link:disabled {
@@ -622,22 +381,10 @@ input:disabled[type="reset"] {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button .wp-block-button__link:disabled{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file .wp-block-file__button:disabled {
 	background-color: rgba(255, 255, 255, 0.5);
 	border-color: rgba(255, 255, 255, 0.5);
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file .wp-block-file__button:disabled{
-	color: #f0f0f0;
-	}
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -1328,23 +1075,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 }
@@ -1354,21 +1101,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 }
@@ -1694,18 +1441,6 @@ body {
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	body{
-	background-color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	body{
-	color: #f0f0f0;
-	}
-}
-
 button {
 	cursor: pointer;
 }
@@ -1754,22 +1489,10 @@ blockquote cite {
 	letter-spacing: normal;
 }
 
-@media (prefers-color-scheme: dark){
-	blockquote cite{
-	color: #f0f0f0;
-	}
-}
-
 blockquote footer {
 	color: #28303d;
 	font-size: 1rem;
 	letter-spacing: normal;
-}
-
-@media (prefers-color-scheme: dark){
-	blockquote footer{
-	color: #f0f0f0;
-	}
 }
 
 blockquote > * {
@@ -1830,18 +1553,6 @@ input[type="text"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="text"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="text"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="email"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1849,18 +1560,6 @@ input[type="email"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="email"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="email"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="url"] {
@@ -1872,18 +1571,6 @@ input[type="url"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="url"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="url"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="password"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1891,18 +1578,6 @@ input[type="password"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="password"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="password"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="search"] {
@@ -1914,18 +1589,6 @@ input[type="search"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="search"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="search"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="number"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1933,18 +1596,6 @@ input[type="number"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="number"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="number"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="tel"] {
@@ -1956,18 +1607,6 @@ input[type="tel"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="tel"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="tel"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="date"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -1975,18 +1614,6 @@ input[type="date"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="date"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="date"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="month"] {
@@ -1998,18 +1625,6 @@ input[type="month"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="month"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="month"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="week"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -2017,18 +1632,6 @@ input[type="week"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="week"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="week"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="time"] {
@@ -2040,18 +1643,6 @@ input[type="time"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="time"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="time"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="datetime"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -2059,18 +1650,6 @@ input[type="datetime"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="datetime"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="datetime"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 input[type="datetime-local"] {
@@ -2082,18 +1661,6 @@ input[type="datetime-local"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="datetime-local"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="datetime-local"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="color"] {
 	border: 3px solid #39414d;
 	border-radius: 0;
@@ -2101,18 +1668,6 @@ input[type="color"] {
 	background: rgba(255, 255, 255, 0.5);
 	line-height: 1.7;
 	padding: 10px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="color"]{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="color"]{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .site textarea {
@@ -2124,28 +1679,10 @@ input[type="color"] {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	.site textarea{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site textarea{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 input[type="text"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="text"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="email"]:focus {
@@ -2154,22 +1691,10 @@ input[type="email"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="email"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="url"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="url"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="password"]:focus {
@@ -2178,22 +1703,10 @@ input[type="password"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="password"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="search"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="search"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="number"]:focus {
@@ -2202,22 +1715,10 @@ input[type="number"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="number"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="tel"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="tel"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="date"]:focus {
@@ -2226,22 +1727,10 @@ input[type="date"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="date"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="month"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="month"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="week"]:focus {
@@ -2250,22 +1739,10 @@ input[type="week"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="week"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="time"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="time"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="datetime"]:focus {
@@ -2274,22 +1751,10 @@ input[type="datetime"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="datetime"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 input[type="datetime-local"]:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="datetime-local"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="color"]:focus {
@@ -2298,22 +1763,10 @@ input[type="color"]:focus {
 	background: #fff;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="color"]:focus{
-	outline: 1px solid #f0f0f0;
-	}
-}
-
 .site textarea:focus {
 	color: #28303d;
 	outline: 1px solid #39414d;
 	background: #fff;
-}
-
-@media (prefers-color-scheme: dark){
-	.site textarea:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 input[type="text"]:disabled,
@@ -2362,26 +1815,8 @@ select {
 	background-position: right 10px top 60%;
 }
 
-@media (prefers-color-scheme: dark){
-	select{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	select{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 select:focus {
 	outline: 1px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	select:focus{
-	outline: 1px solid #f0f0f0;
-	}
 }
 
 textarea {
@@ -2410,16 +1845,6 @@ License: MIT.
 		border: 3px solid #39414d;
 		outline-offset: 0;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="checkbox"]{
-		border: 3px solid #f0f0f0;
-		}
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="checkbox"]{
-		border: 3px solid #f0f0f0;
-		}
-	}
 	input[type="radio"] {
 		-webkit-appearance: none;
 		-moz-appearance: none;
@@ -2430,16 +1855,6 @@ License: MIT.
 		border: 3px solid #39414d;
 		outline-offset: 0;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="radio"]{
-		border: 3px solid #f0f0f0;
-		}
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="radio"]{
-		border: 3px solid #f0f0f0;
-		}
-	}
 	input[type="checkbox"]:disabled,
 	input[type="radio"]:disabled {
 		opacity: 0.7;
@@ -2447,11 +1862,6 @@ License: MIT.
 	input[type="checkbox"]:focus {
 		outline: 1px solid #39414d;
 		background: #fff;
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="checkbox"]:focus{
-		outline: 1px solid #f0f0f0;
-		}
 	}
 	input[type="checkbox"]:after {
 		content: "";
@@ -2482,11 +1892,6 @@ License: MIT.
 		border: 4px solid #39414d;
 		outline: 1px dotted transparent;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="radio"]:focus{
-		border: 4px solid #f0f0f0;
-		}
-	}
 	input[type="radio"]:after {
 		content: "";
 		opacity: 0;
@@ -2504,21 +1909,11 @@ License: MIT.
 		border: 4px solid #39414d;
 		outline: 1px dotted transparent;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="radio"]:checked{
-		border: 4px solid #f0f0f0;
-		}
-	}
 	input[type="radio"]:checked:after {
 		opacity: 1;
 	}
 	input[type="radio"]:checked:focus {
 		box-shadow: 0 0 0 2px #39414d;
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="radio"]:checked:focus{
-		box-shadow: 0 0 0 2px #f0f0f0;
-		}
 	}
 }
 
@@ -2550,11 +1945,6 @@ input[type="radio"] + label {
 		border-radius: 6px;
 		outline-offset: 10px;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="range"]{
-		background: #f0f0f0;
-		}
-	}
 	input[type="range"]:disabled {
 		opacity: 0.7;
 	}
@@ -2567,16 +1957,6 @@ input[type="radio"] + label {
 		background: #d1e4dd;
 		cursor: pointer;
 	}
-	@media (prefers-color-scheme: dark){
-		input[type="range"]::-webkit-slider-thumb{
-		background: #28303d;
-		}
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="range"]::-webkit-slider-thumb{
-		border: 3px solid #f0f0f0;
-		}
-	}
 	input[type="range"]::-moz-range-thumb {
 		border: 3px solid #39414d;
 		height: 25px;
@@ -2584,16 +1964,6 @@ input[type="radio"] + label {
 		border-radius: 50%;
 		background: #d1e4dd;
 		cursor: pointer;
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="range"]::-moz-range-thumb{
-		background: #28303d;
-		}
-	}
-	@media (prefers-color-scheme: dark){
-		input[type="range"]::-moz-range-thumb{
-		border: 3px solid #f0f0f0;
-		}
 	}
 }
 
@@ -2608,32 +1978,14 @@ input[type="range"]::-ms-track {
 	cursor: pointer;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="range"]::-ms-track{
-	border-color: #28303d;
-	}
-}
-
 input[type="range"]::-ms-fill-upper {
 	background: #39414d;
 	border-radius: 6px;
 }
 
-@media (prefers-color-scheme: dark){
-	input[type="range"]::-ms-fill-upper{
-	background: #f0f0f0;
-	}
-}
-
 input[type="range"]::-ms-fill-lower {
 	background: #39414d;
 	border-radius: 6px;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="range"]::-ms-fill-lower{
-	background: #f0f0f0;
-	}
 }
 
 input[type="range"]::-ms-thumb {
@@ -2643,18 +1995,6 @@ input[type="range"]::-ms-thumb {
 	border-radius: 50%;
 	background: #d1e4dd;
 	cursor: pointer;
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="range"]::-ms-thumb{
-	background: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	input[type="range"]::-ms-thumb{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 img {
@@ -2685,11 +2025,6 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
-@media (prefers-color-scheme: dark){
-	figcaption{
-	color: #f0f0f0;
-	}
-}
 .wp-caption {
 	color: #28303d;
 	font-size: 1rem;
@@ -2698,11 +2033,6 @@ figcaption {
 	margin-bottom: 20px;
 	text-align: center;
 }
-@media (prefers-color-scheme: dark){
-	.wp-caption{
-	color: #f0f0f0;
-	}
-}
 .wp-caption-text {
 	color: #28303d;
 	font-size: 1rem;
@@ -2710,11 +2040,6 @@ figcaption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
-}
-@media (prefers-color-scheme: dark){
-	.wp-caption-text{
-	color: #f0f0f0;
-	}
 }
 
 .alignleft figcaption,
@@ -2766,16 +2091,6 @@ a {
 	text-underline-offset: 3px;
 	text-decoration-skip-ink: all;
 }
-@media (prefers-color-scheme: dark){
-	a{
-	color: #f0f0f0;
-	}
-}
-@media (prefers-color-scheme: dark){
-	a{
-	color: #f0f0f0;
-	}
-}
 
 a:hover {
 	text-decoration-style: dotted;
@@ -2785,18 +2100,6 @@ a:hover {
 .site a:focus {
 	outline: 2px solid #28303d;
 	text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark){
-	.site a:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site a:focus{
-	outline: 2px solid #f0f0f0;
-	}
 }
 
 .site a:focus.skip-link {
@@ -2809,43 +2112,14 @@ a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color) .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .has-background:not(.has-background-background-color).has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.has-background:not(.has-background-background-color).has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 /* Category 05 is all about adjusting the default block styles to the given layout. I only added three blocks as examples. */
 .wp-block-audio audio:focus {
 	outline-offset: 5px;
 	outline: 2px solid #28303d;
-}
-@media (prefers-color-scheme: dark){
-	.wp-block-audio audio:focus{
-	outline: 2px solid #f0f0f0;
-	}
 }
 
 /**
@@ -2860,41 +2134,19 @@ a:hover {
 	border: 3px solid currentColor;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link{
-	color: #f0f0f0;
-	}
-}
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: #39414d;
 	background: transparent;
 	border: 3px solid currentColor;
 	padding: 15px 30px;
 }
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link{
-	color: #f0f0f0;
-	}
-}
 
 .wp-block-button.is-style-outline.wp-block-button__link:visited {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:visited{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link:visited {
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:visited{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:active {
@@ -2903,58 +2155,10 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:active{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:active{
-	background-color: #f0f0f0;
-	}
-}
-
 .wp-block-button.is-style-outline.wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:active {
@@ -2963,58 +2167,10 @@ a:hover {
 	border: 3px solid #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:active{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:active{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:active{
-	background-color: #f0f0f0;
-	}
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
 	border: 3px solid #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:hover{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:focus {
@@ -3024,35 +2180,11 @@ a:hover {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:focus{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link:focus{
-	outline: 2px dotted #f0f0f0;
-	}
-}
-
 .wp-block-button.is-style-outline.wp-block-button__link.has-focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted #39414d;
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link.has-focus{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline.wp-block-button__link.has-focus{
-	outline: 2px dotted #f0f0f0;
-	}
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:focus {
@@ -3062,35 +2194,11 @@ a:hover {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:focus{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link:focus{
-	outline: 2px dotted #f0f0f0;
-	}
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted #39414d;
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link.has-focus{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button.is-style-outline .wp-block-button__link.has-focus{
-	outline: 2px dotted #f0f0f0;
-	}
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {
@@ -3102,21 +2210,9 @@ a:hover {
 	outline: 2px dotted #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.is-style-outline .wp-block-button__link[style*="radius"]:focus{
-	outline: 2px dotted #f0f0f0;
-	}
-}
-
 .wp-block-button a.wp-block-button__link[style*="radius"]:focus {
 	outline-offset: 2px;
 	outline: 2px dotted #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-button a.wp-block-button__link[style*="radius"]:focus{
-	outline: 2px dotted #f0f0f0;
-	}
 }
 
 .wp-block-code {
@@ -3126,26 +2222,8 @@ a:hover {
 	border-color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-code{
-	border-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-code{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-code pre {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-code pre{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-columns .wp-block-column > * {
@@ -3202,91 +2280,41 @@ a:hover {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background){
-		background-color: #28303d;
-		}
-	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
-	}
-	@media (prefers-color-scheme: dark){
-		.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background){
-		background-color: #28303d;
-		}
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;
@@ -3403,96 +2431,24 @@ a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover .wp-block-cover-text .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover-image .wp-block-cover__inner-container .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover-image .wp-block-cover-image-text .has-link-color a {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-image-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-cover-image .wp-block-cover-text .has-link-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image .wp-block-cover-text .has-link-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container {
@@ -3651,32 +2607,8 @@ a:hover {
 	border: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-cover.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-cover-image.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-cover-image.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-file a.wp-block-file__button:active {
@@ -3684,21 +2616,9 @@ a:hover {
 	opacity: inherit;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-file a.wp-block-file__button:active{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file a.wp-block-file__button:focus {
 	color: #39414d;
 	opacity: inherit;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file a.wp-block-file__button:focus{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-file a.wp-block-file__button:hover {
@@ -3706,21 +2626,9 @@ a:hover {
 	opacity: inherit;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-file a.wp-block-file__button:hover{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-file a.wp-block-file__button:visited {
 	color: #39414d;
 	opacity: inherit;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-file a.wp-block-file__button:visited{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-file .wp-block-file__button {
@@ -3732,11 +2640,11 @@ a:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc((100% - 20px)/2);
+	width: calc(50% - 10px);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc((100% - 20px)/2);
+	width: calc(50% - 10px);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -3789,18 +2697,6 @@ a:hover {
 .wp-block-group.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
 	padding: 30px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-group.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-group.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 h1 {
@@ -4050,12 +2946,6 @@ h6 {
 	text-align: center;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-image figcaption{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-image .alignright {
 	margin-left: 25px;
 }
@@ -4085,32 +2975,8 @@ img {
 	border: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-border img{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-border img{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-image.is-style-twentytwentyone-image-frame img {
 	border: 3px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-image-frame img{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-image.is-style-twentytwentyone-image-frame img{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-image.is-style-twentytwentyone-image-frame img {
@@ -4144,12 +3010,6 @@ img {
 .wp-block-latest-comments .wp-block-latest-comments__comment-date {
 	color: #28303d;
 	font-size: 1.125rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-comments .wp-block-latest-comments__comment-date{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
@@ -4230,22 +3090,10 @@ img {
 	line-height: 1.7;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts .wp-block-latest-posts__post-author{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts .wp-block-latest-posts__post-date{
-	color: #f0f0f0;
-	}
 }
 
 [class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
@@ -4283,30 +3131,6 @@ img {
 	border-bottom: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-bottom: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-bottom: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
@@ -4314,35 +3138,11 @@ img {
 	margin-bottom: 30px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li {
 	padding-bottom: 30px;
 	border-bottom: 1px solid #28303d;
 	margin-top: 30px;
 	margin-bottom: 30px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li{
-	border-bottom: 1px solid #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li:last-child,
@@ -4354,24 +3154,6 @@ img {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid {
 	box-shadow: inset 0 -1px 0 0 #28303d;
 	border-bottom: 2px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	border-bottom: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	border-bottom: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid{
-	box-shadow: inset 0 -1px 0 0 #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid li {
@@ -4405,18 +3187,6 @@ img {
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li {
 	border: 3px solid #28303d;
 	padding: 30px 25px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li{
-	border: 3px solid #f0f0f0;
-	}
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li:last-child {
@@ -4565,18 +3335,6 @@ dd {
 	border: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-media-text.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-media-text.is-style-twentytwentyone-border{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-navigation .wp-block-navigation-link {
 	padding: 0;
 }
@@ -4634,50 +3392,20 @@ dd {
 	top: 100%;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container{
-	background: #28303d;
-	}
-}
-
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
 	background: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-background) .wp-block-navigation__container{
-	background: #28303d;
-	}
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
 	background: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container{
-	background: #28303d;
-	}
-}
-
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -4694,18 +3422,6 @@ p.has-background {
 
 p.has-text-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	p.has-text-color a{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	p.has-text-color a{
-	color: #f0f0f0;
-	}
 }
 
 .post-password-form {
@@ -4741,24 +3457,6 @@ p.has-text-color a {
 	/**
 	 * Block Options
 	 */
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	border-bottom-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote{
-	border-top-color: #f0f0f0;
-	}
 }
 
 .wp-block-pullquote::before {
@@ -4872,24 +3570,6 @@ p.has-text-color a {
 	border-color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	border-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-pullquote.is-style-solid-color{
-	background-color: #28303d;
-	}
-}
-
 @media (min-width: 600px) {
 	.wp-block-pullquote.is-style-solid-color {
 		padding: 100px;
@@ -4929,18 +3609,6 @@ p.has-text-color a {
 	 */
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote{
-	border-left: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote{
-	border-left: 1px solid #f0f0f0;
-	}
-}
-
 .wp-block-quote > * {
 	margin-top: 20px;
 	margin-bottom: 20px;
@@ -4966,32 +3634,14 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote .wp-block-quote__citation{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-quote cite {
 	color: #28303d;
 	font-size: 1rem;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote cite{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-quote footer {
 	color: #28303d;
 	font-size: 1rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote footer{
-	color: #f0f0f0;
-	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -5020,18 +3670,6 @@ p.has-text-color a {
 	border-right: 1px solid #39414d;
 	padding-left: 0;
 	padding-right: 25px;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.has-text-align-right{
-	border-right: 1px solid #f0f0f0;
-	}
 }
 
 .wp-block-quote.has-text-align-center {
@@ -5087,21 +3725,9 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large .wp-block-quote__citation{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-quote.is-style-large cite {
 	color: #28303d;
 	font-size: 1rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large cite{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-quote.is-style-large footer {
@@ -5109,21 +3735,9 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-style-large footer{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-quote.is-large .wp-block-quote__citation {
 	color: #28303d;
 	font-size: 1rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large .wp-block-quote__citation{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-quote.is-large cite {
@@ -5131,21 +3745,9 @@ p.has-text-color a {
 	font-size: 1rem;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large cite{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-quote.is-large footer {
 	color: #28303d;
 	font-size: 1rem;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-quote.is-large footer{
-	color: #f0f0f0;
-	}
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,
@@ -5231,22 +3833,10 @@ p.has-text-color a {
 	line-height: 1.7;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-rss .wp-block-rss__item-author{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-rss .wp-block-rss__item-publish-date {
 	color: #28303d;
 	font-size: 1rem;
 	line-height: 1.7;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-rss .wp-block-rss__item-publish-date{
-	color: #f0f0f0;
-	}
 }
 
 [class*="inner-container"] .wp-block-rss .wp-block-rss__item-publish-date,
@@ -5311,27 +3901,9 @@ p.has-text-color a {
 	padding: 10px;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input{
-	border: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input{
-	border: 3px solid #f0f0f0;
-	}
-}
-
 .wp-block-search .wp-block-search__input:focus {
 	color: #28303d;
 	border-color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search .wp-block-search__input:focus{
-	border-color: #f0f0f0;
-	}
 }
 
 .wp-block-search button.wp-block-search__button {
@@ -5340,27 +3912,9 @@ p.has-text-color a {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.wp-block-search button.wp-block-search__button{
-	color: #f0f0f0;
-	}
-}
-
 .wp-block-search button.wp-block-search__button:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search button.wp-block-search__button:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-search button.wp-block-search__button:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .wp-block-search__button {
@@ -5375,35 +3929,11 @@ hr {
 	margin-right: auto;
 }
 
-@media (prefers-color-scheme: dark){
-	hr{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	hr{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 hr.wp-block-separator {
 	border-bottom: 1px solid #28303d;
 	/**
 		 * Block Options
 		 */
-}
-
-@media (prefers-color-scheme: dark){
-	hr.wp-block-separator{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	hr.wp-block-separator{
-	border-bottom: 1px solid #f0f0f0;
-	}
 }
 
 hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
@@ -5451,12 +3981,6 @@ hr.wp-block-separator.is-style-dots:before {
 	}
 }
 
-@media (prefers-color-scheme: dark){
-	hr.wp-block-separator.is-style-dots:before{
-	color: #f0f0f0;
-	}
-}
-
 .has-background:not(.has-background-background-color) hr.wp-block-separator,
 [class*="background-color"]:not(.has-background-background-color) hr.wp-block-separator,
 [style*="background-color"] hr.wp-block-separator,
@@ -5466,12 +3990,6 @@ hr.wp-block-separator.is-style-dots:before {
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-social-links.is-style-twentytwentyone-social-icons-color a{
-	color: #f0f0f0;
-	}
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
@@ -5636,12 +4154,6 @@ table.wp-calendar-table caption {
 	margin-top: 10px;
 	margin-bottom: 20px;
 	text-align: center;
-}
-
-@media (prefers-color-scheme: dark){
-	.wp-block-video figcaption{
-	color: #f0f0f0;
-	}
 }
 
 * > figure > video {
@@ -5826,21 +4338,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 }
@@ -5889,21 +4401,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
+		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
 		}
 	}
 }
@@ -5995,12 +4507,6 @@ table.wp-calendar-table caption {
 	margin-right: 140px;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-branding{
-	color: #f0f0f0;
-	}
-}
-
 .site-branding:last-child {
 	margin-right: 0;
 	width: 100%;
@@ -6024,12 +4530,6 @@ table.wp-calendar-table caption {
 	margin-bottom: 5px;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-title{
-	color: #f0f0f0;
-	}
-}
-
 .site-title a {
 	color: currentColor;
 	font-weight: normal;
@@ -6043,20 +4543,8 @@ table.wp-calendar-table caption {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-title a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .site-title a:focus {
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-title a:focus{
-	color: #f0f0f0;
-	}
 }
 
 @media only screen and (min-width: 482px) {
@@ -6078,12 +4566,6 @@ a.custom-logo-link {
 
 .site-title > a {
 	text-decoration-color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-title > a{
-	text-decoration-color: #f0f0f0;
-	}
 }
 
 .site-logo {
@@ -6188,18 +4670,6 @@ a.custom-logo-link {
 	border-top: 3px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info{
-	color: #f0f0f0;
-	}
-}
-
 .site-footer > .site-info .site-name {
 	text-transform: uppercase;
 	font-size: 1.5rem;
@@ -6224,72 +4694,30 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a{
-	color: #f0f0f0;
-	}
-}
-
 .site-footer > .site-info a:link {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a:link{
-	color: #f0f0f0;
-	}
 }
 
 .site-footer > .site-info a:visited {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a:visited{
-	color: #f0f0f0;
-	}
-}
-
 .site-footer > .site-info a:active {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a:active{
-	color: #f0f0f0;
-	}
 }
 
 .site-footer > .site-info a:hover {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .site-footer > .site-info a:focus {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-footer > .site-info a:focus{
-	color: #f0f0f0;
-	}
 }
 
 .singular .entry-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;
 	margin-bottom: 90px;
-}
-
-@media (prefers-color-scheme: dark){
-	.singular .entry-header{
-	border-bottom: 3px solid #f0f0f0;
-	}
 }
 
 .home .entry-header {
@@ -6313,18 +4741,6 @@ a.custom-logo-link {
 	padding: 5px 7px;
 }
 
-@media (prefers-color-scheme: dark){
-	.sticky-post{
-	background-color: #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.sticky-post{
-	color: #28303d;
-	}
-}
-
 .no-results.not-found > *:first-child {
 	margin-bottom: 90px;
 }
@@ -6343,12 +4759,6 @@ a.custom-logo-link {
 	}
 }
 
-@media (prefers-color-scheme: dark){
-	.entry-title{
-	color: #f0f0f0;
-	}
-}
-
 .entry-title a {
 	color: currentColor;
 	text-underline-offset: 0.15em;
@@ -6358,20 +4768,8 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.entry-title a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .entry-title a:focus {
 	color: #39414d;
-}
-
-@media (prefers-color-scheme: dark){
-	.entry-title a:focus{
-	color: #f0f0f0;
-	}
 }
 
 .entry-title a:active {
@@ -6430,12 +4828,6 @@ h1.entry-title {
 	display: block;
 }
 
-@media (prefers-color-scheme: dark){
-	.entry-footer{
-	color: #f0f0f0;
-	}
-}
-
 .entry-footer a {
 	color: currentColor;
 }
@@ -6444,20 +4836,8 @@ h1.entry-title {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.entry-footer a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .entry-footer a:focus {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.entry-footer a:focus{
-	color: #f0f0f0;
-	}
 }
 
 .entry-footer a:active {
@@ -6469,18 +4849,6 @@ h1.entry-title {
 	padding-top: 20px;
 	padding-bottom: 90px;
 	border-bottom: 1px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.site-main > article > .entry-footer{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.site-main > article > .entry-footer{
-	border-bottom: 1px solid #f0f0f0;
-	}
 }
 
 body:not(.single) .site-main > article:last-of-type .entry-footer {
@@ -6497,12 +4865,6 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	column-gap: 50px;
-}
-
-@media (prefers-color-scheme: dark){
-	.single .site-main > article > .entry-footer{
-	border-top: 3px solid #f0f0f0;
-	}
 }
 
 .single .site-main > article > .entry-footer .post-taxonomies,
@@ -6648,12 +5010,6 @@ h1.page-title {
 .page-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;
-}
-
-@media (prefers-color-scheme: dark){
-	.page-header{
-	border-bottom: 3px solid #f0f0f0;
-	}
 }
 
 .archive .content-area .format-aside .entry-content {
@@ -6881,12 +5237,6 @@ h1.page-title {
 	padding: 8px 0 9px 0;
 }
 
-@media (prefers-color-scheme: dark){
-	.comment-meta .comment-metadata{
-	color: #f0f0f0;
-	}
-}
-
 .comment-meta .comment-metadata .edit-link {
 	margin-left: 25px;
 }
@@ -7107,12 +5457,6 @@ h1.page-title {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.menu-button-container .button.button{
-	color: #f0f0f0;
-	}
-}
-
 .menu-button-container .button.button .dropdown-icon {
 	display: flex;
 	align-items: center;
@@ -7150,12 +5494,6 @@ h1.page-title {
 	background-color: #d1e4dd;
 }
 
-@media (prefers-color-scheme: dark){
-	.primary-navigation-open .menu-button-container{
-	background-color: #28303d;
-	}
-}
-
 .primary-navigation-open .menu-button-container #primary-mobile-menu {
 	position: static;
 }
@@ -7169,12 +5507,6 @@ h1.page-title {
 	line-height: 1.15;
 	margin-top: 0;
 	margin-bottom: 0;
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation{
-	color: #f0f0f0;
-	}
 }
 
 .primary-navigation > .primary-menu-container {
@@ -7194,12 +5526,6 @@ h1.page-title {
 	overflow-y: auto;
 	transition: all .15s ease-in-out;
 	transform: translateY(30px);
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation > .primary-menu-container{
-	background-color: #28303d;
-	}
 }
 
 @media only screen and (max-width: 481px) {
@@ -7322,18 +5648,6 @@ h1.page-title {
 	outline: 2px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus{
-	outline: 2px solid #f0f0f0;
-	}
-}
-
 @media only screen and (max-width: 481px) {
 	.primary-navigation > div > .menu-wrapper .sub-menu-toggle {
 		display: none;
@@ -7390,11 +5704,6 @@ h1.page-title {
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 		background: #d1e4dd;
 	}
-	@media (prefers-color-scheme: dark){
-		.primary-navigation > div > .menu-wrapper > li > .sub-menu li{
-		background: #28303d;
-		}
-	}
 }
 
 .primary-navigation > div > .menu-wrapper > li > .sub-menu .sub-menu {
@@ -7403,12 +5712,6 @@ h1.page-title {
 
 .primary-navigation .primary-menu > .menu-item:hover > a {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation .primary-menu > .menu-item:hover > a{
-	color: #f0f0f0;
-	}
 }
 
 @media only screen and (min-width: 482px) {
@@ -7450,40 +5753,16 @@ h1.page-title {
 	fill: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.primary-navigation a + svg{
-	fill: #f0f0f0;
-	}
-}
-
 .primary-navigation a:hover {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation a:hover{
-	color: #f0f0f0;
-	}
 }
 
 .primary-navigation a:link {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.primary-navigation a:link{
-	color: #f0f0f0;
-	}
-}
-
 .primary-navigation a:visited {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.primary-navigation a:visited{
-	color: #f0f0f0;
-	}
 }
 
 .primary-navigation a:hover {
@@ -7593,12 +5872,6 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
-@media (prefers-color-scheme: dark){
-	.footer-navigation{
-	color: #f0f0f0;
-	}
-}
-
 .footer-navigation-wrapper {
 	display: flex;
 	justify-content: center;
@@ -7618,40 +5891,16 @@ h1.page-title {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.footer-navigation-wrapper li a{
-	color: #f0f0f0;
-	}
-}
-
 .footer-navigation-wrapper li a:link {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.footer-navigation-wrapper li a:link{
-	color: #f0f0f0;
-	}
 }
 
 .footer-navigation-wrapper li a:visited {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.footer-navigation-wrapper li a:visited{
-	color: #f0f0f0;
-	}
-}
-
 .footer-navigation-wrapper li a:active {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.footer-navigation-wrapper li a:active{
-	color: #f0f0f0;
-	}
 }
 
 .footer-navigation-wrapper li a:hover {
@@ -7659,12 +5908,6 @@ h1.page-title {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.footer-navigation-wrapper li a:hover{
-	color: #f0f0f0;
-	}
 }
 
 .footer-navigation-wrapper li svg {
@@ -7684,21 +5927,10 @@ h1.page-title {
 .navigation {
 	color: #28303d;
 }
-@media (prefers-color-scheme: dark){
-	.navigation{
-	color: #f0f0f0;
-	}
-}
 
 .navigation a {
 	color: #28303d;
 	text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark){
-	.navigation a{
-	color: #f0f0f0;
-	}
 }
 
 .navigation a:hover {
@@ -7706,30 +5938,12 @@ h1.page-title {
 	text-decoration: underline;
 }
 
-@media (prefers-color-scheme: dark){
-	.navigation a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .navigation a:focus {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.navigation a:focus{
-	color: #f0f0f0;
-	}
-}
-
 .navigation a:active {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.navigation a:active{
-	color: #f0f0f0;
-	}
 }
 
 .navigation .nav-links .nav-next a,
@@ -7803,12 +6017,6 @@ h1.page-title {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.post-navigation .meta-nav{
-	color: #f0f0f0;
-	}
-}
-
 .post-navigation .post-title {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -7861,22 +6069,10 @@ h1.page-title {
 	margin: 30px auto;
 }
 
-@media (prefers-color-scheme: dark){
-	.pagination{
-	border-top: 3px solid #f0f0f0;
-	}
-}
-
 .comments-pagination {
 	border-top: 3px solid #28303d;
 	padding-top: 30px;
 	margin: 30px auto;
-}
-
-@media (prefers-color-scheme: dark){
-	.comments-pagination{
-	border-top: 3px solid #f0f0f0;
-	}
 }
 
 @media only screen and (min-width: 822px) {
@@ -7899,7 +6095,7 @@ h1.page-title {
 
 @media (prefers-color-scheme: dark){
 	.pagination .nav-links > *{
-	color: #f0f0f0;
+	color: #28303d;
 	}
 }
 
@@ -7914,7 +6110,7 @@ h1.page-title {
 
 @media (prefers-color-scheme: dark){
 	.comments-pagination .nav-links > *{
-	color: #f0f0f0;
+	color: #28303d;
 	}
 }
 
@@ -7922,20 +6118,8 @@ h1.page-title {
 	border-bottom: 1px solid #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.pagination .nav-links > *.current{
-	border-bottom: 1px solid #f0f0f0;
-	}
-}
-
 .comments-pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.comments-pagination .nav-links > *.current{
-	border-bottom: 1px solid #f0f0f0;
-	}
 }
 
 .pagination .nav-links > *:first-child,
@@ -7947,20 +6131,8 @@ h1.page-title {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.pagination .nav-links > *a:hover{
-	color: #f0f0f0;
-	}
-}
-
 .comments-pagination .nav-links > *a:hover {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.comments-pagination .nav-links > *a:hover{
-	color: #f0f0f0;
-	}
 }
 
 .pagination .nav-links > *:last-child,
@@ -8019,12 +6191,6 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
-@media (prefers-color-scheme: dark){
-	.widget-area{
-	color: #f0f0f0;
-	}
-}
-
 @media only screen and (min-width: 822px) {
 	.widget-area {
 		display: grid;
@@ -8057,51 +6223,21 @@ h1.page-title {
 	text-decoration-color: currentColor;
 }
 
-@media (prefers-color-scheme: dark){
-	.widget-area a{
-	color: #f0f0f0;
-	}
-}
-
 .widget-area a:link {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.widget-area a:link{
-	color: #f0f0f0;
-	}
 }
 
 .widget-area a:visited {
 	color: #28303d;
 }
 
-@media (prefers-color-scheme: dark){
-	.widget-area a:visited{
-	color: #f0f0f0;
-	}
-}
-
 .widget-area a:active {
 	color: #28303d;
-}
-
-@media (prefers-color-scheme: dark){
-	.widget-area a:active{
-	color: #f0f0f0;
-	}
 }
 
 .widget-area a:hover {
 	color: #28303d;
 	text-decoration-style: dotted;
-}
-
-@media (prefers-color-scheme: dark){
-	.widget-area a:hover{
-	color: #f0f0f0;
-	}
 }
 
 .widget-area .wp-block-social-links.alignright {
@@ -8172,27 +6308,9 @@ h1.page-title {
 	color: #39414d;
 }
 
-@media (prefers-color-scheme: dark){
-	.widget_search > .search-form .search-submit{
-	color: #f0f0f0;
-	}
-}
-
 .widget_search > .search-form .search-submit:hover {
 	background-color: #39414d;
 	color: #d1e4dd;
-}
-
-@media (prefers-color-scheme: dark){
-	.widget_search > .search-form .search-submit:hover{
-	color: #28303d;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	.widget_search > .search-form .search-submit:hover{
-	background-color: #f0f0f0;
-	}
 }
 
 .widget_rss a.rsswidget .rss-widget-icon {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -80,7 +80,6 @@
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
-	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -213,15 +212,6 @@
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
-@media (prefers-color-scheme: dark) {
-	:root .has-default-light-palette-background {
-		--global--color-background: var(--global--color-dark-gray);
-		--global--color-primary: var(--global--color-light-gray);
-		--global--color-secondary: var(--global--color-light-gray);
-		background-color: var(--global--color-background);
-	}
-}
-
 @media only screen and (min-width: 652px) {
 	:root {
 		--global--font-size-xl: 2.5rem;
@@ -229,6 +219,18 @@
 		--global--font-size-xxxl: 9rem;
 		--heading--font-size-h3: 2rem;
 		--heading--font-size-h2: 3rem;
+	}
+}
+
+/* OS dark theme preference */
+@media (prefers-color-scheme: dark) {
+	html.has-default-light-palette-background {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
+	html.has-default-light-palette-background body {
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -80,6 +80,7 @@
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
+	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -210,6 +211,14 @@
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
 }
 
 @media only screen and (min-width: 652px) {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -214,10 +214,11 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	:root {
+	:root .has-default-light-palette-background {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -89,6 +89,13 @@ $baseline-unit: 10px;
 	--global--color-background: var(--global--color-green); /* Mint, default body background */
 	--global--color-border: var(--global--color-primary); /* Used for borders (separators) */
 
+	/* OS dark theme preference */
+	@media (prefers-color-scheme: dark) {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
+
 	/* Spacing */
 	--global--spacing-unit: #{2 * $baseline-unit}; // 20px
 	--global--spacing-measure: unset; // Use ch units here. ie: 60ch = 60 character max-width

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -91,9 +91,13 @@ $baseline-unit: 10px;
 
 	/* OS dark theme preference */
 	@media (prefers-color-scheme: dark) {
-		--global--color-background: var(--global--color-dark-gray);
-		--global--color-primary: var(--global--color-light-gray);
-		--global--color-secondary: var(--global--color-light-gray);
+		.has-default-light-palette-background {
+			--global--color-background: var(--global--color-dark-gray);
+			--global--color-primary: var(--global--color-light-gray);
+			--global--color-secondary: var(--global--color-light-gray);
+
+			background-color: var(--global--color-background);
+		}
 	}
 
 	/* Spacing */

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -89,17 +89,6 @@ $baseline-unit: 10px;
 	--global--color-background: var(--global--color-green); /* Mint, default body background */
 	--global--color-border: var(--global--color-primary); /* Used for borders (separators) */
 
-	/* OS dark theme preference */
-	@media (prefers-color-scheme: dark) {
-		.has-default-light-palette-background {
-			--global--color-background: var(--global--color-dark-gray);
-			--global--color-primary: var(--global--color-light-gray);
-			--global--color-secondary: var(--global--color-light-gray);
-
-			background-color: var(--global--color-background);
-		}
-	}
-
 	/* Spacing */
 	--global--spacing-unit: #{2 * $baseline-unit}; // 20px
 	--global--spacing-measure: unset; // Use ch units here. ie: 60ch = 60 character max-width
@@ -260,5 +249,18 @@ $baseline-unit: 10px;
 		--global--font-size-xxxl: 9rem; // 144px / 16px
 		--heading--font-size-h3: 2rem; // 32px / 16px
 		--heading--font-size-h2: 3rem; // 48px / 16px
+	}
+}
+
+/* OS dark theme preference */
+@media (prefers-color-scheme: dark) {
+	html.has-default-light-palette-background {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+
+		body {
+			background-color: var(--global--color-background);
+		}
 	}
 }

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -254,6 +254,7 @@ $baseline-unit: 10px;
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
+
 	html.has-default-light-palette-background {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -165,6 +165,13 @@ class Twenty_Twenty_One_Custom_Colors {
 		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
 		if ( 127 > $this->get_relative_luminance_from_hex( $background_color ) ) {
 			$classes[] = 'is-background-dark';
+		} else {
+			$classes[] = 'is-background-light';
+		}
+
+		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
+		if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+			$classes[] = 'has-default-light-palette-background';
 		}
 
 		return $classes;

--- a/functions.php
+++ b/functions.php
@@ -528,7 +528,7 @@ add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' )
  *
  * @since 1.0.0
  *
- * @return string
+ * @return void
  */
 function twentytwentyone_the_html_classes() {
 	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );

--- a/functions.php
+++ b/functions.php
@@ -508,7 +508,7 @@ require get_template_directory() . '/inc/block-styles.php';
 /**
  * Enqueue scripts for the customizer preview.
  *
- * @since Twenty Twenty-One 1.0
+ * @since 1.0.0
  *
  * @return void
  */
@@ -522,3 +522,18 @@ function twentytwentyone_customize_preview_init() {
 	);
 }
 add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' );
+
+/**
+ * Calculate any classes we may want to add to the main <html> element.
+ *
+ * @since 1.0.0
+ *
+ * @return string
+ */
+function twentytwentyone_the_html_classes() {
+	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
+	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
+	if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+		echo 'class="has-default-light-palette-background"';
+	}
+}

--- a/header.php
+++ b/header.php
@@ -13,7 +13,7 @@
 
 ?>
 <!doctype html>
-<html <?php language_attributes(); ?>>
+<html <?php language_attributes(); ?> <?php twentytwentyone_the_html_classes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -172,7 +172,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
-	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -305,15 +304,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
-@media (prefers-color-scheme: dark) {
-	:root .has-default-light-palette-background {
-		--global--color-background: var(--global--color-dark-gray);
-		--global--color-primary: var(--global--color-light-gray);
-		--global--color-secondary: var(--global--color-light-gray);
-		background-color: var(--global--color-background);
-	}
-}
-
 @media only screen and (min-width: 652px) {
 	:root {
 		--global--font-size-xl: 2.5rem;
@@ -321,6 +311,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--global--font-size-xxxl: 9rem;
 		--heading--font-size-h3: 2rem;
 		--heading--font-size-h2: 3rem;
+	}
+}
+
+/* OS dark theme preference */
+@media (prefers-color-scheme: dark) {
+	html.has-default-light-palette-background {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
+	html.has-default-light-palette-background body {
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -306,10 +306,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 }
 
 @media (prefers-color-scheme: dark) {
-	:root {
+	:root .has-default-light-palette-background {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -172,6 +172,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
+	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -302,6 +303,14 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
 }
 
 @media only screen and (min-width: 652px) {

--- a/style.css
+++ b/style.css
@@ -172,7 +172,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
-	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -305,15 +304,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 }
 
-@media (prefers-color-scheme: dark) {
-	:root .has-default-light-palette-background {
-		--global--color-background: var(--global--color-dark-gray);
-		--global--color-primary: var(--global--color-light-gray);
-		--global--color-secondary: var(--global--color-light-gray);
-		background-color: var(--global--color-background);
-	}
-}
-
 @media only screen and (min-width: 652px) {
 	:root {
 		--global--font-size-xl: 2.5rem;
@@ -321,6 +311,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--global--font-size-xxxl: 9rem;
 		--heading--font-size-h3: 2rem;
 		--heading--font-size-h2: 3rem;
+	}
+}
+
+/* OS dark theme preference */
+@media (prefers-color-scheme: dark) {
+	html.has-default-light-palette-background {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
+	html.has-default-light-palette-background body {
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -306,10 +306,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 }
 
 @media (prefers-color-scheme: dark) {
-	:root {
+	:root .has-default-light-palette-background {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		background-color: var(--global--color-background);
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -172,6 +172,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
 	/* Used for borders (separators) */
+	/* OS dark theme preference */
 	/* Spacing */
 	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
@@ -302,6 +303,14 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--global--color-background: var(--global--color-dark-gray);
+		--global--color-primary: var(--global--color-light-gray);
+		--global--color-secondary: var(--global--color-light-gray);
+	}
 }
 
 @media only screen and (min-width: 652px) {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/410

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

This PR will add the dark mode preference to the theme

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Set the OS color preference to dark.
1. Check if the default color is selected in the customizer that the theme is dark.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
