### PR TITLE
Add code block editor styling

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -92,27 +92,27 @@
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:active {
@@ -477,6 +477,18 @@ a:hover {
 .is-style-outline .wp-block-button__link[style*="radius"],
 .wp-block-button__link[style*="radius"] {
 	outline-offset: 2px;
+}
+
+.wp-block-code code {
+	font-size: 1rem;
+}
+
+.wp-block-code {
+	border-color: #28303d;
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0.1rem;
+	padding: 20px;
 }
 
 .wp-block-cover {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -231,51 +231,51 @@ input[type="reset"]:after,
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site button.mejs-inner:not(button):not(.customize-partial-edit-shortcut-button):after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site button.mejs-inner:active:not(.customize-partial-edit-shortcut-button):not(button) {
@@ -1075,23 +1075,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -1101,21 +1101,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2216,14 +2216,16 @@ a:hover {
 }
 
 .wp-block-code {
-	color: #28303d;
-	font-size: 1.125rem;
-	padding: 20px;
 	border-color: #28303d;
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0.1rem;
+	padding: 20px;
 }
 
-.wp-block-code pre {
-	color: #28303d;
+.wp-block-code code {
+	font-size: 1rem;
+	overflow: auto;
 }
 
 .wp-block-columns .wp-block-column > * {
@@ -2640,11 +2642,11 @@ a:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -4338,21 +4340,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4401,21 +4403,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -538,6 +538,18 @@ a:hover {
 	outline-offset: 2px;
 }
 
+.wp-block-code code {
+	font-size: var(--global--font-size-xs);
+}
+
+.wp-block-code {
+	border-color: var(--global--color-border);
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0.1rem;
+	padding: var(--global--spacing-unit);
+}
+
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: var(--cover--color-background);

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -5,6 +5,7 @@
 //   files and conditionally loaded
 
 @import "button/editor";
+@import "code/editor";
 @import "cover/editor";
 @import "columns/editor";
 @import "file/editor";

--- a/assets/sass/05-blocks/code/_editor.scss
+++ b/assets/sass/05-blocks/code/_editor.scss
@@ -1,12 +1,11 @@
+.wp-block-code code {
+	font-size: var(--global--font-size-xs);
+}
+
 .wp-block-code {
 	border-color: var(--global--color-border);
 	border-radius: 0;
 	border-style: solid;
 	border-width: 0.1rem;
 	padding: var(--global--spacing-unit);
-
-	code {
-		font-size: var(--global--font-size-xs);
-		overflow: auto;
-	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1581,14 +1581,16 @@ a:hover {
 }
 
 .wp-block-code {
-	color: var(--global--color-primary);
-	font-size: var(--global--font-size-sm);
-	padding: var(--global--spacing-unit);
 	border-color: var(--global--color-border);
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0.1rem;
+	padding: var(--global--spacing-unit);
 }
 
-.wp-block-code pre {
-	color: var(--global--color-primary);
+.wp-block-code code {
+	font-size: var(--global--font-size-xs);
+	overflow: auto;
 }
 
 .wp-block-columns .wp-block-column > * {

--- a/style.css
+++ b/style.css
@@ -1585,14 +1585,16 @@ a:hover {
 }
 
 .wp-block-code {
-	color: var(--global--color-primary);
-	font-size: var(--global--font-size-sm);
-	padding: var(--global--spacing-unit);
 	border-color: var(--global--color-border);
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0.1rem;
+	padding: var(--global--spacing-unit);
 }
 
-.wp-block-code pre {
-	color: var(--global--color-primary);
+.wp-block-code code {
+	font-size: var(--global--font-size-xs);
+	overflow: auto;
 }
 
 .wp-block-columns .wp-block-column > * {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #531

## Summary
Applied editor styling to tweak the display of the code block. 

## Relevant technical choices:
The theme.css's style application was overriding the code block styles, requiring a dedicated editor style.

## Test instructions

This PR can be tested by following these steps:
1. Add a Code block
2. View it on the front-end to verify they match-up visually.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Editor: 
<img width="1032" alt="Screen Shot 2020-10-17 at 10 18 52 AM" src="https://user-images.githubusercontent.com/1813435/96339477-f5b43700-1062-11eb-9251-11cdd3bb10c3.png">

Front-end:
<img width="1232" alt="Screen Shot 2020-10-17 at 10 19 22 AM" src="https://user-images.githubusercontent.com/1813435/96339468-ee8d2900-1062-11eb-8841-e8b69da11373.png">


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
