### PR TITLE
Show nesting (parent/child pages) in the pages widget

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6220,6 +6220,10 @@ h1.page-title {
 	margin-left: 13px;
 }
 
+.widget-area ul.children {
+	margin-left: 13px;
+}
+
 .widget-area ul .sub-menu-toggle {
 	display: none;
 }

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -20,7 +20,8 @@
 			line-height: var(--widget--line-height-list);
 		}
 
-		&.sub-menu {
+		&.sub-menu,
+		&.children {
 			margin-left: var(--widget--spacing-menu);
 		}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4600,7 +4600,7 @@ h1.page-title {
 	line-height: var(--widget--line-height-list);
 }
 
-.widget-area ul.sub-menu {
+.widget-area ul.sub-menu, .widget-area ul.children {
 	margin-right: var(--widget--spacing-menu);
 }
 

--- a/style.css
+++ b/style.css
@@ -4609,7 +4609,7 @@ h1.page-title {
 	line-height: var(--widget--line-height-list);
 }
 
-.widget-area ul.sub-menu {
+.widget-area ul.sub-menu, .widget-area ul.children {
 	margin-left: var(--widget--spacing-menu);
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #554 

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Uses the _children_ CSS class with the same style that is used for the navigation menu widget.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Create pages that has child pages, or test with the Theme Unit test.
1. Add a pages widget to the widget area.
1. View the indentation of the child pages below the parent.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

![pages-widget](https://user-images.githubusercontent.com/7422055/96327650-b58d8e00-103b-11eb-860a-7a3f91293d0e.png)

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
