### PR TITLE
Fixcaption text should be readable.

### DIFF
--- a/assets/sass/04-elements/media.scss
+++ b/assets/sass/04-elements/media.scss
@@ -22,7 +22,7 @@ video {
 figcaption,
 .wp-caption,
 .wp-caption-text {
-	color: inherit;
+	color: currentColor;
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
 	margin-top: calc(0.5 * var(--global--spacing-unit));

--- a/assets/sass/04-elements/media.scss
+++ b/assets/sass/04-elements/media.scss
@@ -22,7 +22,7 @@ video {
 figcaption,
 .wp-caption,
 .wp-caption-text {
-	color: var(--global--color-primary);
+	color: inherit;
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
 	margin-top: calc(0.5 * var(--global--spacing-unit));
@@ -44,4 +44,3 @@ figcaption,
 	margin-top: 0;
 	padding: 0;
 }
-


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #519 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
set color of fixcaption to `inherit`

## Test instructions
- Table
- Gallery
- Image
- Audio
- Video
- Embed

This PR can be tested by following these steps:
1. Add a group block, media and text or cover block and change its background color.
1. Add any of the blocks mentioned above to a post/page.
1. Go to the customizer and change the body background color.
1. See the text color will only change depending on the group its background.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
