### PR TITLE
Clean up custom properties: Remove unused, update use where appropriate

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -24,7 +24,6 @@
 	/* Header */
 	/* Main navigation */
 	/* Pagination */
-	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -605,6 +605,12 @@ a:hover {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.wp-block-cover h2{
+	font-size: 3rem;
+	}
+}
+
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -612,6 +618,12 @@ a:hover {
 	padding: 0;
 	max-width: inherit;
 	text-align: inherit;
+}
+
+@media only screen and (min-width: 652px){
+	.wp-block-cover-image h2{
+	font-size: 3rem;
+	}
 }
 
 @media only screen and (min-width: 652px){
@@ -1089,10 +1101,22 @@ h1 {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.wp-block-heading h2{
+	font-size: 3rem;
+	}
+}
+
 h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
 	line-height: 1.3;
+}
+
+@media only screen and (min-width: 652px){
+	h2{
+	font-size: 3rem;
+	}
 }
 
 @media only screen and (min-width: 652px){
@@ -1113,8 +1137,14 @@ h2 {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.h2{
+	font-size: 3rem;
+	}
+}
+
 .wp-block-heading h3 {
-	font-size: 1.875rem;
+	font-size: 2rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1126,7 +1156,7 @@ h2 {
 }
 
 h3 {
-	font-size: 1.875rem;
+	font-size: 2rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1138,7 +1168,7 @@ h3 {
 }
 
 .h3 {
-	font-size: 1.875rem;
+	font-size: 2rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -1278,7 +1308,7 @@ h6 {
 .wp-block-latest-posts > li > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -1545,7 +1575,7 @@ p.has-background {
 
 .wp-block-pullquote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-style: normal;
 	font-weight: 700;
 	letter-spacing: normal;
@@ -1621,7 +1651,7 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote p {
-	font-size: 1.875rem;
+	font-size: 2rem;
 }
 
 @media only screen and (min-width: 652px){
@@ -1881,7 +1911,7 @@ p.has-background {
 .wp-block-rss .wp-block-rss__item-title > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -116,7 +116,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	/* Main navigation */
 	/* Pagination */
-	/* Comments */
 	/* Footer */
 	/* Block: Pull quote */
 	/* Block: Table */

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2491,6 +2491,12 @@ a:hover {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.wp-block-cover h2{
+	font-size: 3rem;
+	}
+}
+
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -2498,6 +2504,12 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 	padding: 0;
+}
+
+@media only screen and (min-width: 652px){
+	.wp-block-cover-image h2{
+	font-size: 3rem;
+	}
 }
 
 @media only screen and (min-width: 652px){
@@ -2868,6 +2880,12 @@ h2 {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	h2{
+	font-size: 3rem;
+	}
+}
+
 .h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -2880,8 +2898,14 @@ h2 {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.h2{
+	font-size: 3rem;
+	}
+}
+
 h3 {
-	font-size: 1.875rem;
+	font-size: 2rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -2893,7 +2917,7 @@ h3 {
 }
 
 .h3 {
-	font-size: 1.875rem;
+	font-size: 2rem;
 	letter-spacing: normal;
 	line-height: 1.3;
 }
@@ -3085,7 +3109,7 @@ img {
 .wp-block-latest-posts > li > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -3490,7 +3514,7 @@ p.has-text-color a {
 
 .wp-block-pullquote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-style: normal;
 	font-weight: 700;
 	letter-spacing: normal;
@@ -3605,7 +3629,7 @@ p.has-text-color a {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote p {
-	font-size: 1.875rem;
+	font-size: 2rem;
 }
 
 @media only screen and (min-width: 652px){
@@ -3929,7 +3953,7 @@ p.has-text-color a {
 .wp-block-rss .wp-block-rss__item-title > a {
 	display: inline-block;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-weight: normal;
 	line-height: 1.3;
 	margin-bottom: 10px;
@@ -4880,6 +4904,12 @@ a.custom-logo-link {
 	}
 }
 
+@media only screen and (min-width: 652px){
+	.entry-title{
+	font-size: 3rem;
+	}
+}
+
 .entry-title a {
 	color: currentColor;
 	text-underline-offset: 0.15em;
@@ -5269,9 +5299,19 @@ h1.page-title {
 	font-size: 3rem;
 	}
 }
+@media only screen and (min-width: 652px){
+	.comments-title{
+	font-size: 3rem;
+	}
+}
 .comment-reply-title {
 	font-size: 2.25rem;
 	letter-spacing: normal;
+}
+@media only screen and (min-width: 652px){
+	.comment-reply-title{
+	font-size: 3rem;
+	}
 }
 @media only screen and (min-width: 652px){
 	.comment-reply-title{

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5742,8 +5742,6 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
-		display: flex;
-		justify-content: right;
 		margin-left: auto;
 	}
 	.primary-navigation > .primary-menu-container {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -152,7 +152,6 @@
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
-	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -24,7 +24,6 @@
 	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
-	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
@@ -40,8 +39,8 @@
 	--heading--line-height-h6: var(--global--line-height-heading);
 	--heading--line-height-h5: var(--global--line-height-heading);
 	--heading--line-height-h4: var(--global--line-height-heading);
-	--heading--line-height-h3: var(--heading--line-height);
-	--heading--line-height-h2: var(--heading--line-height);
+	--heading--line-height-h3: var(--global--line-height-heading);
+	--heading--line-height-h2: var(--global--line-height-heading);
 	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
@@ -344,7 +343,7 @@ blockquote {
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h4);
 }
 
 blockquote cite,
@@ -594,7 +593,7 @@ a:hover {
 .wp-block-cover-image h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	padding: 0;
 	max-width: inherit;
 	text-align: inherit;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -27,8 +27,8 @@
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: 1.875rem;
-	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
+	--heading--font-size-h2: var(--global--font-size-xl);
 	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -7,8 +7,6 @@
 	/* Font Family */
 	--global--font-primary: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
 	--global--font-secondary: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
-	--global--font-code: monospace;
-	--global--font-ui: var(--font-base, var(--global--font-secondary));
 	/* Font Size */
 	--global--font-size-base: 1.25rem;
 	--global--font-size-xs: 1rem;
@@ -21,7 +19,6 @@
 	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
-	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
 	--global--line-height-page-title: 1.1;
@@ -75,7 +72,6 @@
 	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var(--global--color-primary);
-	--global--color-secondary-hover: var(--global--color-secondary);
 	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
@@ -107,7 +103,6 @@
 	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-background);
 	--button--color-background-active: var(--global--color-background);
 	--button--font-family: var(--global--font-primary);
 	--button--font-size: var(--global--font-size-base);
@@ -122,7 +117,6 @@
 	--entry-header--color-link: currentColor;
 	--entry-header--color-hover: var(--global--color-primary-hover);
 	--entry-header--color-focus: var(--global--color-secondary);
-	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--global--font-secondary);
 	--entry-author-bio--font-family: var(--heading--font-family);
@@ -130,7 +124,7 @@
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--color-link-hover: var(--global--color-secondary);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -155,23 +149,18 @@
 	--primary-nav--font-style-sub-menu-mobile: normal;
 	--primary-nav--font-weight: normal;
 	--primary-nav--font-weight-button: 500;
-	--primary-nav--line-height: var(--global--line-height-body);
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
-	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
 	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
-	--pagination--color-link: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
 	--pagination--font-family: var(--global--font-secondary);
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
-	/* Comments */
-	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -203,7 +192,6 @@
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
-	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
 	/* Widgets */
 	--widget--line-height-list: 1.9;
@@ -232,7 +220,6 @@
 		--button--color-text-hover: var(--global--color-secondary);
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
-		--button--color-background-hover: var(--global--color-background);
 		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -9,9 +9,6 @@ $baseline-unit: 10px;
 	--global--font-primary: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
 	--global--font-secondary: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
 
-	--global--font-code: monospace;
-	--global--font-ui: var(--font-base, var(--global--font-secondary));
-
 	/* Font Size */
 	--global--font-size-base: 1.25rem; // 20px / 16px
 	--global--font-size-xs: 1rem; // 16px / 16px
@@ -25,7 +22,6 @@ $baseline-unit: 10px;
 	--global--letter-spacing: normal;
 
 	/* Line Height */
-	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
 	--global--line-height-page-title: 1.1;
@@ -85,7 +81,6 @@ $baseline-unit: 10px;
 	--global--color-primary: var(--global--color-dark-gray); /* Body text color, site title, footer text color. */
 	--global--color-secondary: var(--global--color-gray); /* Headings */
 	--global--color-primary-hover: var(--global--color-primary);
-	--global--color-secondary-hover: var(--global--color-secondary);
 	--global--color-background: var(--global--color-green); /* Mint, default body background */
 	--global--color-border: var(--global--color-primary); /* Used for borders (separators) */
 
@@ -121,7 +116,6 @@ $baseline-unit: 10px;
 	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-background);
 	--button--color-background-active: var(--global--color-background);
 	// Fonts
 	--button--font-family: var(--global--font-primary);
@@ -140,7 +134,6 @@ $baseline-unit: 10px;
 	--entry-header--color-link: currentColor;
 	--entry-header--color-hover: var(--global--color-primary-hover);
 	--entry-header--color-focus: var(--global--color-secondary);
-	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--global--font-secondary);
 	--entry-author-bio--font-family: var(--heading--font-family);
@@ -176,25 +169,19 @@ $baseline-unit: 10px;
 	--primary-nav--font-style-sub-menu-mobile: normal;
 	--primary-nav--font-weight: normal;
 	--primary-nav--font-weight-button: 500;
-	--primary-nav--line-height: var(--global--line-height-body);
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
-	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
 	--primary-nav--justify-content: right;
 
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
-	--pagination--color-link: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
 	--pagination--font-family: var(--global--font-secondary);
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
-
-	/* Comments */
-	--comments--border-color: var(--global--color-border);
 
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
@@ -231,7 +218,6 @@ $baseline-unit: 10px;
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
-	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
 
 	/* Widgets */
@@ -265,7 +251,6 @@ $baseline-unit: 10px;
 		--button--color-text-hover: var(--global--color-secondary);
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
-		--button--color-background-hover: var(--global--color-background);
 		--button--color-background-active: var(--global--color-background);
 
 		body {

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -172,7 +172,6 @@ $baseline-unit: 10px;
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
-	--primary-nav--justify-content: right;
 
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -28,7 +28,6 @@ $baseline-unit: 10px;
 
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
-	--heading--line-height: var(--global--line-height-heading);
 
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
@@ -47,8 +46,8 @@ $baseline-unit: 10px;
 	--heading--line-height-h6: var(--global--line-height-heading);
 	--heading--line-height-h5: var(--global--line-height-heading);
 	--heading--line-height-h4: var(--global--line-height-heading);
-	--heading--line-height-h3: var(--heading--line-height);
-	--heading--line-height-h2: var(--heading--line-height);
+	--heading--line-height-h3: var(--global--line-height-heading);
+	--heading--line-height-h2: var(--global--line-height-heading);
 	--heading--line-height-h1: var(--global--line-height-page-title);
 
 	--heading--font-weight: normal;

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -32,8 +32,8 @@ $baseline-unit: 10px;
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: 1.875rem; // 30px / 16px
-	--heading--font-size-h2: 2.25rem; // 36px / 16px
+	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
+	--heading--font-size-h2: var(--global--font-size-xl);
 	--heading--font-size-h1: var(--global--font-size-page-title);
 
 	--heading--letter-spacing-h6: 0.05em;

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -142,7 +142,7 @@ $baseline-unit: 10px;
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--color-link-hover: var(--global--color-secondary);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);

--- a/assets/sass/04-elements/blockquote.scss
+++ b/assets/sass/04-elements/blockquote.scss
@@ -5,7 +5,7 @@ blockquote {
 	p {
 		font-size: var(--heading--font-size-h4);
 		letter-spacing: var(--heading--letter-spacing-h4);
-		line-height: var(--heading--line-height);
+		line-height: var(--heading--line-height-h4);
 	}
 
 	cite,

--- a/assets/sass/05-blocks/cover/_editor.scss
+++ b/assets/sass/05-blocks/cover/_editor.scss
@@ -36,7 +36,7 @@
 	h2 {
 		font-size: var(--heading--font-size-h2);
 		letter-spacing: var(--heading--letter-spacing-h2);
-		line-height: var(--heading--line-height);
+		line-height: var(--heading--line-height-h2);
 		padding: 0;
 		max-width: inherit; // undo opinionated styles
 		text-align: inherit;

--- a/assets/sass/05-blocks/cover/_style.scss
+++ b/assets/sass/05-blocks/cover/_style.scss
@@ -36,7 +36,7 @@
 	h2 {
 		font-size: var(--heading--font-size-h2);
 		letter-spacing: var(--heading--letter-spacing-h2);
-		line-height: var(--heading--line-height);
+		line-height: var(--heading--line-height-h2);
 		max-width: inherit; // undo opinionated styles
 		text-align: inherit; // undo opinionated styles
 		padding: 0;

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -3,7 +3,7 @@
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	overflow-wrap: break-word;
 
 	a {

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -59,7 +59,7 @@
 
 		&:hover,
 		&:focus {
-			color: var(--global--color-secondary);
+			color: var(--branding--color-link-hover);
 		}
 
 	}

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -162,8 +162,6 @@
 
 	@include media(mobile) {
 		position: relative;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
 		margin-left: auto;
 
 		// Hide Mobile menu on desktop

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -91,7 +91,7 @@
 		font-family: var(--global--font-primary);
 		font-size: var(--global--font-size-lg);
 		font-weight: var(--pagination--font-weight-strong);
-		line-height: var(--heading--line-height);
+		line-height: var(--global--line-height-heading);
 		@include media(desktop) {
 			margin: 5px calc(24px + (0.25 * var(--global--spacing-unit))) 0;
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -216,7 +216,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--color-link-hover: var(--global--color-secondary);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -3249,7 +3249,7 @@ table.wp-calendar-table caption {
 }
 
 .site-title a:hover, .site-title a:focus {
-	color: var(--global--color-secondary);
+	color: var(--branding--color-link-hover);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -119,8 +119,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: 1.875rem;
-	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
+	--heading--font-size-h2: var(--global--font-size-xl);
 	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -244,7 +244,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
-	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
@@ -4104,8 +4103,6 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
 		margin-right: auto;
 	}
 	.primary-navigation > .primary-menu-container {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -116,7 +116,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
-	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
@@ -132,8 +131,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h6: var(--global--line-height-heading);
 	--heading--line-height-h5: var(--global--line-height-heading);
 	--heading--line-height-h4: var(--global--line-height-heading);
-	--heading--line-height-h3: var(--heading--line-height);
-	--heading--line-height-h2: var(--heading--line-height);
+	--heading--line-height-h3: var(--global--line-height-heading);
+	--heading--line-height-h2: var(--global--line-height-heading);
 	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
@@ -1118,7 +1117,7 @@ blockquote {
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h4);
 }
 
 blockquote cite,
@@ -1717,7 +1716,7 @@ a:hover {
 .wp-block-cover-image h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	max-width: inherit;
 	text-align: inherit;
 	padding: 0;
@@ -3442,7 +3441,7 @@ a.custom-logo-link {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	overflow-wrap: break-word;
 }
 
@@ -4526,7 +4525,7 @@ h1.page-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-heading);
 }
 
 @media only screen and (min-width: 822px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -99,8 +99,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Font Family */
 	--global--font-primary: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
 	--global--font-secondary: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
-	--global--font-code: monospace;
-	--global--font-ui: var(--font-base, var(--global--font-secondary));
 	/* Font Size */
 	--global--font-size-base: 1.25rem;
 	--global--font-size-xs: 1rem;
@@ -113,7 +111,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
-	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
 	--global--line-height-page-title: 1.1;
@@ -167,7 +164,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var(--global--color-primary);
-	--global--color-secondary-hover: var(--global--color-secondary);
 	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
@@ -199,7 +195,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-background);
 	--button--color-background-active: var(--global--color-background);
 	--button--font-family: var(--global--font-primary);
 	--button--font-size: var(--global--font-size-base);
@@ -214,7 +209,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--entry-header--color-link: currentColor;
 	--entry-header--color-hover: var(--global--color-primary-hover);
 	--entry-header--color-focus: var(--global--color-secondary);
-	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--global--font-secondary);
 	--entry-author-bio--font-family: var(--heading--font-family);
@@ -247,23 +241,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--font-style-sub-menu-mobile: normal;
 	--primary-nav--font-weight: normal;
 	--primary-nav--font-weight-button: 500;
-	--primary-nav--line-height: var(--global--line-height-body);
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
-	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
 	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
-	--pagination--color-link: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
 	--pagination--font-family: var(--global--font-secondary);
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
-	/* Comments */
-	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -295,7 +284,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
-	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
 	/* Widgets */
 	--widget--line-height-list: 1.9;
@@ -324,7 +312,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--button--color-text-hover: var(--global--color-secondary);
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
-		--button--color-background-hover: var(--global--color-background);
 		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {

--- a/style.css
+++ b/style.css
@@ -244,7 +244,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
-	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
@@ -4113,8 +4112,6 @@ h1.page-title {
 @media only screen and (min-width: 482px) {
 	.primary-navigation {
 		position: relative;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
 		margin-left: auto;
 	}
 	.primary-navigation > .primary-menu-container {

--- a/style.css
+++ b/style.css
@@ -216,7 +216,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Header */
 	--branding--color-text: var(--global--color-primary);
 	--branding--color-link: var(--global--color-primary);
-	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--color-link-hover: var(--global--color-secondary);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--global--font-size-lg);
 	--branding--title--font-size-mobile: var(--heading--font-size-h4);
@@ -3258,7 +3258,7 @@ table.wp-calendar-table caption {
 }
 
 .site-title a:hover, .site-title a:focus {
-	color: var(--global--color-secondary);
+	color: var(--branding--color-link-hover);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -119,8 +119,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
-	--heading--font-size-h3: 1.875rem;
-	--heading--font-size-h2: 2.25rem;
+	--heading--font-size-h3: calc(1.25 * var(--global--font-size-lg));
+	--heading--font-size-h2: var(--global--font-size-xl);
 	--heading--font-size-h1: var(--global--font-size-page-title);
 	--heading--letter-spacing-h6: 0.05em;
 	--heading--letter-spacing-h5: 0.05em;

--- a/style.css
+++ b/style.css
@@ -116,7 +116,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--line-height-page-title: 1.1;
 	/* Headings */
 	--heading--font-family: var(--global--font-primary);
-	--heading--line-height: var(--global--line-height-heading);
 	--heading--font-size-h6: var(--global--font-size-xs);
 	--heading--font-size-h5: var(--global--font-size-sm);
 	--heading--font-size-h4: var(--global--font-size-lg);
@@ -132,8 +131,8 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--heading--line-height-h6: var(--global--line-height-heading);
 	--heading--line-height-h5: var(--global--line-height-heading);
 	--heading--line-height-h4: var(--global--line-height-heading);
-	--heading--line-height-h3: var(--heading--line-height);
-	--heading--line-height-h2: var(--heading--line-height);
+	--heading--line-height-h3: var(--global--line-height-heading);
+	--heading--line-height-h2: var(--global--line-height-heading);
 	--heading--line-height-h1: var(--global--line-height-page-title);
 	--heading--font-weight: normal;
 	--heading--font-weight-page-title: 300;
@@ -1122,7 +1121,7 @@ blockquote {
 blockquote p {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h4);
 }
 
 blockquote cite,
@@ -1721,7 +1720,7 @@ a:hover {
 .wp-block-cover-image h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	max-width: inherit;
 	text-align: inherit;
 	padding: 0;
@@ -3451,7 +3450,7 @@ a.custom-logo-link {
 	color: var(--entry-header--color);
 	font-size: var(--entry-header--font-size);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--heading--line-height-h2);
 	overflow-wrap: break-word;
 }
 
@@ -4535,7 +4534,7 @@ h1.page-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	font-weight: var(--pagination--font-weight-strong);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-heading);
 }
 
 @media only screen and (min-width: 822px) {

--- a/style.css
+++ b/style.css
@@ -99,8 +99,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Font Family */
 	--global--font-primary: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
 	--global--font-secondary: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
-	--global--font-code: monospace;
-	--global--font-ui: var(--font-base, var(--global--font-secondary));
 	/* Font Size */
 	--global--font-size-base: 1.25rem;
 	--global--font-size-xs: 1rem;
@@ -113,7 +111,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--font-size-page-title: var(--global--font-size-xxl);
 	--global--letter-spacing: normal;
 	/* Line Height */
-	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.3;
 	--global--line-height-page-title: 1.1;
@@ -167,7 +164,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--global--color-secondary: var(--global--color-gray);
 	/* Headings */
 	--global--color-primary-hover: var(--global--color-primary);
-	--global--color-secondary-hover: var(--global--color-secondary);
 	--global--color-background: var(--global--color-green);
 	/* Mint, default body background */
 	--global--color-border: var(--global--color-primary);
@@ -199,7 +195,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--button--color-text-hover: var(--global--color-secondary);
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
-	--button--color-background-hover: var(--global--color-background);
 	--button--color-background-active: var(--global--color-background);
 	--button--font-family: var(--global--font-primary);
 	--button--font-size: var(--global--font-size-base);
@@ -214,7 +209,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--entry-header--color-link: currentColor;
 	--entry-header--color-hover: var(--global--color-primary-hover);
 	--entry-header--color-focus: var(--global--color-secondary);
-	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--global--font-secondary);
 	--entry-author-bio--font-family: var(--heading--font-family);
@@ -247,23 +241,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--font-style-sub-menu-mobile: normal;
 	--primary-nav--font-weight: normal;
 	--primary-nav--font-weight-button: 500;
-	--primary-nav--line-height: var(--global--line-height-body);
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
-	--primary-nav--color-link-border: var(--global--color-primary);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
 	--primary-nav--justify-content: right;
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
-	--pagination--color-link: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
 	--pagination--font-family: var(--global--font-secondary);
 	--pagination--font-size: var(--global--font-size-lg);
 	--pagination--font-weight: normal;
 	--pagination--font-weight-strong: 600;
-	/* Comments */
-	--comments--border-color: var(--global--color-border);
 	/* Footer */
 	--footer--color-text: var(--global--color-primary);
 	--footer--color-link: var(--global--color-primary);
@@ -295,7 +284,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Block: Table */
 	--table--stripes-border-color: var(--global--color-light-gray);
 	--table--stripes-background-color: var(--global--color-light-gray);
-	--table--has-background-border-color: var(--global--color-dark-gray);
 	--table--has-background-text-color: var(--global--color-dark-gray);
 	/* Widgets */
 	--widget--line-height-list: 1.9;
@@ -324,7 +312,6 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--button--color-text-hover: var(--global--color-secondary);
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
-		--button--color-background-hover: var(--global--color-background);
 		--button--color-background-active: var(--global--color-background);
 	}
 	html.has-default-light-palette-background body {


### PR DESCRIPTION
Fixes #486, after the revert of #540

## Summary

I wrote up a quick (hacky) script to run through the CSS files & pull out unused variables, and this PR removes those. It also updates some other variables:

- Update and use the `--branding--color-link-hover` variable
- Remove `--heading--line-height` since it was just a clone of `--global--line-height-heading`, and replaces the use of it in the CSS with the appropriate header level line-height
- I also brought in the relative font-size updates from #540
- Remove `--primary-nav--justify-content` since the value doesn't change anything in the menu display

## Test instructions

This PR can be tested by following these steps:

1. View the site, and make sure there are no visual changes
2. Specifically around headings & navigation (where the most variables were changed/removed)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
