### PR TITLE
fix comment-submit dark mode color

### DIFF
--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -228,6 +228,12 @@
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		--button--color-text: var(--global--color-background);
+		--button--color-text-hover: var(--global--color-secondary);
+		--button--color-text-active: var(--global--color-secondary);
+		--button--color-background: var(--global--color-secondary);
+		--button--color-background-hover: var(--global--color-background);
+		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {
 		background-color: var(--global--color-background);

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -260,6 +260,14 @@ $baseline-unit: 10px;
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
 
+		// These need to be redefined for comment-submit buttons.
+		--button--color-text: var(--global--color-background);
+		--button--color-text-hover: var(--global--color-secondary);
+		--button--color-text-active: var(--global--color-secondary);
+		--button--color-background: var(--global--color-secondary);
+		--button--color-background-hover: var(--global--color-background);
+		--button--color-background-active: var(--global--color-background);
+
 		body {
 			background-color: var(--global--color-background);
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -320,6 +320,12 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		--button--color-text: var(--global--color-background);
+		--button--color-text-hover: var(--global--color-secondary);
+		--button--color-text-active: var(--global--color-secondary);
+		--button--color-background: var(--global--color-secondary);
+		--button--color-background-hover: var(--global--color-background);
+		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {
 		background-color: var(--global--color-background);

--- a/style.css
+++ b/style.css
@@ -320,6 +320,12 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
+		--button--color-text: var(--global--color-background);
+		--button--color-text-hover: var(--global--color-secondary);
+		--button--color-text-active: var(--global--color-secondary);
+		--button--color-background: var(--global--color-secondary);
+		--button--color-background-hover: var(--global--color-background);
+		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {
 		background-color: var(--global--color-background);


### PR DESCRIPTION
## Summary

On dark-mode (OS preference) with a Linux/Firefox combo, the comment-submit buttons were not inheriting the color preferences.

## Before:

![Peek 2020-10-16 15-35](https://user-images.githubusercontent.com/588688/96259073-b97ec900-0fc5-11eb-9253-c6f36c202234.gif)

## After:

![Peek 2020-10-16 15-36](https://user-images.githubusercontent.com/588688/96259139-d1eee380-0fc5-11eb-83a2-a91f0e150bac.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
