### PR TITLE
Colors: Add an option to disable the "dark mode" functionality

### DIFF
--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -65,7 +65,7 @@ class Twenty_Twenty_One_Custom_Colors {
 
 		$theme_css        = 'editor' === $context ? ':root .editor-styles-wrapper{' : ':root{';
 		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
-		
+
 		if ( 'd1e4dd' !== strtolower( $background_color ) ) {
 			$theme_css .= '--global--color-background: #' . $background_color . ';';
 			$theme_css .= '--global--color-primary: ' . $this->custom_get_readable_color( $background_color ) . ';';
@@ -170,8 +170,9 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-light';
 		}
 
+		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
 		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-		if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+		if ( $should_respect_color_scheme && in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
 			$classes[] = 'has-default-light-palette-background';
 		}
 

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -161,9 +161,9 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			$wp_customize->add_control(
 				'respect_user_color_preference',
 				array(
-					'type'    => 'checkbox',
-					'section' => 'colors',
-					'label'   => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
+					'type'        => 'checkbox',
+					'section'     => 'colors',
+					'label'       => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
 					'description' => __( 'Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?', 'twentytwentyone' ),
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -146,6 +146,27 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					)
 				)
 			);
+
+			$wp_customize->add_setting(
+				'respect_user_color_preference',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => true,
+					'sanitize_callback' => function( $value ) {
+						return (bool) $value;
+					},
+				)
+			);
+
+			$wp_customize->add_control(
+				'respect_user_color_preference',
+				array(
+					'type'    => 'checkbox',
+					'section' => 'colors',
+					'label'   => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
+					'description' => __( 'Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?', 'twentytwentyone' ),
+				)
+			);
 		}
 
 		/**

--- a/functions.php
+++ b/functions.php
@@ -539,9 +539,10 @@ add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' )
  * @return void
  */
 function twentytwentyone_the_html_classes() {
+	$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
 	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
 	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-	if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+	if ( $should_respect_color_scheme && in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
 		echo 'class="has-default-light-palette-background"';
 	}
 }


### PR DESCRIPTION
See #592 

## Summary

The "prefers-color-scheme"/dark mode feature might be unexpected for some site content & customizations, so this PR adds a way to disable it. This also adds a place for us to explain that this feature exists, and how to use it.

## Screenshots

<img width="295" alt="Screen Shot 2020-10-19 at 3 14 56 PM" src="https://user-images.githubusercontent.com/541093/96501188-01982880-121e-11eb-883b-d318f567450a.png">

This text is very, very placeholder — would love some help with the longer description, and what, if any link we should provide for more info. Ideally something that would explain how to turn on dark mode yourself to test it out.

Text out of the screenshot:
> **Support visitor's color scheme preference**
> Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?

## Test instructions

This PR can be tested by following these steps:
1. Open the customizer -> Colors
2. Make sure the background is set to a light color
3. Turn on dark mode, the background should flip to a dark color
4. Unselect the new checkbox, save
5. The background should flip back to the light color
6. Select a dark background, it should save & display correctly

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively — I think we're good since it's on by default
