### PR TITLE
Group block clear floats

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -748,6 +748,10 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block-group {
+	display: flow-root;
+}
+
 .wp-block-group.has-background {
 	padding: 30px;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -748,10 +748,6 @@ a:hover {
 	margin-bottom: 0;
 }
 
-.wp-block-group {
-	display: flow-root;
-}
-
 .wp-block-group.has-background {
 	padding: 30px;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -748,6 +748,17 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block-group {
+	display: block;
+	clear: both;
+}
+
+.wp-block-group:before, .wp-block-group:after {
+	content: "";
+	display: block;
+	clear: both;
+}
+
 .wp-block-group.has-background {
 	padding: 30px;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -751,6 +751,7 @@ a:hover {
 .wp-block-group {
 	display: block;
 	clear: both;
+	display: flow-root;
 }
 
 .wp-block-group:before, .wp-block-group:after {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2659,6 +2659,10 @@ a:hover {
 	font-size: 1rem;
 }
 
+.wp-block-group {
+	display: flow-root;
+}
+
 .wp-block-group .wp-block-group__inner-container {
 	margin-left: auto;
 	margin-right: auto;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2660,7 +2660,14 @@ a:hover {
 }
 
 .wp-block-group {
-	display: flow-root;
+	display: block;
+	clear: both;
+}
+
+.wp-block-group:before, .wp-block-group:after {
+	content: "";
+	display: block;
+	clear: both;
 }
 
 .wp-block-group .wp-block-group__inner-container {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2662,6 +2662,7 @@ a:hover {
 .wp-block-group {
 	display: block;
 	clear: both;
+	display: flow-root;
 }
 
 .wp-block-group:before, .wp-block-group:after {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -686,6 +686,7 @@ a:hover {
 .wp-block-group {
 	display: block;
 	clear: both;
+	display: flow-root;
 }
 
 .wp-block-group:before, .wp-block-group:after {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -683,6 +683,17 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block-group {
+	display: block;
+	clear: both;
+}
+
+.wp-block-group:before, .wp-block-group:after {
+	content: "";
+	display: block;
+	clear: both;
+}
+
 .wp-block-group.has-background {
 	padding: var(--global--spacing-vertical);
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -683,6 +683,10 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block-group {
+	display: flow-root;
+}
+
 .wp-block-group.has-background {
 	padding: var(--global--spacing-vertical);
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -683,10 +683,6 @@ a:hover {
 	margin-bottom: 0;
 }
 
-.wp-block-group {
-	display: flow-root;
-}
-
 .wp-block-group.has-background {
 	padding: var(--global--spacing-vertical);
 }

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -1,4 +1,17 @@
 .wp-block-group {
+	// Start IE clearfix.
+	// This hack is only necessary because we want to support IE11.
+	// If we don't want to support IE11, then "display: flow-root" would suffice.
+	display: block;
+	clear: both;
+
+	&:before,
+	&:after {
+		content: "";
+		display: block;
+		clear: both;
+	}
+	// End IE clearfix.
 
 	&.has-background {
 		padding: var(--global--spacing-vertical);

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -1,5 +1,4 @@
 .wp-block-group {
-	display: flow-root;
 
 	&.has-background {
 		padding: var(--global--spacing-vertical);

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -5,6 +5,8 @@
 	display: block;
 	clear: both;
 
+	display: flow-root; // stylelint-disable-line declaration-block-no-duplicate-properties
+
 	&:before,
 	&:after {
 		content: "";

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -1,4 +1,5 @@
 .wp-block-group {
+	display: flow-root;
 
 	&.has-background {
 		padding: var(--global--spacing-vertical);

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -11,7 +11,7 @@
 		display: block;
 		clear: both;
 	}
-	// End IF clearfix.
+	// End IE clearfix.
 
 	.wp-block-group__inner-container {
 		margin-left: auto;

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -5,6 +5,8 @@
 	display: block;
 	clear: both;
 
+	display: flow-root; // stylelint-disable-line declaration-block-no-duplicate-properties
+
 	&:before,
 	&:after {
 		content: "";

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -1,4 +1,5 @@
 .wp-block-group {
+	display: flow-root;
 
 	.wp-block-group__inner-container {
 		margin-left: auto;

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -1,5 +1,17 @@
 .wp-block-group {
-	display: flow-root;
+	// Start IE clearfix.
+	// This hack is only necessary because we want to support IE11.
+	// If we don't want to support IE11, then "display: flow-root" would suffice.
+	display: block;
+	clear: both;
+
+	&:before,
+	&:after {
+		content: "";
+		display: block;
+		clear: both;
+	}
+	// End IF clearfix.
 
 	.wp-block-group__inner-container {
 		margin-left: auto;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1835,6 +1835,7 @@ a:hover {
 .wp-block-group {
 	display: block;
 	clear: both;
+	display: flow-root;
 }
 
 .wp-block-group:before, .wp-block-group:after {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1833,7 +1833,14 @@ a:hover {
 }
 
 .wp-block-group {
-	display: flow-root;
+	display: block;
+	clear: both;
+}
+
+.wp-block-group:before, .wp-block-group:after {
+	content: "";
+	display: block;
+	clear: both;
 }
 
 .wp-block-group .wp-block-group__inner-container {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1832,6 +1832,10 @@ a:hover {
 	font-size: var(--global--font-size-xs);
 }
 
+.wp-block-group {
+	display: flow-root;
+}
+
 .wp-block-group .wp-block-group__inner-container {
 	margin-right: auto;
 	margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -1837,7 +1837,14 @@ a:hover {
 }
 
 .wp-block-group {
-	display: flow-root;
+	display: block;
+	clear: both;
+}
+
+.wp-block-group:before, .wp-block-group:after {
+	content: "";
+	display: block;
+	clear: both;
 }
 
 .wp-block-group .wp-block-group__inner-container {

--- a/style.css
+++ b/style.css
@@ -1839,6 +1839,7 @@ a:hover {
 .wp-block-group {
 	display: block;
 	clear: both;
+	display: flow-root;
 }
 
 .wp-block-group:before, .wp-block-group:after {

--- a/style.css
+++ b/style.css
@@ -1836,6 +1836,10 @@ a:hover {
 	font-size: var(--global--font-size-xs);
 }
 
+.wp-block-group {
+	display: flow-root;
+}
+
 .wp-block-group .wp-block-group__inner-container {
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
Fixes #555 

## Summary
Initially I added `display: flow-root;` to group blocks. That worked fine, but then I remembered that doesn't work in IE11 so pushed a solution that will work there too.

## Screenshots

Used the instructions from #555 for the content.

Frontend (dark mode)

![Screenshot_2020-10-19 clearings #555 – My Blog](https://user-images.githubusercontent.com/588688/96414865-5c1d8e80-11f6-11eb-8f0a-08092f5468db.png)

Editor

![Screenshot_2020-10-19 Edit Post ‹ My Blog — WordPress](https://user-images.githubusercontent.com/588688/96414909-7192b880-11f6-11eb-8254-b374869f1307.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
