### PR TITLE
Pagination: Add page number placeholder to translated string

### DIFF
--- a/image.php
+++ b/image.php
@@ -42,8 +42,8 @@ while ( have_posts() ) {
 				array(
 					'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
 					'after'    => '</nav>',
-					/* translators: There is a space after page. */
-					'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
+					/* translators: %: page number. */
+					'pagelink' => esc_html__( 'Page %', 'twentytwentyone' ),
 				)
 			);
 			?>

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -32,8 +32,8 @@
 			array(
 				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
 				'after'    => '</nav>',
-				/* translators: There is a space after page. */
-				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
+				/* translators: %: page number. */
+				'pagelink' => esc_html__( 'Page %', 'twentytwentyone' ),
 			)
 		);
 		?>

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -26,8 +26,8 @@
 			array(
 				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
 				'after'    => '</nav>',
-				/* translators: There is a space after page. */
-				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
+				/* translators: %: page number. */
+				'pagelink' => esc_html__( 'Page %', 'twentytwentyone' ),
 			)
 		);
 		?>

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -35,8 +35,8 @@
 			array(
 				'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'twentytwentyone' ) . '">',
 				'after'    => '</nav>',
-				/* translaors: There is a space after page. */
-				'pagelink' => esc_html__( 'Page ', 'twentytwentyone' ) . '%',
+				/* translators: %: page number. */
+				'pagelink' => esc_html__( 'Page %', 'twentytwentyone' ),
 			)
 		);
 


### PR DESCRIPTION
See https://github.com/WordPress/twentytwentyone/pull/570/files#r507867744

## Summary
Move the `%` into the translated string, to support languages where the number appears in a different position.

## Test instructions

This PR can be tested by following these steps:
1. View a page with page breaks
2. The page nav numbers should display correctly, ex: "Page 1  Page 2"
3. This is how it works on trunk - there should be no functionality change

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
