### PR TITLE
Eagerly load the thumbnail on single pages

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -193,7 +193,10 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 		<?php if ( is_singular() ) : ?>
 
 			<figure class="post-thumbnail">
-				<?php the_post_thumbnail(); ?>
+				<?php 
+				// Thumbnail is loaded eagerly because it's going to be in the viewport immediately.
+				the_post_thumbnail( 'post-thumbnail', array( 'loading' => 'eager' ) );
+				?>
 			</figure><!-- .post-thumbnail -->
 
 		<?php else : ?>


### PR DESCRIPTION
## Summary
As the thumbnail is going to be in the viewport immediately, we should make it load eagerly.

## Test instructions

This PR can be tested by following these steps:
1. Create a post that has a featured image.
1. See that `loading="eager"` is set on that image's `img` tag.

## Screenshots

No visual change.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly). --- It improves it.
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
