### PR TITLE
Colors: Add an option to disable the "dark mode" functionality (continuation of #599)

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -32,11 +32,11 @@
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	html.has-default-light-palette-background body {
+	html.respect-color-scheme-preference body {
 		background-color: #28303d;
 	}
 	@media (prefers-color-scheme: dark){
-		html.has-default-light-palette-background body{
+		html.respect-color-scheme-preference body{
 		background-color: #28303d;
 		}
 	}
@@ -91,27 +91,27 @@
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:active {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -124,11 +124,11 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	html.has-default-light-palette-background body {
+	html.respect-color-scheme-preference body {
 		background-color: #28303d;
 	}
 	@media (prefers-color-scheme: dark){
-		html.has-default-light-palette-background body{
+		html.respect-color-scheme-preference body{
 		background-color: #28303d;
 		}
 	}
@@ -230,51 +230,51 @@ input[type="reset"]:after,
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site .button:active {
@@ -1074,23 +1074,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -1100,21 +1100,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2653,11 +2653,11 @@ a:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -4474,21 +4474,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4537,21 +4537,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -210,7 +210,7 @@
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	html.has-default-light-palette-background {
+	html.respect-color-scheme-preference {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
@@ -220,7 +220,7 @@
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
 	}
-	html.has-default-light-palette-background body {
+	html.respect-color-scheme-preference body {
 		background-color: var(--global--color-background);
 	}
 }

--- a/assets/js/customize-helpers.js
+++ b/assets/js/customize-helpers.js
@@ -1,0 +1,35 @@
+/**
+ * Get luminance from a HEX color.
+ *
+ * @param {string} hex - The hex color.
+ *
+ * @return {number} - Returns the luminance, number between 0 and 255.
+ */
+function twentytwentyoneGetHexLum( hex ) {
+	var rgb = twentytwentyoneGetRgbFromHex( hex );
+	return Math.round( ( 0.2126 * rgb.r ) + ( 0.7152 * rgb.g ) + ( 0.0722 * rgb.b ) );
+}
+
+/**
+ * Get RGB from HEX.
+ *
+ * @param {string} hex - The hex color.
+ *
+ * @return {Object} - Returns an object {r, g, b}
+ */
+function twentytwentyoneGetRgbFromHex( hex ) {
+	var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
+		result;
+
+	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF").
+	hex = hex.replace( shorthandRegex, function( m, r, g, b ) {
+		return r.toString() + r.toString() + g.toString() + g.toString() + b.toString() + b.toString();
+	} );
+
+	result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec( hex );
+	return result ? {
+		r: parseInt( result[1], 16 ),
+		g: parseInt( result[2], 16 ),
+		b: parseInt( result[3], 16 )
+	} : null;
+}

--- a/assets/js/customize-helpers.js
+++ b/assets/js/customize-helpers.js
@@ -5,7 +5,7 @@
  *
  * @return {number} - Returns the luminance, number between 0 and 255.
  */
-function twentytwentyoneGetHexLum( hex ) {
+function twentytwentyoneGetHexLum( hex ) { // eslint-disable-line no-unused-vars
 	var rgb = twentytwentyoneGetRgbFromHex( hex );
 	return Math.round( ( 0.2126 * rgb.r ) + ( 0.7152 * rgb.g ) + ( 0.0722 * rgb.b ) );
 }

--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -1,0 +1,21 @@
+/* global twentytwentyoneGetHexLum */
+
+( function() {
+	// Wait until the customizer has finished loading.
+	wp.customize.bind( 'ready', function() {
+		// Hide the "respect_user_color_preference" setting if the background-color is dark.
+		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {
+			wp.customize.control( 'respect_user_color_preference' ).deactivate();
+		}
+
+		wp.customize( 'background_color', function( setting ) {
+			setting.bind( function( value ) {
+				if ( 127 > twentytwentyoneGetHexLum( value ) ) {
+					wp.customize.control( 'respect_user_color_preference' ).deactivate();
+				} else {
+					wp.customize.control( 'respect_user_color_preference' ).activate();
+				}
+			} );
+		} );
+	} );
+}() );

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -239,7 +239,7 @@ $baseline-unit: 10px;
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
 
-	html.has-default-light-palette-background {
+	html.respect-color-scheme-preference {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -47,21 +47,6 @@ class Twenty_Twenty_One_Custom_Colors {
 	}
 
 	/**
-	 * Determine if the background color is of the theme's default palette.
-	 *
-	 * @access public
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return bool
-	 */
-	public function is_default_palette() {
-		$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
-		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-		return in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true );
-	}
-
-	/**
 	 * Generate color variables.
 	 *
 	 * Adjust the color value of the CSS variables depending on the background color theme mod.
@@ -131,12 +116,13 @@ class Twenty_Twenty_One_Custom_Colors {
 			(string) filemtime( get_theme_file_path( 'assets/css/custom-color-overrides.css' ) )
 		);
 
-		if ( 'd1e4dd' !== strtolower( get_theme_mod( 'background_color', 'D1E4DD' ) ) ) {
+		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
+		if ( 'd1e4dd' !== strtolower( $background_color ) ) {
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', $this->generate_custom_color_variables( 'editor' ) );
 		} 
 
 		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
-		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
+		if ( $should_respect_color_scheme && self::get_relative_luminance_from_hex( $background_color ) > 127 ) {
 			// Add dark mode variable overrides.
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', '@media (prefers-color-scheme: dark) { :root .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); } }' );
 		}
@@ -192,11 +178,6 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-dark';
 		} else {
 			$classes[] = 'is-background-light';
-		}
-
-		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
-		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
-			$classes[] = 'has-default-light-palette-background';
 		}
 
 		return $classes;

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -194,7 +194,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-light';
 		}
 
-		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
+		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
 		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
 			$classes[] = 'has-default-light-palette-background';
 		}

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -194,7 +194,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-light';
 		}
 
-		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
+		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );  // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
 		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
 		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
 			$classes[] = 'has-default-light-palette-background';

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -195,7 +195,6 @@ class Twenty_Twenty_One_Custom_Colors {
 		}
 
 		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
-		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
 		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
 			$classes[] = 'has-default-light-palette-background';
 		}

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -65,7 +65,7 @@ class Twenty_Twenty_One_Custom_Colors {
 
 		$theme_css        = 'editor' === $context ? ':root .editor-styles-wrapper{' : ':root{';
 		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
-		
+
 		if ( 'd1e4dd' !== strtolower( $background_color ) ) {
 			$theme_css .= '--global--color-background: #' . $background_color . ';';
 			$theme_css .= '--global--color-primary: ' . $this->custom_get_readable_color( $background_color ) . ';';
@@ -170,8 +170,9 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-light';
 		}
 
+		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
 		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-		if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+		if ( $should_respect_color_scheme && in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
 			$classes[] = 'has-default-light-palette-background';
 		}
 

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -135,7 +135,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', $this->generate_custom_color_variables( 'editor' ) );
 		} 
 
-		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true );
+		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
 		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
 			// Add dark mode variable overrides.
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', '@media (prefers-color-scheme: dark) { :root .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); } }' );
@@ -194,7 +194,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-light';
 		}
 
-		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );  // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
+		$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
 		$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
 		if ( $should_respect_color_scheme && $this->is_default_palette() ) {
 			$classes[] = 'has-default-light-palette-background';

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -163,8 +163,8 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'type'            => 'checkbox',
 					'section'         => 'colors',
-					'label'           => esc_html__( 'Respect visitor\'s device light/dark mode settings', 'twentytwentyone' ),
-					'description'     => __( 'Show your site in dark mode if a visitor to your site requests it.', 'twentytwentyone' ),
+					'label'           => esc_html__( 'Respect visitor\'s device dark mode settings', 'twentytwentyone' ),
+					'description'     => __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.', 'twentytwentyone' ),
 					'active_callback' => function( $value ) {
 						return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 					},

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -161,10 +161,13 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			$wp_customize->add_control(
 				'respect_user_color_preference',
 				array(
-					'type'        => 'checkbox',
-					'section'     => 'colors',
-					'label'       => esc_html__( 'Respect visitor\'s device light/dark mode settings', 'twentytwentyone' ),
-					'description' => __( 'Show your site in dark mode if a visitor to your site requests it.', 'twentytwentyone' ),
+					'type'            => 'checkbox',
+					'section'         => 'colors',
+					'label'           => esc_html__( 'Respect visitor\'s device light/dark mode settings', 'twentytwentyone' ),
+					'description'     => __( 'Show your site in dark mode if a visitor to your site requests it.', 'twentytwentyone' ),
+					'active_callback' => function( $value ) {
+						return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
+					},
 				)
 			);
 		}

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -163,8 +163,8 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'type'        => 'checkbox',
 					'section'     => 'colors',
-					'label'       => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
-					'description' => __( 'Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?', 'twentytwentyone' ),
+					'label'       => esc_html__( 'Respect visitor\'s device light/dark mode settings', 'twentytwentyone' ),
+					'description' => __( 'Show your site in dark mode if a visitor to your site requests it.', 'twentytwentyone' ),
 				)
 			);
 		}

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -161,9 +161,9 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 			$wp_customize->add_control(
 				'respect_user_color_preference',
 				array(
-					'type'    => 'checkbox',
-					'section' => 'colors',
-					'label'   => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
+					'type'        => 'checkbox',
+					'section'     => 'colors',
+					'label'       => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
 					'description' => __( 'Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?', 'twentytwentyone' ),
 				)
 			);

--- a/classes/class-twenty-twenty-one-customize.php
+++ b/classes/class-twenty-twenty-one-customize.php
@@ -146,6 +146,27 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 					)
 				)
 			);
+
+			$wp_customize->add_setting(
+				'respect_user_color_preference',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => true,
+					'sanitize_callback' => function( $value ) {
+						return (bool) $value;
+					},
+				)
+			);
+
+			$wp_customize->add_control(
+				'respect_user_color_preference',
+				array(
+					'type'    => 'checkbox',
+					'section' => 'colors',
+					'label'   => esc_html__( 'Support visitor\'s color scheme preference', 'twentytwentyone' ),
+					'description' => __( 'Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?', 'twentytwentyone' ),
+				)
+			);
 		}
 
 		/**

--- a/functions.php
+++ b/functions.php
@@ -528,7 +528,7 @@ function twentytwentyone_customize_preview_init() {
 		'twentytwentyone-customize-helpers',
 		get_theme_file_uri( '/assets/js/customize-helpers.js' ),
 		array(),
-		get_theme_file_path( 'assets/js/customize-helpers.js' ),
+		wp_get_theme()->get( 'Version' ),
 		true
 	);
 
@@ -536,7 +536,7 @@ function twentytwentyone_customize_preview_init() {
 		'twentytwentyone-customize-preview',
 		get_theme_file_uri( '/assets/js/customize-preview.js' ),
 		array( 'customize-preview', 'customize-selective-refresh', 'jquery', 'twentytwentyone-customize-helpers' ),
-		get_theme_file_path( 'assets/js/customize-preview.js' ),
+		wp_get_theme()->get( 'Version' ),
 		true
 	);
 }
@@ -556,7 +556,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 		'twentytwentyone-customize-helpers',
 		get_theme_file_uri( '/assets/js/customize-helpers.js' ),
 		array(),
-		get_theme_file_path( 'assets/js/customize-helpers.js' ),
+		wp_get_theme()->get( 'Version' ),
 		true
 	);
 
@@ -564,7 +564,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 		'twentytwentyone-customize-controls',
 		get_theme_file_uri( '/assets/js/customize.js' ),
 		array( 'customize-base', 'customize-controls', 'underscore', 'jquery', 'twentytwentyone-customize-helpers' ),
-		get_theme_file_path( 'assets/js/customize.js' ),
+		wp_get_theme()->get( 'Version' ),
 		true
 	);
 }

--- a/functions.php
+++ b/functions.php
@@ -525,14 +525,50 @@ require get_template_directory() . '/inc/block-styles.php';
  */
 function twentytwentyone_customize_preview_init() {
 	wp_enqueue_script(
+		'twentytwentyone-customize-helpers',
+		get_theme_file_uri( '/assets/js/customize-helpers.js' ),
+		array(),
+		get_theme_file_path( 'assets/js/customize-helpers.js' ),
+		true
+	);
+
+	wp_enqueue_script(
 		'twentytwentyone-customize-preview',
 		get_theme_file_uri( '/assets/js/customize-preview.js' ),
-		array( 'customize-preview', 'customize-selective-refresh', 'jquery' ),
+		array( 'customize-preview', 'customize-selective-refresh', 'jquery', 'twentytwentyone-customize-helpers' ),
 		get_theme_file_path( 'assets/js/customize-preview.js' ),
 		true
 	);
 }
 add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' );
+
+
+/**
+ * Enqueue scripts for the customizer.
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function twentytwentyone_customize_controls_enqueue_scripts() {
+
+	wp_enqueue_script(
+		'twentytwentyone-customize-helpers',
+		get_theme_file_uri( '/assets/js/customize-helpers.js' ),
+		array(),
+		get_theme_file_path( 'assets/js/customize-helpers.js' ),
+		true
+	);
+
+	wp_enqueue_script(
+		'twentytwentyone-customize-controls',
+		get_theme_file_uri( '/assets/js/customize.js' ),
+		array( 'customize-base', 'customize-controls', 'underscore', 'jquery', 'twentytwentyone-customize-helpers' ),
+		get_theme_file_path( 'assets/js/customize.js' ),
+		true
+	);
+}
+add_action( 'customize_controls_enqueue_scripts', 'twentytwentyone_customize_controls_enqueue_scripts' );
 
 /**
  * Calculate classes for the main <html> element.

--- a/functions.php
+++ b/functions.php
@@ -578,8 +578,9 @@ add_action( 'customize_controls_enqueue_scripts', 'twentytwentyone_customize_con
  * @return void
  */
 function twentytwentyone_the_html_classes() {
+	$background_color            = get_theme_mod( 'background_color', 'D1E4DD' );
 	$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true );
-	if ( $should_respect_color_scheme ) {
+	if ( $should_respect_color_scheme && 127 <= Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( $background_color ) ) {
 		echo 'class="respect-color-scheme-preference"';
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -542,10 +542,8 @@ add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' )
  * @return void
  */
 function twentytwentyone_the_html_classes() {
-	$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
-	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
-	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-	if ( $should_respect_color_scheme && in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
-		echo 'class="has-default-light-palette-background"';
+	$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true );
+	if ( $should_respect_color_scheme ) {
+		echo 'class="respect-color-scheme-preference"';
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -539,9 +539,10 @@ add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' )
  * @return void
  */
 function twentytwentyone_the_html_classes() {
+	$should_respect_color_scheme  = get_theme_mod( 'respect_user_color_preference', true );
 	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
 	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-	if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+	if ( $should_respect_color_scheme && in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
 		echo 'class="has-default-light-palette-background"';
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -302,7 +302,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	html.has-default-light-palette-background {
+	html.respect-color-scheme-preference {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
@@ -312,7 +312,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
 	}
-	html.has-default-light-palette-background body {
+	html.respect-color-scheme-preference body {
 		background-color: var(--global--color-background);
 	}
 }

--- a/style.css
+++ b/style.css
@@ -302,7 +302,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 
 /* OS dark theme preference */
 @media (prefers-color-scheme: dark) {
-	html.has-default-light-palette-background {
+	html.respect-color-scheme-preference {
 		--global--color-background: var(--global--color-dark-gray);
 		--global--color-primary: var(--global--color-light-gray);
 		--global--color-secondary: var(--global--color-light-gray);
@@ -312,7 +312,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
 	}
-	html.has-default-light-palette-background body {
+	html.respect-color-scheme-preference body {
 		background-color: var(--global--color-background);
 	}
 }


### PR DESCRIPTION
This PR continues #599. 

---

See #592 

## Summary

The "prefers-color-scheme"/dark mode feature might be unexpected for some site content & customizations, so this PR adds a way to disable it. This also adds a place for us to explain that this feature exists, and how to use it.

## Screenshots

<img width="295" alt="Screen Shot 2020-10-19 at 3 14 56 PM" src="https://user-images.githubusercontent.com/541093/96501188-01982880-121e-11eb-883b-d318f567450a.png">

This text is very, very placeholder — would love some help with the longer description, and what, if any link we should provide for more info. Ideally something that would explain how to turn on dark mode yourself to test it out.

Text out of the screenshot:
> **Support visitor's color scheme preference**
> Show your site in dark mode if a visitor to your site requests it. More info? Accessibility warning?

## Test instructions

This PR can be tested by following these steps:
1. Open the customizer -> Colors
2. Make sure the background is set to a light color
3. Turn on dark mode, the background should flip to a dark color
4. Unselect the new checkbox, save
5. The background should flip back to the light color
6. Select a dark background, it should save & display correctly

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively — I think we're good since it's on by default
