### PR TITLE
Update content pagination to use a nav and increase the spacing

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4739,17 +4739,22 @@ a.custom-logo-link {
 	margin-bottom: 0;
 }
 
-.sticky-post {
-	color: #d1e4dd;
-	background-color: #39414d;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1rem;
-	line-height: 1;
-	padding: 5px 7px;
-}
-
 .no-results.not-found > *:first-child {
 	margin-bottom: 90px;
+}
+
+.page-links {
+	clear: both;
+}
+
+.page-links .post-page-numbers {
+	margin-left: 13px;
+	margin-right: 13px;
+	padding: 10px 0;
+}
+
+.page-links .post-page-numbers:first-child {
+	margin-left: 0;
 }
 
 .entry-title {

--- a/assets/sass/06-components/posts-and-pages.scss
+++ b/assets/sass/06-components/posts-and-pages.scss
@@ -2,15 +2,21 @@
 	// This class is required to pass ThemeCheck.
 }
 
-.sticky-post {
-	color: var(--global--color-background);
-	background-color: var(--global--color-secondary);
-	font-family: var(--global--font-secondary);
-	font-size: var(--global--font-size-xs);
-	line-height: 1;
-	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
-}
-
 .no-results.not-found > *:first-child {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
+// Styling for wp_link_pages.
+.page-links {
+	clear: both;
+
+	.post-page-numbers {
+		margin-left: calc(0.66 * var(--global--spacing-unit));
+		margin-right: calc(0.66 * var(--global--spacing-unit));
+		padding: calc(0.33 * var(--global--spacing-vertical)) 0;
+
+		&:first-child {
+			margin-left: 0;
+		}
+	}
 }

--- a/image.php
+++ b/image.php
@@ -40,12 +40,10 @@ while ( have_posts() ) {
 
 			wp_link_pages(
 				array(
-					'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'twentytwentyone' ) . '</span>',
-					'after'       => '</div>',
-					'link_before' => '<span>',
-					'link_after'  => '</span>',
-					'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', 'twentytwentyone' ) . ' </span>%',
-					'separator'   => '<span class="screen-reader-text">, </span>',
+					'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
+					'after'    => '</nav>',
+					/* translators: There is a space after page. */
+					'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
 				)
 			);
 			?>

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3358,17 +3358,22 @@ a.custom-logo-link {
 	margin-bottom: 0;
 }
 
-.sticky-post {
-	color: var(--global--color-background);
-	background-color: var(--global--color-secondary);
-	font-family: var(--global--font-secondary);
-	font-size: var(--global--font-size-xs);
-	line-height: 1;
-	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
-}
-
 .no-results.not-found > *:first-child {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
+.page-links {
+	clear: both;
+}
+
+.page-links .post-page-numbers {
+	margin-right: calc(0.66 * var(--global--spacing-unit));
+	margin-left: calc(0.66 * var(--global--spacing-unit));
+	padding: calc(0.33 * var(--global--spacing-vertical)) 0;
+}
+
+.page-links .post-page-numbers:first-child {
+	margin-right: 0;
 }
 
 .entry-title {

--- a/style.css
+++ b/style.css
@@ -3367,17 +3367,22 @@ a.custom-logo-link {
 	margin-bottom: 0;
 }
 
-.sticky-post {
-	color: var(--global--color-background);
-	background-color: var(--global--color-secondary);
-	font-family: var(--global--font-secondary);
-	font-size: var(--global--font-size-xs);
-	line-height: 1;
-	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
-}
-
 .no-results.not-found > *:first-child {
 	margin-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
+.page-links {
+	clear: both;
+}
+
+.page-links .post-page-numbers {
+	margin-left: calc(0.66 * var(--global--spacing-unit));
+	margin-right: calc(0.66 * var(--global--spacing-unit));
+	padding: calc(0.33 * var(--global--spacing-vertical)) 0;
+}
+
+.page-links .post-page-numbers:first-child {
+	margin-left: 0;
 }
 
 .entry-title {

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -30,8 +30,10 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentytwentyone' ),
-				'after'  => '</div>',
+				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
+				'after'    => '</nav>',
+				/* translators: There is a space after page. */
+				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
 			)
 		);
 		?>

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -29,8 +29,10 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentytwentyone' ),
-				'after'  => '</div>',
+				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
+				'after'    => '</nav>',
+				/* translators: There is a space after page. */
+				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
 			)
 		);
 		?>

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -33,10 +33,13 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentytwentyone' ),
-				'after'  => '</div>',
+				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
+				'after'    => '</nav>',
+				/* translaors: There is a space after page. */
+				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
 			)
 		);
+
 		?>
 	</div><!-- .entry-content -->
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/557

Partial fix for https://github.com/WordPress/twentytwentyone/issues/533
Follow up on https://github.com/WordPress/twentytwentyone/issues/475

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Replaced the wrapping div with a nav element with an aria label that says "Page".
Cleared the element using CSS.
Removed the span with the text that said "Pages:" 
-I felt that having the text read: `Pages: Page 1 Page 2 Page 3` was redundant, but it also means the pagination looks different than what we are used to. :thinking:

Added the text "Page" before each link
Added spacing that is more consistent with the current older/newer posts pagination, but has a larger click target area of
minimum 59x 46px.

-The pagination was not the same for the image attachment and other types of content. 
This PR makes it more consistent.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View a page or post that has pagination, for example "Template: Paginated" in the Theme Unit Test.
1.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

Before:
![96293380-43239c00-0fb0-11eb-88ef-3efaa16e3fa1](https://user-images.githubusercontent.com/7422055/96328538-77489c80-1044-11eb-8686-45740de5a0a5.jpg)


![paginated-content-before](https://user-images.githubusercontent.com/7422055/96328628-7c5a1b80-1045-11eb-8ce8-a137912bca3a.png)




After:

![clear-float-after](https://user-images.githubusercontent.com/7422055/96328532-597b3780-1044-11eb-8331-fa3964e59dd6.png)

![paginated-content-after](https://user-images.githubusercontent.com/7422055/96328513-26d13f00-1044-11eb-9f1b-db8e7c40700c.png)

</details>


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
