### PR TITLE
Calendar color fix

### DIFF
--- a/assets/sass/05-blocks/table/_editor.scss
+++ b/assets/sass/05-blocks/table/_editor.scss
@@ -48,13 +48,15 @@ table.wp-calendar-table {
 
 	thead,
 	tbody {
-		border: 1px solid var(--global--color-dark-gray);
+		color: currentColor;
+		border: 1px solid;
 	}
 
 	caption {
 		font-weight: bold;
 		text-align: left;
 		margin-bottom: var(--global--spacing-unit);
+		color: currentColor;
 	}
 }
 

--- a/assets/sass/05-blocks/table/_style.scss
+++ b/assets/sass/05-blocks/table/_style.scss
@@ -53,13 +53,15 @@ table.wp-calendar-table {
 
 	thead,
 	tbody {
-		border: 1px solid var(--global--color-dark-gray);
+		color: currentColor;
+		border: 1px solid;
 	}
 
 	caption {
 		font-weight: bold;
 		text-align: left;
 		margin-bottom: var(--global--spacing-unit);
+		color: currentColor;
 	}
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes the calendar not using currentColor

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Replaced the gray colors with the currentColor variable

This PR can be tested by following these steps:
1. Add a calendar block to a post/page
1. Change the theme its color
1. The calendar should change its color accordingly
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/20287474/96571541-fbf91c00-12cb-11eb-8139-0f1c4b90ce28.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/20287474/96571572-061b1a80-12cc-11eb-8b51-723593c3eba2.png)

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
