### PR TITLE
Change the direction of the calendar arrows on RTL

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -270,8 +270,8 @@ function twenty_twenty_one_get_icon_svg( $group, $icon, $size = 24 ) {
  * @return string
  */
 function twenty_twenty_one_change_calendar_nav_arrows( $calendar_output ) {
-	$calendar_output = str_replace( '&laquo; ', twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ), $calendar_output );
-	$calendar_output = str_replace( ' &raquo;', twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ), $calendar_output );
+	$calendar_output = str_replace( '&laquo; ', is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ), $calendar_output );
+	$calendar_output = str_replace( ' &raquo;', is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ), $calendar_output );
 	return $calendar_output;
 }
 add_filter( 'get_calendar', 'twenty_twenty_one_change_calendar_nav_arrows' );


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/552

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Adds an is_rtl conditional and displays the left or right arrow depending on if RTL is used.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a calendar widget block and view the icons.
1. Set the site to use an RTL language.
1. View the arrows.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.
![arrow](https://user-images.githubusercontent.com/7422055/96589035-a4b37580-12e4-11eb-85d9-385e3c8b7cd7.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
