### PR TITLE
Revert "Unused css variables"

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -24,6 +24,7 @@
 	/* Header */
 	/* Main navigation */
 	/* Pagination */
+	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */
@@ -223,6 +224,11 @@
 	}
 }
 
+blockquote {
+	margin: 0;
+	padding: 0;
+}
+
 blockquote p {
 	font-size: 1.5rem;
 	letter-spacing: normal;
@@ -230,11 +236,15 @@ blockquote p {
 }
 
 blockquote cite {
+	color: #28303d;
 	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 blockquote footer {
+	color: #28303d;
 	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 blockquote > * {
@@ -248,6 +258,42 @@ blockquote > *:first-child {
 
 blockquote > *:last-child {
 	margin-bottom: 0;
+}
+
+blockquote.alignleft, blockquote.alignright {
+	padding-left: inherit;
+}
+
+blockquote.alignleft p {
+	font-size: 1.125rem;
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignright p {
+	font-size: 1.125rem;
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignleft cite {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignleft footer {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignright cite {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignright footer {
+	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 img {
@@ -560,12 +606,6 @@ a:hover {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.wp-block-cover h2{
-	font-size: 3rem;
-	}
-}
-
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -573,12 +613,6 @@ a:hover {
 	padding: 0;
 	max-width: inherit;
 	text-align: inherit;
-}
-
-@media only screen and (min-width: 652px){
-	.wp-block-cover-image h2{
-	font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px){
@@ -1056,22 +1090,10 @@ h1 {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.wp-block-heading h2{
-	font-size: 3rem;
-	}
-}
-
 h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
 	line-height: 1.3;
-}
-
-@media only screen and (min-width: 652px){
-	h2{
-	font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px){
@@ -1092,14 +1114,8 @@ h2 {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.h2{
-	font-size: 3rem;
-	}
-}
-
 .wp-block-heading h3 {
-	font-size: 2rem;
+	font-size: 1.875rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1111,7 +1127,7 @@ h2 {
 }
 
 h3 {
-	font-size: 2rem;
+	font-size: 1.875rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1123,7 +1139,7 @@ h3 {
 }
 
 .h3 {
-	font-size: 2rem;
+	font-size: 1.875rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1263,7 +1279,7 @@ h6 {
 .wp-block-latest-posts > li > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -1530,7 +1546,7 @@ p.has-background {
 
 .wp-block-pullquote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-style: normal;
 	font-weight: 700;
 	letter-spacing: normal;
@@ -1606,7 +1622,7 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote p {
-	font-size: 2rem;
+	font-size: 1.875rem;
 }
 
 @media only screen and (min-width: 652px){
@@ -1866,7 +1882,7 @@ p.has-background {
 .wp-block-rss .wp-block-rss__item-title > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -2522,7 +2538,6 @@ html {
 }
 
 body {
-	line-height: --global--line-height-body;
 	color: #28303d;
 	background-color: #d1e4dd;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -116,6 +116,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	/* Main navigation */
 	/* Pagination */
+	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */
@@ -1471,6 +1472,11 @@ button {
 }
 
 /* Category 04 can contain any default HTML element. Do not add classes here, just give the elements some basic styles. */
+blockquote {
+	margin: 0;
+	padding: 0;
+}
+
 blockquote p {
 	font-size: 1.5rem;
 	letter-spacing: normal;
@@ -1478,11 +1484,15 @@ blockquote p {
 }
 
 blockquote cite {
+	color: #28303d;
 	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 blockquote footer {
+	color: #28303d;
 	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 blockquote > * {
@@ -1496,6 +1506,42 @@ blockquote > *:first-child {
 
 blockquote > *:last-child {
 	margin-bottom: 0;
+}
+
+blockquote.alignleft, blockquote.alignright {
+	padding-left: inherit;
+}
+
+blockquote.alignleft p {
+	font-size: 1.125rem;
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignright p {
+	font-size: 1.125rem;
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignleft cite {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignleft footer {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignright cite {
+	font-size: 1rem;
+	letter-spacing: normal;
+}
+
+blockquote.alignright footer {
+	font-size: 1rem;
+	letter-spacing: normal;
 }
 
 input[type="text"] {
@@ -2446,12 +2492,6 @@ a:hover {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.wp-block-cover h2{
-	font-size: 3rem;
-	}
-}
-
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -2459,12 +2499,6 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 	padding: 0;
-}
-
-@media only screen and (min-width: 652px){
-	.wp-block-cover-image h2{
-	font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px){
@@ -2835,12 +2869,6 @@ h2 {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	h2{
-	font-size: 3rem;
-	}
-}
-
 .h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -2853,14 +2881,8 @@ h2 {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.h2{
-	font-size: 3rem;
-	}
-}
-
 h3 {
-	font-size: 2rem;
+	font-size: 1.875rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -2872,7 +2894,7 @@ h3 {
 }
 
 .h3 {
-	font-size: 2rem;
+	font-size: 1.875rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -3064,7 +3086,7 @@ img {
 .wp-block-latest-posts > li > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -3469,7 +3491,7 @@ p.has-text-color a {
 
 .wp-block-pullquote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-style: normal;
 	font-weight: 700;
 	letter-spacing: normal;
@@ -3584,7 +3606,7 @@ p.has-text-color a {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote p {
-	font-size: 2rem;
+	font-size: 1.875rem;
 }
 
 @media only screen and (min-width: 652px){
@@ -3908,7 +3930,7 @@ p.has-text-color a {
 .wp-block-rss .wp-block-rss__item-title > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 2rem;
+	font-size: 1.875rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -4859,12 +4881,6 @@ a.custom-logo-link {
 	}
 }
 
-@media only screen and (min-width: 652px){
-	.entry-title{
-	font-size: 3rem;
-	}
-}
-
 .entry-title a {
 	color: currentColor;
 	text-underline-offset: 0.15em;
@@ -5254,19 +5270,9 @@ h1.page-title {
 	font-size: 3rem;
 	}
 }
-@media only screen and (min-width: 652px){
-	.comments-title{
-	font-size: 3rem;
-	}
-}
 .comment-reply-title {
 	font-size: 2.25rem;
 	letter-spacing: normal;
-}
-@media only screen and (min-width: 652px){
-	.comment-reply-title{
-	font-size: 3rem;
-	}
 }
 @media only screen and (min-width: 652px){
 	.comment-reply-title{
@@ -5697,6 +5703,8 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
+		display: flex;
+		justify-content: right;
 		margin-left: auto;
 	}
 	.primary-navigation > .primary-menu-container {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -18,19 +18,22 @@
 	--global--font-size-xl: 2.25rem;
 	--global--font-size-xxl: 4rem;
 	--global--font-size-xxxl: 5rem;
+	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
+	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
-	--heading--font-size-h2: var(--global--font-size-xl);
-	--heading--font-size-h1: var(--global--font-size-xxl);
+	--heading--font-size-h3: 1.875rem;
+	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;
 	--heading--letter-spacing-h4: var(--global--letter-spacing);
@@ -42,7 +45,7 @@
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: 1.1;
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -127,7 +130,7 @@
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-secondary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -135,6 +138,7 @@
 	--branding--title--text-transform: uppercase;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
+	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 300px;
 	--branding--logo--max-height: 100px;
 	--branding--logo--max-width-mobile: 96px;
@@ -157,6 +161,7 @@
 	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link: var(--global--color-primary);
@@ -165,6 +170,8 @@
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
+	/* Comments */
+	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -342,6 +349,11 @@
 	}
 }
 
+blockquote {
+	margin: 0;
+	padding: 0;
+}
+
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
@@ -350,7 +362,9 @@ blockquote p {
 
 blockquote cite,
 blockquote footer {
+	color: var(--global--color-primary);
 	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 blockquote > * {
@@ -364,6 +378,23 @@ blockquote > *:first-child {
 
 blockquote > *:last-child {
 	margin-bottom: 0;
+}
+
+blockquote.alignleft, blockquote.alignright {
+	padding-left: inherit;
+}
+
+blockquote.alignleft p, blockquote.alignright p {
+	font-size: var(--heading--font-size-h5);
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignleft cite,
+blockquote.alignleft footer, blockquote.alignright cite,
+blockquote.alignright footer {
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 img {
@@ -1665,7 +1696,7 @@ pre.wp-block-verse {
 .wp-block.editor-post-title__block .editor-post-title__input {
 	color: var(--global--color-secondary);
 	font-family: var(--heading--font-family);
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 	font-weight: var(--heading--font-weight-page-title);
 	line-height: var(--heading--line-height-h1);
 }
@@ -1786,7 +1817,7 @@ html {
 }
 
 body {
-	line-height: var(--wp--typography--line-height, --global--line-height-body);
+	--wp--typography--line-height: var(--global--line-height-body);
 	color: var(--global--color-primary);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -21,11 +21,14 @@ $baseline-unit: 10px;
 	--global--font-size-xl: 2.25rem; // 36px / 16px
 	--global--font-size-xxl: 4rem; // 64px / 16px
 	--global--font-size-xxxl: 5rem; // 80px / 16px
+	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 
 	/* Line Height */
+	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
@@ -34,9 +37,9 @@ $baseline-unit: 10px;
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg)); // 30px / 16px
-	--heading--font-size-h2: var(--global--font-size-xl);
-	--heading--font-size-h1: var(--global--font-size-xxl);
+	--heading--font-size-h3: 1.875rem; // 30px / 16px
+	--heading--font-size-h2: 2.25rem; // 36px / 16px
+	--heading--font-size-h1: var(--global--font-size-page-title);
 
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;
@@ -50,7 +53,7 @@ $baseline-unit: 10px;
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: 1.1;
+	--heading--line-height-h1: var(--global--line-height-page-title);
 
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
@@ -146,7 +149,7 @@ $baseline-unit: 10px;
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-secondary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -154,7 +157,7 @@ $baseline-unit: 10px;
 	--branding--title--text-transform: uppercase;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
-
+	--branding--description--font-family: var(--global--font-secondary);
 
 	--branding--logo--max-width: 300px;
 	--branding--logo--max-height: 100px;
@@ -179,6 +182,7 @@ $baseline-unit: 10px;
 	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--justify-content: right;
 
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
@@ -188,6 +192,9 @@ $baseline-unit: 10px;
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
+
+	/* Comments */
+	--comments--border-color: var(--global--color-border);
 
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);

--- a/assets/sass/03-generic/breakpoints.scss
+++ b/assets/sass/03-generic/breakpoints.scss
@@ -16,6 +16,7 @@ $breakpoint_xxl: 1024px;
 
 // Responsive breakpoints mixin
 @mixin media( $res ) {
+
 	@if mobile-only == $res {
 		@media only screen and (max-width: #{$breakpoint_sm - 1}) {
 			@content;
@@ -130,7 +131,6 @@ $breakpoint_xxl: 1024px;
 }
 
 @include media(mobile) {
-
 	%responsive-alignfull-width {
 		max-width: var(--responsive--alignfull-width);
 		width: auto;
@@ -154,7 +154,6 @@ $breakpoint_xxl: 1024px;
 }
 
 @include media(desktop) {
-
 	%responsive-alignfull-width-nested {
 		margin-left: auto;
 		margin-right: auto;
@@ -162,6 +161,7 @@ $breakpoint_xxl: 1024px;
 		max-width: var(--responsive--alignfull-width);
 	}
 }
+
 
 %responsive-alignleft-mobile {
 
@@ -173,7 +173,6 @@ $breakpoint_xxl: 1024px;
 }
 
 @include media(mobile) {
-
 	%responsive-alignleft {
 
 		/*rtl:ignore*/
@@ -194,7 +193,6 @@ $breakpoint_xxl: 1024px;
 }
 
 @include media(mobile) {
-
 	%responsive-alignright {
 
 		/*rtl:ignore*/

--- a/assets/sass/04-elements/blockquote.scss
+++ b/assets/sass/04-elements/blockquote.scss
@@ -1,4 +1,6 @@
 blockquote {
+	margin: 0;
+	padding: 0;
 
 	p {
 		font-size: var(--heading--font-size-h4);
@@ -8,8 +10,9 @@ blockquote {
 
 	cite,
 	footer {
+		color: var(--global--color-primary);
 		font-size: var(--global--font-size-xs);
-
+		letter-spacing: var(--global--letter-spacing);
 	}
 
 	> * {
@@ -25,5 +28,21 @@ blockquote {
 		}
 	}
 
+	&.alignleft,
+	&.alignright {
 
+		padding-left: inherit;
+
+		p {
+			font-size: var(--heading--font-size-h5);
+			max-width: inherit;
+			width: inherit;
+		}
+
+		cite,
+		footer {
+			font-size: var(--global--font-size-xs);
+			letter-spacing: var(--global--letter-spacing);
+		}
+	}
 }

--- a/assets/sass/05-blocks/utilities/_editor.scss
+++ b/assets/sass/05-blocks/utilities/_editor.scss
@@ -13,7 +13,7 @@
 	.editor-post-title__input {
 		color: var(--global--color-secondary);
 		font-family: var(--heading--font-family);
-		font-size: var(--global--font-size-xxl);
+		font-size: var(--global--font-size-page-title);
 		font-weight: var(--heading--font-weight-page-title);
 		line-height: var(--heading--line-height-h1);
 	}
@@ -115,7 +115,7 @@
 		&[data-align="full"],
 		&.alignfull {
 
-			> [data-block] {
+			>[data-block] {
 				margin-top: 0;
 				margin-bottom: 0;
 			}

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -1,5 +1,5 @@
 .page-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.page-title,
@@ -52,3 +52,4 @@ h1.page-title {
 		}
 	}
 }
+

--- a/assets/sass/06-components/editor.scss
+++ b/assets/sass/06-components/editor.scss
@@ -4,7 +4,7 @@ html {
 }
 
 body {
-	line-height: var(--wp--typography--line-height, --global--line-height-body);
+	--wp--typography--line-height: var(--global--line-height-body);
 	color: var(--global--color-primary);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -25,7 +25,7 @@
 }
 
 .singular .entry-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.entry-title {

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -59,7 +59,7 @@
 
 		&:hover,
 		&:focus {
-			color: var(--branding--color-link-hover);
+			color: var(--global--color-secondary);
 		}
 
 	}

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -162,6 +162,8 @@
 
 	@include media(mobile) {
 		position: relative;
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
 		margin-left: auto;
 
 		// Hide Mobile menu on desktop

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -110,19 +110,22 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--font-size-xl: 2.25rem;
 	--global--font-size-xxl: 4rem;
 	--global--font-size-xxxl: 5rem;
+	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
+	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
-	--heading--font-size-h2: var(--global--font-size-xl);
-	--heading--font-size-h1: var(--global--font-size-xxl);
+	--heading--font-size-h3: 1.875rem;
+	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;
 	--heading--letter-spacing-h4: var(--global--letter-spacing);
@@ -134,7 +137,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: 1.1;
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -219,7 +222,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-secondary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -227,6 +230,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--branding--title--text-transform: uppercase;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
+	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 300px;
 	--branding--logo--max-height: 100px;
 	--branding--logo--max-width-mobile: 96px;
@@ -249,6 +253,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link: var(--global--color-primary);
@@ -257,6 +262,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
+	/* Comments */
+	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -1116,6 +1123,11 @@ button {
 }
 
 /* Category 04 can contain any default HTML element. Do not add classes here, just give the elements some basic styles. */
+blockquote {
+	margin: 0;
+	padding: 0;
+}
+
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
@@ -1124,7 +1136,9 @@ blockquote p {
 
 blockquote cite,
 blockquote footer {
+	color: var(--global--color-primary);
 	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 blockquote > * {
@@ -1138,6 +1152,23 @@ blockquote > *:first-child {
 
 blockquote > *:last-child {
 	margin-bottom: 0;
+}
+
+blockquote.alignleft, blockquote.alignright {
+	padding-right: inherit;
+}
+
+blockquote.alignleft p, blockquote.alignright p {
+	font-size: var(--heading--font-size-h5);
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignleft cite,
+blockquote.alignleft footer, blockquote.alignright cite,
+blockquote.alignright footer {
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 input[type="text"],
@@ -3231,7 +3262,7 @@ table.wp-calendar-table caption {
 }
 
 .site-title a:hover, .site-title a:focus {
-	color: var(--branding--color-link-hover);
+	color: var(--global--color-secondary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -3446,7 +3477,7 @@ a.custom-logo-link {
 }
 
 .singular .entry-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.entry-title {
@@ -3609,7 +3640,7 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 }
 
 .page-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.page-title,
@@ -4087,6 +4118,8 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
 		margin-right: auto;
 	}
 	.primary-navigation > .primary-menu-container {

--- a/style.css
+++ b/style.css
@@ -110,19 +110,22 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--font-size-xl: 2.25rem;
 	--global--font-size-xxl: 4rem;
 	--global--font-size-xxxl: 5rem;
+	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
+	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
+	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
-	--heading--font-size-h2: var(--global--font-size-xl);
-	--heading--font-size-h1: var(--global--font-size-xxl);
+	--heading--font-size-h3: 1.875rem;
+	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;
 	--heading--letter-spacing-h4: var(--global--letter-spacing);
@@ -134,7 +137,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h4: var(--global--line-height-heading);
 	--heading--line-height-h3: var(--heading--line-height);
 	--heading--line-height-h2: var(--heading--line-height);
-	--heading--line-height-h1: 1.1;
+	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
 	--heading--font-weight-strong: 600;
@@ -219,7 +222,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-secondary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -227,6 +230,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--branding--title--text-transform: uppercase;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
+	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 300px;
 	--branding--logo--max-height: 100px;
 	--branding--logo--max-width-mobile: 96px;
@@ -249,6 +253,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link: var(--global--color-primary);
@@ -257,6 +262,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
+	/* Comments */
+	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -1120,6 +1127,11 @@ button {
 }
 
 /* Category 04 can contain any default HTML element. Do not add classes here, just give the elements some basic styles. */
+blockquote {
+	margin: 0;
+	padding: 0;
+}
+
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
@@ -1128,7 +1140,9 @@ blockquote p {
 
 blockquote cite,
 blockquote footer {
+	color: var(--global--color-primary);
 	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 blockquote > * {
@@ -1142,6 +1156,23 @@ blockquote > *:first-child {
 
 blockquote > *:last-child {
 	margin-bottom: 0;
+}
+
+blockquote.alignleft, blockquote.alignright {
+	padding-left: inherit;
+}
+
+blockquote.alignleft p, blockquote.alignright p {
+	font-size: var(--heading--font-size-h5);
+	max-width: inherit;
+	width: inherit;
+}
+
+blockquote.alignleft cite,
+blockquote.alignleft footer, blockquote.alignright cite,
+blockquote.alignright footer {
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing);
 }
 
 input[type="text"],
@@ -3240,7 +3271,7 @@ table.wp-calendar-table caption {
 }
 
 .site-title a:hover, .site-title a:focus {
-	color: var(--branding--color-link-hover);
+	color: var(--global--color-secondary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -3455,7 +3486,7 @@ a.custom-logo-link {
 }
 
 .singular .entry-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.entry-title {
@@ -3618,7 +3649,7 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 }
 
 .page-title {
-	font-size: var(--global--font-size-xxl);
+	font-size: var(--global--font-size-page-title);
 }
 
 h1.page-title,
@@ -4096,6 +4127,8 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
 		margin-left: auto;
 	}
 	.primary-navigation > .primary-menu-container {


### PR DESCRIPTION
Reverts WordPress/twentytwentyone#540

This removed & changed a few variables that are still useful, and included an unrelated blockquote change. Reverting this in favor of an alternate PR for just standardizing & removing unused variables.