### PR TITLE
Avoid using "we" and "our" in inline docs.

### DIFF
--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -32,7 +32,7 @@ class Twenty_Twenty_One_Custom_Colors {
 	}
 
 	/**
-	 * Determine the luminance of the given color and then return #fff or #000 so that our text is always readable.
+	 * Determine the luminance of the given color and then return #fff or #000 so that the text is always readable.
 	 *
 	 * @access public
 	 *
@@ -138,7 +138,7 @@ class Twenty_Twenty_One_Custom_Colors {
 		// Remove the "#" symbol from the beginning of the color.
 		$hex = ltrim( $hex, '#' );
 
-		// Make sure we have 6 digits for the below calculations.
+		// Make sure there are 6 digits for the below calculations.
 		if ( 3 === strlen( $hex ) ) {
 			$hex = substr( $hex, 0, 1 ) . substr( $hex, 0, 1 ) . substr( $hex, 1, 1 ) . substr( $hex, 1, 1 ) . substr( $hex, 2, 1 ) . substr( $hex, 2, 1 );
 		}

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -40,8 +40,8 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 		public function register( $wp_customize ) {
 
 			// Change site-title & description to postMessage.
-			$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage'; // @phpstan-ignore-line. We will assume that this setting exist.
-			$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage'; // @phpstan-ignore-line. We will assume that this setting exist.
+			$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage'; // @phpstan-ignore-line. Assume that this setting exists.
+			$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage'; // @phpstan-ignore-line. Assume that this setting exists.
 
 			// Add partial for blogname.
 			$wp_customize->selective_refresh->add_partial(
@@ -126,7 +126,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			// Get the palette from theme-supports.
 			$palette = get_theme_support( 'editor-color-palette' );
 
-			// Build the colors array from our theme-support.
+			// Build the colors array from theme-support.
 			$colors = array();
 			if ( isset( $palette[0] ) && is_array( $palette[0] ) ) {
 				foreach ( $palette[0] as $palette_color ) {

--- a/comments.php
+++ b/comments.php
@@ -14,7 +14,7 @@
 
 /*
  * If the current post is protected by a password and
- * the visitor has not yet entered the password we will
+ * the visitor has not yet entered the password,
  * return early without loading the comments.
  */
 if ( post_password_required() ) {

--- a/functions.php
+++ b/functions.php
@@ -40,9 +40,8 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 
 		/*
 		 * Let WordPress manage the document title.
-		 * By adding theme support, we declare that this theme does not use a
-		 * hard-coded <title> tag in the document head, and expect WordPress to
-		 * provide it for us.
+		 * This theme does not use a hard-coded <title> tag in the document head,
+		 * WordPress will provide it for us.
 		 */
 		add_theme_support( 'title-tag' );
 
@@ -536,7 +535,7 @@ function twentytwentyone_customize_preview_init() {
 add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' );
 
 /**
- * Calculate any classes we may want to add to the main <html> element.
+ * Calculate classes for the main <html> element.
  *
  * @since 1.0.0
  *

--- a/header.php
+++ b/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme
+ * The header.
  *
  * This is the template that displays all of the <head> section and everything up until main.
  *

--- a/image.php
+++ b/image.php
@@ -101,7 +101,7 @@ while ( have_posts() ) {
 		</footer><!-- .entry-footer -->
 	</article><!-- #post-## -->
 	<?php
-	// If comments are open or we have at least one comment, load up the comment template.
+	// If comments are open or there is at least one comment, load up the comment template.
 	if ( comments_open() || get_comments_number() ) {
 		comments_template();
 	}

--- a/inc/custom-css.php
+++ b/inc/custom-css.php
@@ -23,7 +23,7 @@
  */
 function twenty_twenty_one_generate_css( $selector, $style, $value, $prefix = '', $suffix = '', $echo = true ) {
 
-	// Bail early if we have no $selector elements or properties and $value.
+	// Bail early if there is no $selector elements or properties and $value.
 	if ( ! $value || ! $selector ) {
 		return '';
 	}
@@ -34,7 +34,7 @@ function twenty_twenty_one_generate_css( $selector, $style, $value, $prefix = ''
 		/**
 		 * Note to reviewers: $css contains auto-generated CSS.
 		 * It is included inside <style> tags and can only be interpreted as CSS on the browser.
-		 * Using wp_strip_all_tags() here is sufficient escaping since we just need to avoid
+		 * Using wp_strip_all_tags() here is sufficient escaping to avoid
 		 * malicious attempts to close </style> and open a <script>.
 		 */
 		echo wp_strip_all_tags( $css ); // phpcs:ignore WordPress.Security.EscapeOutput

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -398,8 +398,8 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  *
  * @param string      $block_name The full block type name, or a partial match.
  *                                Example: `core/image`, `core-embed/*`.
- * @param string|null $content    The content we need to search in. Use null for get_the_content().
- * @param int         $instances  How many instances of the block we want to print. Defaults to 1.
+ * @param string|null $content    The content to search in. Use null for get_the_content().
+ * @param int         $instances  How many instances of the block will be printed (max). Defaults to 1.
  *
  * @return bool Returns true if a block was located & printed, otherwise false.
  */
@@ -422,10 +422,10 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 			continue;
 		}
 
-		// Check if this the block we're looking for.
+		// Check if this the block matches the $block_name.
 		$is_matching_block = false;
 
-		// If the block ends with *, we should just try to match the first portion.
+		// If the block ends with *, try to match the first portion.
 		if ( '*' === $block_name[-1] ) {
 			$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
 		} else {
@@ -439,7 +439,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 			// Add the block HTML.
 			$blocks_content .= render_block( $block );
 
-			// Break the loop if we've reached the $instances count.
+			// Break the loop if the $instances count was reached.
 			if ( $instances_count >= $instances ) {
 				break;
 			}

--- a/page.php
+++ b/page.php
@@ -16,7 +16,7 @@ while ( have_posts() ) :
 	the_post();
 	get_template_part( 'template-parts/content/content-page' );
 
-	// If comments are open or we have at least one comment, load up the comment template.
+	// If comments are open or there is at least one comment, load up the comment template.
 	if ( comments_open() || get_comments_number() ) {
 		comments_template();
 	}

--- a/single.php
+++ b/single.php
@@ -27,7 +27,7 @@ while ( have_posts() ) :
 		);
 	}
 
-	// If comments are open or we have at least one comment, load up the comment template.
+	// If comments are open or there is at least one comment, load up the comment template.
 	if ( comments_open() || get_comments_number() ) {
 		comments_template();
 	}

--- a/template-parts/excerpt/excerpt-chat.php
+++ b/template-parts/excerpt/excerpt-chat.php
@@ -10,7 +10,7 @@
  */
 
 // If there are paragraph blocks, print up to two.
-// Otherwise this is legacy content, and we can post the excerpt.
+// Otherwise this is legacy content, so print the excerpt.
 if ( has_block( 'core/paragraph', get_the_content() ) ) {
 
 	twenty_twenty_one_print_first_instance_of_block( 'core/paragraph', get_the_content(), 2 );

--- a/template-parts/excerpt/excerpt-gallery.php
+++ b/template-parts/excerpt/excerpt-gallery.php
@@ -9,7 +9,7 @@
  * @since 1.0.0
  */
 
-// Print the 1st gallery we can find.
+// Print the 1st gallery found.
 if ( has_block( 'core/gallery', get_the_content() ) ) {
 
 	twenty_twenty_one_print_first_instance_of_block( 'core/gallery', get_the_content() );

--- a/template-parts/excerpt/excerpt-image.php
+++ b/template-parts/excerpt/excerpt-image.php
@@ -9,7 +9,7 @@
  * @since 1.0.0
  */
 
-// If there is no featured-image, print the first image block we can find.
+// If there is no featured-image, print the first image block found.
 if (
 	! twenty_twenty_one_can_show_post_thumbnail() &&
 	has_block( 'core/image', get_the_content() )


### PR DESCRIPTION
See #602

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
