### PR TITLE
Make post meta in footer consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor/
 *.sublime-project
 *.sublime-workspace
 *.map
+*.log

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -44,8 +44,6 @@ h1.page-title {
 
 	.entry-footer {
 
-		.posted-on,
-		.byline,
 		.cat-links,
 		.tags-links {
 			display: block;

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -42,19 +42,22 @@ h1.page-title {
 		}
 	}
 
+	.entry-footer {
+
+		.posted-on,
+		.byline,
+		.cat-links,
+		.tags-links {
+			display: block;
+		}
+	}
+
 	&.logged-in {
 
 		.entry-footer {
 
 			.posted-on {
 				margin-right: calc(0.5 * var(--global--spacing-unit));
-			}
-
-			.posted-on,
-			.byline,
-			.cat-links,
-			.tags-links {
-				display: block;
 			}
 		}
 	}

--- a/assets/sass/06-components/archives.scss
+++ b/assets/sass/06-components/archives.scss
@@ -49,6 +49,13 @@ h1.page-title {
 			.posted-on {
 				margin-right: calc(0.5 * var(--global--spacing-unit));
 			}
+
+			.posted-on,
+			.byline,
+			.cat-links,
+			.tags-links {
+				display: block;
+			}
 		}
 	}
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -95,7 +95,7 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				if ( $categories_list ) {
 					printf(
 						/* translators: %s: list of categories. */
-						'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'twentytwentyone' ) . '. </span>',
+						'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'twentytwentyone' ) . ' </span>',
 						$categories_list // phpcs:ignore WordPress.Security.EscapeOutput
 					);
 				}
@@ -105,7 +105,7 @@ if ( ! function_exists( 'twenty_twenty_one_entry_meta_footer' ) ) {
 				if ( $tags_list ) {
 					printf(
 						/* translators: %s: list of tags. */
-						'<span class="tags-links">' . esc_html__( 'Tagged %s', 'twentytwentyone' ) . '.</span>',
+						'<span class="tags-links">' . esc_html__( 'Tagged %s', 'twentytwentyone' ) . '</span>',
 						$tags_list // phpcs:ignore WordPress.Security.EscapeOutput
 					);
 				}

--- a/style.css
+++ b/style.css
@@ -3610,6 +3610,22 @@ h1.page-title {
 	margin-top: calc(2 * var(--global--spacing-vertical));
 }
 
+.archive .entry-footer .posted-on,
+.archive .entry-footer .byline,
+.archive .entry-footer .cat-links,
+.archive .entry-footer .tags-links,
+.search .entry-footer .posted-on,
+.search .entry-footer .byline,
+.search .entry-footer .cat-links,
+.search .entry-footer .tags-links,
+.blog .entry-footer .posted-on,
+.blog .entry-footer .byline,
+.blog .entry-footer .cat-links,
+.blog .entry-footer .tags-links {
+	display: block;
+}
+
+
 .archive.logged-in .entry-footer .posted-on,
 .search.logged-in .entry-footer .posted-on,
 .blog.logged-in .entry-footer .posted-on {

--- a/style.css
+++ b/style.css
@@ -3610,16 +3610,10 @@ h1.page-title {
 	margin-top: calc(2 * var(--global--spacing-vertical));
 }
 
-.archive .entry-footer .posted-on,
-.archive .entry-footer .byline,
 .archive .entry-footer .cat-links,
 .archive .entry-footer .tags-links,
-.search .entry-footer .posted-on,
-.search .entry-footer .byline,
 .search .entry-footer .cat-links,
 .search .entry-footer .tags-links,
-.blog .entry-footer .posted-on,
-.blog .entry-footer .byline,
 .blog .entry-footer .cat-links,
 .blog .entry-footer .tags-links {
 	display: block;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #550 - Remove period after footer meta categories, and brings consistency to footer post meta generally

## Summary
* Removing periods from post meta when shown in the post footer on archive and single views
* Set each post meta item to `display:block`; on their own row

## Relevant technical choices:

## Test instructions

This PR can be tested by following these steps:
1. Preview a post (with both tags and categories) in single view
2. Preview the category in which the post is contained.

## Screenshots

Single:
![Screen Shot 2020-10-21 at 7 03 14 am](https://user-images.githubusercontent.com/1842363/96640079-62367b00-136e-11eb-81c1-02df16f662f8.jpg)

Archive:
![Screen Shot 2020-10-21 at 7 18 23 am](https://user-images.githubusercontent.com/1842363/96640090-66629880-136e-11eb-9fbd-6be00d384990.jpg)


## Quality assurance
* [x ] I have thought about any security implications this code might add.
* [x ] I have checked that this code doesn't impact performance (greatly).
* [x ] I have tested this code to the best of my abilities
* [x ] I have checked that this code does not affect the accessibility negatively
