### PR TITLE
Add continue-reading link to aside & status post-formats

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 
 			$post_format = get_post_format();
 			if ( 'aside' === $post_format || 'status' === $post_format ) {
-				echo '<p><a href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></p>';
+				echo '<p><a href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></p>'; // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 
 			// Posted on.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -72,6 +72,12 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 
 		// Hide meta information on pages.
 		if ( ! is_single() ) {
+
+			$post_format = get_post_format();
+			if ( 'aside' === $post_format || 'status' === $post_format ) {
+				echo '<p><a href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></p>';
+			}
+
 			// Posted on.
 			twenty_twenty_one_posted_on();
 


### PR DESCRIPTION
Fixes #527 

## Summary

Added a continue-reading link to the 2 post-formats that don't have a title/link.

## Screenshots

This is a status post-type. A "continue-reading" link was added in the post-footer.

![Screenshot_2020-10-19 My Blog(3)](https://user-images.githubusercontent.com/588688/96419855-5f684880-11fd-11eb-89d5-66e72839f9eb.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
