### PR TITLE
Reduce size of comment meta

### DIFF
--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -126,7 +126,7 @@
 
 	.comment-metadata {
 		color: var(--global--color-primary);
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 		padding: 8px 0 9px 0;
 
 		.edit-link {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3730,7 +3730,7 @@ h1.page-title {
 
 .comment-meta .comment-metadata {
 	color: var(--global--color-primary);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	padding: 8px 0 9px 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -3739,7 +3739,7 @@ h1.page-title {
 
 .comment-meta .comment-metadata {
 	color: var(--global--color-primary);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	padding: 8px 0 9px 0;
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #535

## Summary
Reduced the comment meta font size to match post meta.

## Relevant technical choices:
N/A

## Test instructions

This PR can be tested by following these steps:
1. Visit a post with a comment.
2. Check and see that the comment meta (date, edit link) are using the `xs` font variable.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

**Before:**
<img src="https://user-images.githubusercontent.com/2846578/96306494-c4d5f280-0fcd-11eb-93f5-c1ea934100ba.png" width="400" />

**After:**
<img src="https://user-images.githubusercontent.com/2846578/96306458-b687d680-0fcd-11eb-9e8a-07452ef999fd.png" width="400" />

## Quality assurance
* [ x ] I have thought about any security implications this code might add.
* [ ] I have checked that this code doesn't impact performance (greatly).
* [ x ] I have tested this code to the best of my abilities
* [ x ] I have checked that this code does not affect the accessibility negatively
