### PR TITLE
quote color change

### DIFF
--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -10,7 +10,7 @@
 	border-color: currentColor;
 	position: relative;
 
-	&::before {
+	blockquote::before {
 		color: currentColor;
 		content: "\201C";
 		display: block;
@@ -58,7 +58,7 @@
 			padding: calc(5 * var(--global--spacing-unit));
 		}
 
-		&::before {
+		blockquote::before {
 			text-align: left;
 		}
 

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -6,7 +6,7 @@
 	border-top-style: solid;
 	position: relative;
 
-	&::before {
+	blockquote::before {
 		color: currentColor;
 		content: "\201C";
 		display: block;
@@ -48,7 +48,7 @@
 
 	&.alignleft {
 
-		&:before,
+		blockquote:before,
 		cite {
 			text-align: center;
 		}
@@ -78,7 +78,7 @@
 			padding: calc(5 * var(--global--spacing-unit));
 		}
 
-		&::before {
+		blockquote::before {
 			text-align: left;
 		}
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #518

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Set the quote as a `:before` element on the `blockquote` instead of `figure`

## Test instructions

This PR can be tested by following these steps:
1. Insert a pullquote block
1. change the text color
1. The quote its color should change accordingly
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

</details>

<details>
<summary>Desktop (Large)</summary>

</details>


<details>
<summary>Tablet (Medium)</summary>

</details>


<details>
<summary>Mobile (Small)</summary>

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
