### PR TITLE
Add customizer notice for dark-mode

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -1,62 +1,58 @@
-/* global twentytwentyoneGetHexLum */
+/* global twentytwentyoneGetHexLum, backgroundColorNotice */
 
 ( function() {
 	// Wait until the customizer has finished loading.
 	wp.customize.bind( 'ready', function() {
+		var supportsDarkMode = ( 127 < twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) && wp.customize( 'respect_user_color_preference' ).get() );
+
 		// Hide the "respect_user_color_preference" setting if the background-color is dark.
 		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {
 			wp.customize.control( 'respect_user_color_preference' ).deactivate();
 		}
 
+		// Add notice on init if needed.
+		if ( window.matchMedia( '(prefers-color-scheme: dark)' ).matches && wp.customize( 'respect_user_color_preference' ) ) {
+			if ( supportsDarkMode ) {
+				wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
+					type: 'info',
+					message: backgroundColorNotice.message
+				} ) );
+			}
+
+			// Remove notice when the value changes.
+			wp.customize( 'background_color', function( setting ) {
+				setting.bind( function() {
+					setting.notifications.remove( 'backgroundColorNotice' );
+				} );
+			} );
+		}
+
+		// Handle changes to the background-color.
 		wp.customize( 'background_color', function( setting ) {
 			setting.bind( function( value ) {
 				if ( 127 > twentytwentyoneGetHexLum( value ) ) {
 					wp.customize.control( 'respect_user_color_preference' ).deactivate();
+					supportsDarkMode = false;
 				} else {
 					wp.customize.control( 'respect_user_color_preference' ).activate();
+					supportsDarkMode = wp.customize( 'respect_user_color_preference' ).get();
 				}
 			} );
 		} );
-	} );
-}() );
 
-/* global backgroundColorNotice */
-
-( function() {
-	// Wait until the customizer has finished loading.
-	wp.customize.bind( 'ready', function() {
-		// Early exit if not on dark mode.
-		if ( ! window.matchMedia( '(prefers-color-scheme: dark)' ).matches || ! backgroundColorNotice.isDarkMode ) {
-			return;
-		}
-
-		/**
-		 * Add initial notice to the `background_color` setting.
-		 *
-		 * @since 1.0.0
-		 */
-		wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
-			type: 'info',
-			message: backgroundColorNotice.darkModeEnabledMessage
-		} ) );
-
-		wp.customize( 'background_color', function( setting ) {
+		// Handle changes to the "respect_user_color_preference" setting.
+		wp.customize( 'respect_user_color_preference', function( setting ) {
 			setting.bind( function( value ) {
-				/**
-				 * Remove the notice if the value changes.
-				 *
-				 * @since 1.0.0
-				 */
-				setting.notifications.remove( 'backgroundColorNotice' );
-
-				/**
-				 * If the background color selected is not one that allows dark-mode, notify the user.
-				 */
-				if ( -1 === backgroundColorNotice.lightPaletteColors.indexOf( value.toUpperCase() ) ) {
-					wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
-						type: 'warning',
-						message: backgroundColorNotice.darkModeUnavailableMessage
-					} ) );
+				supportsDarkMode = value && 127 < twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() );
+				if ( window.matchMedia( '(prefers-color-scheme: dark)' ).matches ) {
+					if ( ! supportsDarkMode ) {
+						wp.customize( 'background_color' ).notifications.remove( 'backgroundColorNotice' );
+					} else {
+						wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
+							type: 'info',
+							message: backgroundColorNotice.message
+						} ) );
+					}
 				}
 			} );
 		} );

--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -3,7 +3,7 @@
 ( function() {
 	// Wait until the customizer has finished loading.
 	wp.customize.bind( 'ready', function() {
-		var supportsDarkMode = ( 127 < twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) && wp.customize( 'respect_user_color_preference' ).get() );
+		var supportsDarkMode = ( 127 <= twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) && wp.customize( 'respect_user_color_preference' ).get() );
 
 		// Hide the "respect_user_color_preference" setting if the background-color is dark.
 		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {

--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -1,0 +1,42 @@
+/* global backgroundColorNotice */
+
+( function() {
+	// Wait until the customizer has finished loading.
+	wp.customize.bind( 'ready', function() {
+		// Early exit if not on dark mode.
+		if ( ! window.matchMedia( '(prefers-color-scheme: dark)' ).matches || ! backgroundColorNotice.isDarkMode ) {
+			return;
+		}
+
+		/**
+		 * Add initial notice to the `background_color` setting.
+		 *
+		 * @since 1.0.0
+		 */
+		wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
+			type: 'info',
+			message: backgroundColorNotice.darkModeEnabledMessage
+		} ) );
+
+		wp.customize( 'background_color', function( setting ) {
+			setting.bind( function( value ) {
+				/**
+				 * Remove the notice if the value changes.
+				 *
+				 * @since 1.0.0
+				 */
+				setting.notifications.remove( 'backgroundColorNotice' );
+
+				/**
+				 * If the background color selected is not one that allows dark-mode, notify the user.
+				 */
+				if ( -1 === backgroundColorNotice.lightPaletteColors.indexOf( value.toUpperCase() ) ) {
+					wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
+						type: 'warning',
+						message: backgroundColorNotice.darkModeUnavailableMessage
+					} ) );
+				}
+			} );
+		} );
+	} );
+}() );

