### PR TITLE
Mobile/ small screens: Let the comment text input fields be wider

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5360,6 +5360,13 @@ h1.page-title {
 	flex-grow: 1;
 }
 
+@media only screen and (max-width: 481px) {
+	.comment-form .comment-form-author,
+	.comment-form .comment-form-email {
+		flex-basis: 100%;
+	}
+}
+
 .comment-form .comment-form-cookies-consent > label {
 	font-size: 1rem;
 	font-weight: normal;

--- a/assets/sass/06-components/comments.scss
+++ b/assets/sass/06-components/comments.scss
@@ -238,6 +238,10 @@
 	.comment-form-email {
 		flex-basis: 0;
 		flex-grow: 1;
+
+		@include media(mobile-only) {
+			flex-basis: 100%;
+		}
 	}
 
 	.comment-form-cookies-consent > label,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3842,6 +3842,13 @@ h1.page-title {
 	flex-grow: 1;
 }
 
+@media only screen and (max-width: 481px) {
+	.comment-form .comment-form-author,
+	.comment-form .comment-form-email {
+		flex-basis: 100%;
+	}
+}
+
 .comment-form .comment-form-cookies-consent > label,
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-xs);

--- a/style.css
+++ b/style.css
@@ -3851,6 +3851,13 @@ h1.page-title {
 	flex-grow: 1;
 }
 
+@media only screen and (max-width: 481px) {
+	.comment-form .comment-form-author,
+	.comment-form .comment-form-email {
+		flex-basis: 100%;
+	}
+}
+
 .comment-form .comment-form-cookies-consent > label,
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-xs);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/542

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Changes the width of the author and email fields on the mobile-only media query.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Reduce the browser window width
1. When logged out, view a post or page with a comment form.
1. Confirm that the fields are  full width and on their own row, compared to half width.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

<details>
<summary>Mobile (Small)</summary>

After:
![comment-after](https://user-images.githubusercontent.com/7422055/96329196-d14c6080-104a-11eb-82d3-c9ac9c2aaf4d.png)


</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
