### PR TITLE
Only display author if the post type supports it

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'twenty_twenty_one_posted_by' ) ) {
 	 * @return void
 	 */
 	function twenty_twenty_one_posted_by() {
-		if ( ! get_the_author_meta( 'description' ) ) {
+		if ( ! get_the_author_meta( 'description' ) && post_type_supports( get_post_type(), 'author' ) ) {
 			echo '<span class="byline">';
 			printf(
 				/* translators: %s author name. */
@@ -179,7 +179,7 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 		<?php if ( is_singular() ) : ?>
 
 			<figure class="post-thumbnail">
-				<?php 
+				<?php
 				// Thumbnail is loaded eagerly because it's going to be in the viewport immediately.
 				the_post_thumbnail( 'post-thumbnail', array( 'loading' => 'eager' ) );
 				?>

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<?php if ( (bool) get_the_author_meta( 'description' ) ) : ?>
+<?php if ( (bool) get_the_author_meta( 'description' ) && post_type_supports( get_post_type(), 'author' ) ) : ?>
 	<div class="author-bio <?php echo get_option( 'show_avatars' ) ? 'show-avatars' : ''; ?>">
 		<?php echo get_avatar( get_the_author_meta( 'ID' ), '85' ); ?>
 		<div class="author-bio-content">


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/566

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Checks if the post type supports author before displaying the author information.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
(Twenty Twenty also checks if the author is supported)

## Test instructions

This PR can be tested by following these steps:
1. Create or view a custom post type (https://developer.wordpress.org/reference/functions/register_post_type/)
1. Test the post type with and without support for author, with and without author description.
1. Test a standard post with and without author description to make sure that it still works.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
