### PR TITLE
Fixes commenter name + avatar overlap

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5135,6 +5135,7 @@ h1.page-title {
 }
 
 .comments-area.show-avatars .fn {
+	display: inline-block;
 	padding-left: 85px;
 }
 

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -25,6 +25,7 @@
 		}
 
 		.fn {
+			display: inline-block;
 			padding-left: 85px;
 		}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3640,6 +3640,7 @@ h1.page-title {
 }
 
 .comments-area.show-avatars .fn {
+	display: inline-block;
 	padding-right: 85px;
 }
 

--- a/style.css
+++ b/style.css
@@ -3649,6 +3649,7 @@ h1.page-title {
 }
 
 .comments-area.show-avatars .fn {
+	display: inline-block;
 	padding-left: 85px;
 }
 


### PR DESCRIPTION
Fixes #543 

## Summary
Change the author name to `display:inline-block`.

| Before | After |
| ----- | ----- |
| ![Screenshot_2020-10-16 Hello world – My Blog](https://user-images.githubusercontent.com/588688/96265971-c6ec8100-0fce-11eb-8d30-7758efb316ca.png) | ![Screenshot_2020-10-16 Hello world – My Blog(1)](https://user-images.githubusercontent.com/588688/96265996-cfdd5280-0fce-11eb-8180-92886ed718b1.png) |

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
