### PR TITLE
Remove unnecessary get_the_title function from the_content function

### DIFF
--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -25,10 +25,7 @@
 	<div class="entry-content">
 		<?php
 		the_content(
-			sprintf(
-				twenty_twenty_one_continue_reading_text(),
-				get_the_title()
-			)
+			twenty_twenty_one_continue_reading_text()
 		);
 
 		wp_link_pages(


### PR DESCRIPTION
## Summary
Remove unnecessary get_the_title function from the_content function. It was unnecessarily there.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
