### PR TITLE
Colors: Use the "dark editor style" when using a dark background color

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -126,6 +126,10 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 
 		// Add support for editor styles.
 		add_theme_support( 'editor-styles' );
+		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
+		if ( 127 > Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( $background_color ) ) {
+			add_theme_support( 'dark-editor-style' );
+		}
 
 		$editor_stylesheet_path = './assets/css/style-editor.css';
 


### PR DESCRIPTION
When a user's selected a dark background for their site, the editor should use the "dark styles", so that the placeholder content displays.

| Before | After |
|--------|------|
| <img width="740" alt="Screen Shot 2020-10-19 at 7 27 01 PM" src="https://user-images.githubusercontent.com/541093/96522491-792b7f00-1241-11eb-82a9-8e4748610ca1.png"> | <img width="770" alt="Screen Shot 2020-10-19 at 7 27 16 PM" src="https://user-images.githubusercontent.com/541093/96522503-7d579c80-1241-11eb-9d69-587235486565.png"> |

## Test instructions

This PR can be tested by following these steps:
1. Go to Customizer -> Colors, select a dark background (from palette or custom)
2. See the text flips to white on the frontend
3. Go to create a new post or page
4. The placeholders should also be light colored text

Optionally test that this doesn't regress light backgrounds 👍 

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
