### PR TITLE
Update footer navigation icon color

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6033,11 +6033,12 @@ h1.page-title {
 	color: #28303d;
 }
 
-.footer-navigation-wrapper li svg {
+.footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
+	fill: #28303d;
 }
 
-.footer-navigation-wrapper li svg:hover {
+.footer-navigation-wrapper li .svg-icon:hover {
 	transform: scale(1.1);
 }
 

--- a/assets/sass/06-components/footer-navigation.scss
+++ b/assets/sass/06-components/footer-navigation.scss
@@ -38,8 +38,9 @@
 			}
 		}
 
-		svg {
+		.svg-icon {
 			vertical-align: middle;
+			fill: var(--footer--color-link);
 
 			&:hover {
 				transform: scale(1.1);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4407,11 +4407,12 @@ h1.page-title {
 	color: var(--footer--color-link-hover);
 }
 
-.footer-navigation-wrapper li svg {
+.footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
+	fill: var(--footer--color-link);
 }
 
-.footer-navigation-wrapper li svg:hover {
+.footer-navigation-wrapper li .svg-icon:hover {
 	transform: scale(1.1);
 }
 

--- a/style.css
+++ b/style.css
@@ -4416,11 +4416,12 @@ h1.page-title {
 	color: var(--footer--color-link-hover);
 }
 
-.footer-navigation-wrapper li svg {
+.footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
+	fill: var(--footer--color-link);
 }
 
-.footer-navigation-wrapper li svg:hover {
+.footer-navigation-wrapper li .svg-icon:hover {
 	transform: scale(1.1);
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Partial fix for https://github.com/WordPress/twentytwentyone/issues/592.

## Summary
Adds a fill for the social media icons in the menu, using `var(--footer--color-link)` so that the icon color changes depending on the background.

Uses the CSS class for the icon so that the customizer shortcut icon is not affected by the color.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a menu with social media links to the footer menu location
1. View the icon color.
1. Change the body background color in the customizer.
1. View that the icon color changes when the body background color changes.
<!-- Don't forget to test the unhappy-paths! -->


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
