### PR TITLE
Update default form label weight

### DIFF
--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -93,8 +93,7 @@
 	--form--line-height: var(--global--line-height-body);
 	--form--color-text: var(--global--color-dark-gray);
 	--form--color-ranged: var(--global--color-secondary);
-	--form--label-weight: normal;
-	--form--label-weight-strong: 500;
+	--form--label-weight: 500;
 	--form--border-color: var(--global--color-secondary);
 	--form--border-width: 3px;
 	--form--border-radius: 0;
@@ -1360,7 +1359,7 @@ p.has-background {
 
 .wp-block-search .wp-block-search__label {
 	font-size: var(--form--font-size);
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 	margin-bottom: calc(var(--global--spacing-vertical) / 3);
 }
 

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -104,8 +104,7 @@ $baseline-unit: 10px;
 	--form--line-height: var(--global--line-height-body);
 	--form--color-text: var(--global--color-dark-gray); // Text color in input fields is always dark over light background.
 	--form--color-ranged: var(--global--color-secondary);
-	--form--label-weight: normal;
-	--form--label-weight-strong: 500;
+	--form--label-weight: 500;
 	--form--border-color: var(--global--color-secondary);
 	--form--border-width: 3px;
 	--form--border-radius: 0;

--- a/assets/sass/05-blocks/search/_editor.scss
+++ b/assets/sass/05-blocks/search/_editor.scss
@@ -3,7 +3,7 @@
 
 	.wp-block-search__label {
 		font-size: var(--form--font-size);
-		font-weight: var(--form--label-weight-strong);
+		font-weight: var(--form--label-weight);
 		margin-bottom: calc(var(--global--spacing-vertical) / 3);
 	}
 

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -3,7 +3,7 @@
 
 	.wp-block-search__label {
 		font-size: var(--form--font-size);
-		font-weight: var(--form--label-weight-strong);
+		font-weight: var(--form--label-weight);
 		margin-bottom: calc(var(--global--spacing-vertical) / 3);
 	}
 

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -267,7 +267,7 @@
 		font-size: var(--global--font-size-sm);
 		margin-bottom: calc(.5 * var(--global--spacing-unit));
 		width: 100%;
-		font-weight: var(--form--label-weight-strong);
+		font-weight: var(--form--label-weight);
 	}
 
 	&.comment-form-cookies-consent {

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -82,7 +82,7 @@
 	> label {
 		width: 100%;
 		margin-bottom: 0;
-		font-weight: var(--form--label-weight-strong);
+		font-weight: var(--form--label-weight);
 	}
 
 	.search-field {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -185,8 +185,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--form--line-height: var(--global--line-height-body);
 	--form--color-text: var(--global--color-dark-gray);
 	--form--color-ranged: var(--global--color-secondary);
-	--form--label-weight: normal;
-	--form--label-weight-strong: 500;
+	--form--label-weight: 500;
 	--form--border-color: var(--global--color-secondary);
 	--form--border-width: 3px;
 	--form--border-radius: 0;
@@ -2743,7 +2742,7 @@ p.has-text-color a {
 
 .wp-block-search .wp-block-search__label {
 	font-size: var(--form--font-size);
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 	margin-bottom: calc(var(--global--spacing-vertical) / 3);
 }
 
@@ -3870,7 +3869,7 @@ h1.page-title {
 	font-size: var(--global--font-size-sm);
 	margin-bottom: calc(.5 * var(--global--spacing-unit));
 	width: 100%;
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 }
 
 .comment-form > p.comment-form-cookies-consent {
@@ -4656,7 +4655,7 @@ h1.page-title {
 .search-form > label {
 	width: 100%;
 	margin-bottom: 0;
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 }
 
 .search-form .search-field {

--- a/style.css
+++ b/style.css
@@ -185,8 +185,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--form--line-height: var(--global--line-height-body);
 	--form--color-text: var(--global--color-dark-gray);
 	--form--color-ranged: var(--global--color-secondary);
-	--form--label-weight: normal;
-	--form--label-weight-strong: 500;
+	--form--label-weight: 500;
 	--form--border-color: var(--global--color-secondary);
 	--form--border-width: 3px;
 	--form--border-radius: 0;
@@ -2747,7 +2746,7 @@ p.has-text-color a {
 
 .wp-block-search .wp-block-search__label {
 	font-size: var(--form--font-size);
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 	margin-bottom: calc(var(--global--spacing-vertical) / 3);
 }
 
@@ -3879,7 +3878,7 @@ h1.page-title {
 	font-size: var(--global--font-size-sm);
 	margin-bottom: calc(.5 * var(--global--spacing-unit));
 	width: 100%;
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 }
 
 .comment-form > p.comment-form-cookies-consent {
@@ -4665,7 +4664,7 @@ h1.page-title {
 .search-form > label {
 	width: 100%;
 	margin-bottom: 0;
-	font-weight: var(--form--label-weight-strong);
+	font-weight: var(--form--label-weight);
 }
 
 .search-form .search-field {


### PR DESCRIPTION
## Summary
I noticed we have two form labels weights. `-form--label-weight` which is 400, and
`-form--label-weight-strong` which is 500. We only need the one, 500. I removed `-form--label-weight-strong` and switched the default value to 500.

## Test instructions

This PR can be tested by following these steps:
1. Go to a missing page and check what weight the label is
2. Go to a password protected post and check what weight the label is
3. Check the weight of the search form label
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [ X ] I have thought about any security implications this code might add.
* [ ] I have checked that this code doesn't impact performance (greatly).
* [ X ] I have tested this code to the best of my abilities
* [ X ] I have checked that this code does not affect the accessibility negatively