--- a/functions.php
+++ b/functions.php
@@ -535,6 +535,54 @@ function twentytwentyone_customize_preview_init() {
 add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' );
 
 /**
+ * Enqueue scripts for the customizer.
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function twentytwentyone_customize_controls_enqueue_scripts() {
+
+	wp_enqueue_script(
+		'twentytwentyone-customize-controls',
+		get_theme_file_uri( '/assets/js/customize.js' ),
+		array( 'customize-base', 'customize-controls', 'underscore', 'jquery' ),
+		get_theme_file_path( 'assets/js/customize.js' ),
+		true
+	);
+
+	$background_color_notice_vars = array(
+		'isDarkMode'                 => twentytwentyone_supports_dark_mode(),
+		'lightPaletteColors'         => array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' ),
+		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark-mode enabled in your device. Changing the colorpicker will allow you to preview the light mode.', 'twentytwentyone' ),
+		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark-mode.', 'twentytwentyone' ),
+	);
+
+	wp_localize_script(
+		'twentytwentyone-customize-controls',
+		'backgroundColorNotice',
+		$background_color_notice_vars
+	);
+}
+add_action( 'customize_controls_enqueue_scripts', 'twentytwentyone_customize_controls_enqueue_scripts' );
+
+/**
+ * Determine if the theme supports dark-mode based on the settings.
+ *
+ * @since 1.0.0
+ *
+ * @return bool
+ */
+function twentytwentyone_supports_dark_mode() {
+	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
+	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
+	if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
  * Calculate classes for the main <html> element.
  *
  * @since 1.0.0
@@ -542,9 +590,7 @@ add_action( 'customize_preview_init', 'twentytwentyone_customize_preview_init' )
  * @return void
  */
 function twentytwentyone_the_html_classes() {
-	$background_color             = get_theme_mod( 'background_color', 'D1E4DD' );
-	$light_colors_default_palette = array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' );
-	if ( in_array( strtoupper( '#' . ltrim( $background_color, '#' ) ), $light_colors_default_palette, true ) ) {
+	if ( twentytwentyone_supports_dark_mode() ) {
 		echo 'class="has-default-light-palette-background"';
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -555,7 +555,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 		'isDarkMode'                 => twentytwentyone_supports_dark_mode(),
 		'lightPaletteColors'         => array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' ),
 		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled in your device. Changing the color picker will allow you to preview the light mode.', 'twentytwentyone' ),
-		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark-mode.', 'twentytwentyone' ),
+		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark mode.', 'twentytwentyone' ),
 	);
 
 	wp_localize_script(

--- a/functions.php
+++ b/functions.php
@@ -554,7 +554,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 	$background_color_notice_vars = array(
 		'isDarkMode'                 => twentytwentyone_supports_dark_mode(),
 		'lightPaletteColors'         => array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' ),
-		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled on your device. Changing the color will allow you to preview the light mode.', 'twentytwentyone' ),
+		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled on your device. Changing the color picker will allow you to preview light mode.', 'twentytwentyone' ),
 		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark mode.', 'twentytwentyone' ),
 	);
 

--- a/functions.php
+++ b/functions.php
@@ -554,7 +554,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 	$background_color_notice_vars = array(
 		'isDarkMode'                 => twentytwentyone_supports_dark_mode(),
 		'lightPaletteColors'         => array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' ),
-		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark-mode enabled in your device. Changing the colorpicker will allow you to preview the light mode.', 'twentytwentyone' ),
+		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled in your device. Changing the color picker will allow you to preview the light mode.', 'twentytwentyone' ),
 		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark-mode.', 'twentytwentyone' ),
 	);
 

--- a/functions.php
+++ b/functions.php
@@ -554,7 +554,7 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 	$background_color_notice_vars = array(
 		'isDarkMode'                 => twentytwentyone_supports_dark_mode(),
 		'lightPaletteColors'         => array( '#D1E4DD', '#D1DFE4', '#D1D1E4', '#E4D1D1', '#E4DAD1', '#EEEADD', '#FFFFFF' ),
-		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled in your device. Changing the color picker will allow you to preview the light mode.', 'twentytwentyone' ),
+		'darkModeEnabledMessage'     => esc_html__( 'You currently have dark mode enabled on your device. Changing the color will allow you to preview the light mode.', 'twentytwentyone' ),
 		'darkModeUnavailableMessage' => esc_html__( 'Selecting a custom color disables dark mode support. Select one of the light colors from the palette if you need to support dark mode.', 'twentytwentyone' ),
 	);
 

--- a/functions.php
+++ b/functions.php
@@ -567,6 +567,14 @@ function twentytwentyone_customize_controls_enqueue_scripts() {
 		get_theme_file_path( 'assets/js/customize.js' ),
 		true
 	);
+
+	wp_localize_script(
+		'twentytwentyone-customize-controls',
+		'backgroundColorNotice',
+		array(
+			'message' => esc_html__( 'You currently have dark mode enabled on your device. Changing the color will allow you to preview the light mode.', 'twentytwentyone' ),
+		)
+	);
 }
 add_action( 'customize_controls_enqueue_scripts', 'twentytwentyone_customize_controls_enqueue_scripts' );
 


### PR DESCRIPTION
Fixes #614 

This PR adds a customizer notice in the background-color setting so that dark-mode users can easier understand what goes on and why.

![Peek 2020-10-20 15-52](https://user-images.githubusercontent.com/588688/96588665-9cf7cf00-12ec-11eb-9868-4652c5d63831.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
