### PR TITLE
Add a dark-mode toggle

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6782,46 +6782,12 @@ footer {
 #night-day-toggle {
 	cursor: pointer;
 	position: fixed;
-	bottom: 1em;
-	right: 1em;
-	padding: 24px;
-}
-
-#night-day-toggle label {
-	border-radius: 50%;
-	width: 36px;
-	height: 36px;
-	position: absolute;
-	top: 5px;
-	left: 5px;
-	box-shadow: inset 16px -16px 0 0 #28303d;
-	transform: scale(1) rotate(-2deg);
-	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-}
-
-#night-day-toggle label:before {
-	content: "";
-	width: inherit;
-	height: inherit;
-	border-radius: inherit;
-	position: absolute;
-	left: 0;
-	top: 0;
-	transition: background .3s ease;
-}
-
-#night-day-toggle label:after {
-	content: "";
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	margin: -4px 0 0 -4px;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
-	transform: scale(0);
-	transition: all .3s ease;
+	bottom: 5px;
+	right: 5px;
+	padding: 5px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 #night-day-toggle input {
@@ -6832,20 +6798,53 @@ footer {
 	position: absolute;
 }
 
-#night-day-toggle input:checked + label {
-	box-shadow: inset 32px -32px 0 0 #28303d;
-	transform: scale(0.5) rotate(0deg);
-	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
+#night-day-toggle *,
+#night-day-toggle *:after,
+#night-day-toggle *:before {
+	box-sizing: border-box;
 }
 
-#night-day-toggle input:checked + label:before {
-	background: #fff;
-	transition: background .3s ease .1s;
+#night-day-toggle label {
+	position: relative;
+	display: block;
+	width: 60px;
+	height: 33px;
+	border-radius: 33px;
+	background-color: currentColor;
+	overflow: hidden;
+	cursor: pointer;
+	margin: 0;
 }
 
-#night-day-toggle input:checked + label:after {
-	transform: scale(1.5);
-	transition: transform .5s ease .15s;
+#night-day-toggle label:before, #night-day-toggle label:after {
+	display: block;
+	position: absolute;
+	content: "";
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	top: 4.5px;
+	left: 4.5px;
+	transition: .1s ease-in-out;
+}
+
+#night-day-toggle label:before {
+	background-color: #d1e4dd;
+}
+
+#night-day-toggle label:after {
+	background-color: currentColor;
+	left: -19px;
+	transform: scale(0.00001);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:before {
+	background-color: #d1e4dd;
+	transform: translateX(27px);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:after {
+	transform: translateX(40px) scale(1);
 }
 
 #night-day-toggle.focused {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6737,4 +6737,193 @@ section,
 footer {
 	max-width: none;
 }
+
+#night-day-toggle {
+	position: fixed;
+	bottom: 10px;
+	right: 1em;
+	overflow: hidden;
+}
+
+#night-day-toggle input {
+	position: absolute;
+	left: -99em;
+}
+
+#night-day-toggle .toggle {
+	cursor: pointer;
+	display: inline-block;
+	position: relative;
+	width: 90px;
+	height: 50px;
+	background-color: #83d8ff;
+	border-radius: 84px;
+	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .toggle__handler {
+	display: inline-block;
+	position: relative;
+	z-index: 1;
+	top: 3px;
+	left: -7px;
+	width: 44px;
+	height: 44px;
+	background-color: #ffcf96;
+	border-radius: 50px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
+	transform: rotate(-45deg);
+}
+
+#night-day-toggle .toggle__handler .crater {
+	position: absolute;
+	background-color: #e8cda5;
+	opacity: 0;
+	transition: opacity 200ms ease-in-out;
+	border-radius: 100%;
+}
+
+#night-day-toggle .toggle__handler .crater--1 {
+	top: 18px;
+	left: 10px;
+	width: 4px;
+	height: 4px;
+}
+
+#night-day-toggle .toggle__handler .crater--2 {
+	top: 28px;
+	left: 22px;
+	width: 6px;
+	height: 6px;
+}
+
+#night-day-toggle .toggle__handler .crater--3 {
+	top: 10px;
+	left: 25px;
+	width: 8px;
+	height: 8px;
+}
+
+#night-day-toggle .star {
+	position: absolute;
+	background-color: #fff;
+	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	border-radius: 50%;
+}
+
+#night-day-toggle .star--1 {
+	top: 10px;
+	left: 35px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--2 {
+	top: 18px;
+	left: 28px;
+	z-index: 1;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--3 {
+	top: 27px;
+	left: 40px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--4,
+#night-day-toggle .star--5,
+#night-day-toggle .star--6 {
+	opacity: 0;
+	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .star--4 {
+	top: 16px;
+	left: 11px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle .star--5 {
+	top: 32px;
+	left: 17px;
+	z-index: 0;
+	width: 3px;
+	height: 3px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle .star--6 {
+	top: 36px;
+	left: 28px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle {
+	background-color: #749dd6;
+}
+
+#night-day-toggle input:checked + .toggle:before {
+	color: #749ed7;
+}
+
+#night-day-toggle input:checked + .toggle:after {
+	color: #fff;
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler {
+	background-color: #ffe5b5;
+	transform: translate3d(40px, 0, 0) rotate(0);
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler .crater {
+	opacity: 1;
+}
+
+#night-day-toggle input:checked + .toggle .star--1 {
+	width: 2px;
+	height: 2px;
+}
+
+#night-day-toggle input:checked + .toggle .star--2 {
+	width: 4px;
+	height: 4px;
+	transform: translate3d(-5px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--3 {
+	width: 2px;
+	height: 2px;
+	transform: translate3d(-7px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4,
+#night-day-toggle input:checked + .toggle .star--5,
+#night-day-toggle input:checked + .toggle .star--6 {
+	opacity: 1;
+	transform: translate3d(0, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4 {
+	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--5 {
+	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--6 {
+	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
 /*# sourceMappingURL=ie.css.map */

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6760,7 +6760,7 @@ footer {
 }
 
 #night-day-toggle input + label:before {
-	content: '';
+	content: "";
 	width: inherit;
 	height: inherit;
 	border-radius: inherit;
@@ -6771,7 +6771,7 @@ footer {
 }
 
 #night-day-toggle input + label:after {
-	content: '';
+	content: "";
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6784,23 +6784,22 @@ footer {
 	position: fixed;
 	bottom: 1em;
 	right: 1em;
+	padding: 24px;
 }
 
-#night-day-toggle input {
-	display: none;
-}
-
-#night-day-toggle input + label {
+#night-day-toggle label {
 	border-radius: 50%;
 	width: 36px;
 	height: 36px;
-	position: relative;
+	position: absolute;
+	top: 5px;
+	left: 5px;
 	box-shadow: inset 16px -16px 0 0 #28303d;
 	transform: scale(1) rotate(-2deg);
 	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle input + label:before {
+#night-day-toggle label:before {
 	content: "";
 	width: inherit;
 	height: inherit;
@@ -6811,7 +6810,7 @@ footer {
 	transition: background .3s ease;
 }
 
-#night-day-toggle input + label:after {
+#night-day-toggle label:after {
 	content: "";
 	width: 8px;
 	height: 8px;
@@ -6823,6 +6822,14 @@ footer {
 	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
 	transform: scale(0);
 	transition: all .3s ease;
+}
+
+#night-day-toggle input {
+	width: 1px;
+	height: 1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
 }
 
 #night-day-toggle input:checked + label {
@@ -6839,5 +6846,9 @@ footer {
 #night-day-toggle input:checked + label:after {
 	transform: scale(1.5);
 	transition: transform .5s ease .15s;
+}
+
+#night-day-toggle.focused {
+	box-shadow: 0 0 0 2px currentColor;
 }
 /*# sourceMappingURL=ie.css.map */

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6739,191 +6739,64 @@ footer {
 }
 
 #night-day-toggle {
+	cursor: pointer;
 	position: fixed;
-	bottom: 10px;
+	bottom: 1em;
 	right: 1em;
-	overflow: hidden;
 }
 
 #night-day-toggle input {
-	position: absolute;
-	left: -99em;
+	display: none;
 }
 
-#night-day-toggle .toggle {
-	cursor: pointer;
-	display: inline-block;
+#night-day-toggle input + label {
+	border-radius: 50%;
+	width: 36px;
+	height: 36px;
 	position: relative;
-	width: 90px;
-	height: 50px;
-	background-color: #83d8ff;
-	border-radius: 84px;
-	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	box-shadow: inset 16px -16px 0 0 #28303d;
+	transform: scale(1) rotate(-2deg);
+	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle .toggle__handler {
-	display: inline-block;
-	position: relative;
-	z-index: 1;
-	top: 3px;
-	left: -7px;
-	width: 44px;
-	height: 44px;
-	background-color: #ffcf96;
-	border-radius: 50px;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
-	transform: rotate(-45deg);
-}
-
-#night-day-toggle .toggle__handler .crater {
+#night-day-toggle input + label:before {
+	content: '';
+	width: inherit;
+	height: inherit;
+	border-radius: inherit;
 	position: absolute;
-	background-color: #e8cda5;
-	opacity: 0;
-	transition: opacity 200ms ease-in-out;
-	border-radius: 100%;
+	left: 0;
+	top: 0;
+	transition: background .3s ease;
 }
 
-#night-day-toggle .toggle__handler .crater--1 {
-	top: 18px;
-	left: 10px;
-	width: 4px;
-	height: 4px;
-}
-
-#night-day-toggle .toggle__handler .crater--2 {
-	top: 28px;
-	left: 22px;
-	width: 6px;
-	height: 6px;
-}
-
-#night-day-toggle .toggle__handler .crater--3 {
-	top: 10px;
-	left: 25px;
+#night-day-toggle input + label:after {
+	content: '';
 	width: 8px;
 	height: 8px;
-}
-
-#night-day-toggle .star {
-	position: absolute;
-	background-color: #fff;
-	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
 	border-radius: 50%;
+	margin: -4px 0 0 -4px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
+	transform: scale(0);
+	transition: all .3s ease;
 }
 
-#night-day-toggle .star--1 {
-	top: 10px;
-	left: 35px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label {
+	box-shadow: inset 32px -32px 0 0 #28303d;
+	transform: scale(0.5) rotate(0deg);
+	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
 }
 
-#night-day-toggle .star--2 {
-	top: 18px;
-	left: 28px;
-	z-index: 1;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label:before {
+	background: #fff;
+	transition: background .3s ease .1s;
 }
 
-#night-day-toggle .star--3 {
-	top: 27px;
-	left: 40px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
-}
-
-#night-day-toggle .star--4,
-#night-day-toggle .star--5,
-#night-day-toggle .star--6 {
-	opacity: 0;
-	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle .star--4 {
-	top: 16px;
-	left: 11px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle .star--5 {
-	top: 32px;
-	left: 17px;
-	z-index: 0;
-	width: 3px;
-	height: 3px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle .star--6 {
-	top: 36px;
-	left: 28px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle {
-	background-color: #749dd6;
-}
-
-#night-day-toggle input:checked + .toggle:before {
-	color: #749ed7;
-}
-
-#night-day-toggle input:checked + .toggle:after {
-	color: #fff;
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler {
-	background-color: #ffe5b5;
-	transform: translate3d(40px, 0, 0) rotate(0);
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler .crater {
-	opacity: 1;
-}
-
-#night-day-toggle input:checked + .toggle .star--1 {
-	width: 2px;
-	height: 2px;
-}
-
-#night-day-toggle input:checked + .toggle .star--2 {
-	width: 4px;
-	height: 4px;
-	transform: translate3d(-5px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--3 {
-	width: 2px;
-	height: 2px;
-	transform: translate3d(-7px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4,
-#night-day-toggle input:checked + .toggle .star--5,
-#night-day-toggle input:checked + .toggle .star--6 {
-	opacity: 1;
-	transform: translate3d(0, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4 {
-	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--5 {
-	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--6 {
-	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+#night-day-toggle input:checked + label:after {
+	transform: scale(1.5);
+	transition: transform .5s ease .15s;
 }
 /*# sourceMappingURL=ie.css.map */

--- a/assets/js/night-day.js
+++ b/assets/js/night-day.js
@@ -1,0 +1,18 @@
+function twentytwentyoneNightDayToggler() {
+	var toggler = document.getElementById( 'night-day-toggle-input' ),
+		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches,
+		html = document.querySelector( 'html' );
+
+	if ( isDarkMode ) {
+		toggler.checked = true;
+	}
+
+	toggler.addEventListener( 'click', function() {
+		if ( toggler.checked ) {
+			html.classList.add( 'respect-color-scheme-preference' );
+		} else {
+			html.classList.remove( 'respect-color-scheme-preference' );
+		}
+	} );
+}
+twentytwentyoneNightDayToggler();

--- a/assets/js/night-day.js
+++ b/assets/js/night-day.js
@@ -28,5 +28,13 @@ function twentytwentyoneNightDayToggler() {
 			window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
 		}
 	} );
+
+	toggler.addEventListener( 'focus', function() {
+		document.getElementById( 'night-day-toggle' ).classList.add( 'focused' );
+	} );
+
+	toggler.addEventListener( 'blur', function() {
+		document.getElementById( 'night-day-toggle' ).classList.remove( 'focused' );
+	} );
 }
 twentytwentyoneNightDayToggler();

--- a/assets/js/night-day.js
+++ b/assets/js/night-day.js
@@ -3,15 +3,29 @@ function twentytwentyoneNightDayToggler() {
 		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches,
 		html = document.querySelector( 'html' );
 
+	if ( 'yes' === window.localStorage.getItem( 'twentytwentyoneDarkMode' ) ) {
+		isDarkMode = true;
+	} else if ( 'no' === window.localStorage.getItem( 'twentytwentyoneDarkMode' ) ) {
+		isDarkMode = false;
+	}
+
 	if ( isDarkMode ) {
 		toggler.checked = true;
+	}
+
+	if ( isDarkMode ) {
+		html.classList.add( 'respect-color-scheme-preference' );
+	} else {
+		html.classList.remove( 'respect-color-scheme-preference' );
 	}
 
 	toggler.addEventListener( 'click', function() {
 		if ( toggler.checked ) {
 			html.classList.add( 'respect-color-scheme-preference' );
+			window.localStorage.setItem( 'twentytwentyoneDarkMode', 'yes' );
 		} else {
 			html.classList.remove( 'respect-color-scheme-preference' );
+			window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
 		}
 	} );
 }

--- a/assets/sass/04-elements/night-day.scss
+++ b/assets/sass/04-elements/night-day.scss
@@ -3,44 +3,51 @@
 	position: fixed;
 	bottom: 1em;
 	right: 1em;
+	padding: 24px;
+
+	label {
+		border-radius: 50%;
+		width: 36px;
+		height: 36px;
+		position: absolute;
+		top: 5px;
+		left: 5px;
+		box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
+		transform: scale(1) rotate(-2deg);
+		transition: box-shadow .5s ease 0s, transform .4s ease .1s;
+
+		&:before {
+			content: "";
+			width: inherit;
+			height: inherit;
+			border-radius: inherit;
+			position: absolute;
+			left: 0;
+			top: 0;
+			transition: background .3s ease;
+		}
+
+		&:after {
+			content: "";
+			width: 8px;
+			height: 8px;
+			border-radius: 50%;
+			margin: -4px 0 0 -4px;
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
+			transform: scale(0);
+			transition: all .3s ease;
+		}
+	}
 
 	input {
-		display: none;
-
-		+ label {
-			border-radius: 50%;
-			width: 36px;
-			height: 36px;
-			position: relative;
-			box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
-			transform: scale(1) rotate(-2deg);
-			transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-
-			&:before {
-				content: "";
-				width: inherit;
-				height: inherit;
-				border-radius: inherit;
-				position: absolute;
-				left: 0;
-				top: 0;
-				transition: background .3s ease;
-			}
-
-			&:after {
-				content: "";
-				width: 8px;
-				height: 8px;
-				border-radius: 50%;
-				margin: -4px 0 0 -4px;
-				position: absolute;
-				top: 50%;
-				left: 50%;
-				box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
-				transform: scale(0);
-				transition: all .3s ease;
-			}
-		}
+		width: 1px;
+		height: 1px;
+		opacity: 0;
+		overflow: hidden;
+		position: absolute;
 
 		&:checked + label {
 			box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
@@ -57,5 +64,9 @@
 				transition: transform .5s ease .15s;
 			}
 		}
+	}
+
+	&.focused {
+		box-shadow: 0 0 0 2px currentColor;
 	}
 }

--- a/assets/sass/04-elements/night-day.scss
+++ b/assets/sass/04-elements/night-day.scss
@@ -1,0 +1,191 @@
+#night-day-toggle {
+	position: fixed;
+	bottom: 10px;
+	right: 1em;
+	overflow: hidden;
+
+	input {
+		position: absolute;
+		left: -99em;
+	}
+
+	.toggle {
+		cursor: pointer;
+		display: inline-block;
+		position: relative;
+		width: 90px;
+		height: 50px;
+		background-color: #83d8ff;
+		border-radius: 90px - 6;
+		transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	}
+
+	.toggle__handler {
+		display: inline-block;
+		position: relative;
+		z-index: 1;
+		top: 3px;
+		left: -7px;
+		width: 50px - 6;
+		height: 50px - 6;
+		background-color: #ffcf96;
+		border-radius: 50px;
+		box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
+		transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
+		transform: rotate(-45deg);
+
+		.crater {
+			position: absolute;
+			background-color: #e8cda5;
+			opacity: 0;
+			transition: opacity 200ms ease-in-out;
+			border-radius: 100%;
+		}
+
+		.crater--1 {
+			top: 18px;
+			left: 10px;
+			width: 4px;
+			height: 4px;
+		}
+
+		.crater--2 {
+			top: 28px;
+			left: 22px;
+			width: 6px;
+			height: 6px;
+		}
+
+		.crater--3 {
+			top: 10px;
+			left: 25px;
+			width: 8px;
+			height: 8px;
+		}
+	}
+
+	.star {
+		position: absolute;
+		background-color: #fff;
+		transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+		border-radius: 50%;
+	}
+
+	.star--1 {
+		top: 10px;
+		left: 35px;
+		z-index: 0;
+		width: 30px;
+		height: 3px;
+	}
+
+	.star--2 {
+		top: 18px;
+		left: 28px;
+		z-index: 1;
+		width: 30px;
+		height: 3px;
+	}
+
+	.star--3 {
+		top: 27px;
+		left: 40px;
+		z-index: 0;
+		width: 30px;
+		height: 3px;
+	}
+
+	.star--4,
+	.star--5,
+	.star--6 {
+		opacity: 0;
+		transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	}
+
+	.star--4 {
+		top: 16px;
+		left: 11px;
+		z-index: 0;
+		width: 2px;
+		height: 2px;
+		transform: translate3d(3px, 0, 0);
+	}
+
+	.star--5 {
+		top: 32px;
+		left: 17px;
+		z-index: 0;
+		width: 3px;
+		height: 3px;
+		transform: translate3d(3px, 0, 0);
+	}
+
+	.star--6 {
+		top: 36px;
+		left: 28px;
+		z-index: 0;
+		width: 2px;
+		height: 2px;
+		transform: translate3d(3px, 0, 0);
+	}
+
+	input:checked {
+
+		+ .toggle {
+			background-color: #749dd6;
+
+			&:before {
+				color: #749ed7;
+			}
+
+			&:after {
+				color: #fff;
+			}
+
+			.toggle__handler {
+				background-color: #ffe5b5;
+				transform: translate3d(40px, 0, 0) rotate(0);
+
+				.crater {
+					opacity: 1;
+				}
+			}
+
+			.star--1 {
+				width: 2px;
+				height: 2px;
+			}
+
+			.star--2 {
+				width: 4px;
+				height: 4px;
+				transform: translate3d(-5px, 0, 0);
+			}
+
+			.star--3 {
+				width: 2px;
+				height: 2px;
+				transform: translate3d(-7px, 0, 0);
+			}
+
+			.star--4,
+			.star--5,
+			.star--6 {
+				opacity: 1;
+				transform: translate3d(0, 0, 0);
+			}
+
+			.star--4 {
+				transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+			}
+
+			.star--5 {
+				transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+			}
+
+			.star--6 {
+				transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+			}
+		}
+	}
+}

--- a/assets/sass/04-elements/night-day.scss
+++ b/assets/sass/04-elements/night-day.scss
@@ -1,46 +1,13 @@
 #night-day-toggle {
 	cursor: pointer;
 	position: fixed;
-	bottom: 1em;
-	right: 1em;
-	padding: 24px;
+	bottom: 5px;
+	right: 5px;
+	padding: 5px;
 
-	label {
-		border-radius: 50%;
-		width: 36px;
-		height: 36px;
-		position: absolute;
-		top: 5px;
-		left: 5px;
-		box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
-		transform: scale(1) rotate(-2deg);
-		transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-
-		&:before {
-			content: "";
-			width: inherit;
-			height: inherit;
-			border-radius: inherit;
-			position: absolute;
-			left: 0;
-			top: 0;
-			transition: background .3s ease;
-		}
-
-		&:after {
-			content: "";
-			width: 8px;
-			height: 8px;
-			border-radius: 50%;
-			margin: -4px 0 0 -4px;
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
-			transform: scale(0);
-			transition: all .3s ease;
-		}
-	}
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	input {
 		width: 1px;
@@ -48,20 +15,57 @@
 		opacity: 0;
 		overflow: hidden;
 		position: absolute;
+	}
+	*,
+	*:after,
+	*:before {
+		box-sizing: border-box;
+	}
+
+	label {
+		position: relative;
+		display: block;
+		width: 60px;
+		height: 33px;
+		border-radius: 33px;
+		background-color: currentColor;
+		overflow: hidden;
+		cursor: pointer;
+		margin: 0;
+
+		&:before,
+		&:after {
+			display: block;
+			position: absolute;
+			content: "";
+			width: 24px;
+			height: 24px;
+			border-radius: 50%;
+			top: 4.5px;
+			left: 4.5px;
+			transition: .1s ease-in-out;
+		}
+		&:before {
+			background-color: var(--global--color-background);
+		}
+
+		&:after {
+			background-color: currentColor;
+			left: -19px;
+			transform: scale(0.00001);
+		}
+	}
+
+	input[type="checkbox"] {
 
 		&:checked + label {
-			box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
-			transform: scale(.5) rotate(0deg);
-			transition: transform .3s ease .1s, box-shadow .2s ease 0s;
-
 			&:before {
-				background: #fff;
-				transition: background .3s ease .1s;
+				background-color: var(--global--color-background);
+				transform: translateX(27px);
 			}
 
 			&:after {
-				transform: scale(1.5);
-				transition: transform .5s ease .15s;
+				transform: translateX(40px) scale(1);
 			}
 		}
 	}

--- a/assets/sass/04-elements/night-day.scss
+++ b/assets/sass/04-elements/night-day.scss
@@ -3,52 +3,59 @@
 	position: fixed;
 	bottom: 1em;
 	right: 1em;
-    input {
-        display: none;
-        & + label {
-            border-radius: 50%;
-            width: 36px;
-            height: 36px;
-            position: relative;
-            box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
-            transform: scale(1) rotate(-2deg);
-            transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-            &:before {
-                content: '';
-                width: inherit;
-                height: inherit;
-                border-radius: inherit;
-                position: absolute;
-                left: 0;
-                top: 0;
-                transition: background .3s ease;
-            }
-            &:after {
-                content: '';
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                margin: -4px 0 0 -4px;
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
-                transform: scale(0);
-                transition: all .3s ease;
-            }
-        }
-        &:checked + label {
-            box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
-            transform: scale(.5) rotate(0deg);
-            transition: transform .3s ease .1s, box-shadow .2s ease 0s;
-            &:before {
-                background: #fff;
-                transition: background .3s ease .1s;
-            }
-            &:after {
-                transform: scale(1.5);
-                transition: transform .5s ease .15s;
-            }
-        }
-    }
+
+	input {
+		display: none;
+
+		+ label {
+			border-radius: 50%;
+			width: 36px;
+			height: 36px;
+			position: relative;
+			box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
+			transform: scale(1) rotate(-2deg);
+			transition: box-shadow .5s ease 0s, transform .4s ease .1s;
+
+			&:before {
+				content: "";
+				width: inherit;
+				height: inherit;
+				border-radius: inherit;
+				position: absolute;
+				left: 0;
+				top: 0;
+				transition: background .3s ease;
+			}
+
+			&:after {
+				content: "";
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				margin: -4px 0 0 -4px;
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
+				transform: scale(0);
+				transition: all .3s ease;
+			}
+		}
+
+		&:checked + label {
+			box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
+			transform: scale(.5) rotate(0deg);
+			transition: transform .3s ease .1s, box-shadow .2s ease 0s;
+
+			&:before {
+				background: #fff;
+				transition: background .3s ease .1s;
+			}
+
+			&:after {
+				transform: scale(1.5);
+				transition: transform .5s ease .15s;
+			}
+		}
+	}
 }

--- a/assets/sass/04-elements/night-day.scss
+++ b/assets/sass/04-elements/night-day.scss
@@ -1,191 +1,54 @@
 #night-day-toggle {
+	cursor: pointer;
 	position: fixed;
-	bottom: 10px;
+	bottom: 1em;
 	right: 1em;
-	overflow: hidden;
-
-	input {
-		position: absolute;
-		left: -99em;
-	}
-
-	.toggle {
-		cursor: pointer;
-		display: inline-block;
-		position: relative;
-		width: 90px;
-		height: 50px;
-		background-color: #83d8ff;
-		border-radius: 90px - 6;
-		transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-	}
-
-	.toggle__handler {
-		display: inline-block;
-		position: relative;
-		z-index: 1;
-		top: 3px;
-		left: -7px;
-		width: 50px - 6;
-		height: 50px - 6;
-		background-color: #ffcf96;
-		border-radius: 50px;
-		box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
-		transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
-		transform: rotate(-45deg);
-
-		.crater {
-			position: absolute;
-			background-color: #e8cda5;
-			opacity: 0;
-			transition: opacity 200ms ease-in-out;
-			border-radius: 100%;
-		}
-
-		.crater--1 {
-			top: 18px;
-			left: 10px;
-			width: 4px;
-			height: 4px;
-		}
-
-		.crater--2 {
-			top: 28px;
-			left: 22px;
-			width: 6px;
-			height: 6px;
-		}
-
-		.crater--3 {
-			top: 10px;
-			left: 25px;
-			width: 8px;
-			height: 8px;
-		}
-	}
-
-	.star {
-		position: absolute;
-		background-color: #fff;
-		transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-		border-radius: 50%;
-	}
-
-	.star--1 {
-		top: 10px;
-		left: 35px;
-		z-index: 0;
-		width: 30px;
-		height: 3px;
-	}
-
-	.star--2 {
-		top: 18px;
-		left: 28px;
-		z-index: 1;
-		width: 30px;
-		height: 3px;
-	}
-
-	.star--3 {
-		top: 27px;
-		left: 40px;
-		z-index: 0;
-		width: 30px;
-		height: 3px;
-	}
-
-	.star--4,
-	.star--5,
-	.star--6 {
-		opacity: 0;
-		transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
-	}
-
-	.star--4 {
-		top: 16px;
-		left: 11px;
-		z-index: 0;
-		width: 2px;
-		height: 2px;
-		transform: translate3d(3px, 0, 0);
-	}
-
-	.star--5 {
-		top: 32px;
-		left: 17px;
-		z-index: 0;
-		width: 3px;
-		height: 3px;
-		transform: translate3d(3px, 0, 0);
-	}
-
-	.star--6 {
-		top: 36px;
-		left: 28px;
-		z-index: 0;
-		width: 2px;
-		height: 2px;
-		transform: translate3d(3px, 0, 0);
-	}
-
-	input:checked {
-
-		+ .toggle {
-			background-color: #749dd6;
-
-			&:before {
-				color: #749ed7;
-			}
-
-			&:after {
-				color: #fff;
-			}
-
-			.toggle__handler {
-				background-color: #ffe5b5;
-				transform: translate3d(40px, 0, 0) rotate(0);
-
-				.crater {
-					opacity: 1;
-				}
-			}
-
-			.star--1 {
-				width: 2px;
-				height: 2px;
-			}
-
-			.star--2 {
-				width: 4px;
-				height: 4px;
-				transform: translate3d(-5px, 0, 0);
-			}
-
-			.star--3 {
-				width: 2px;
-				height: 2px;
-				transform: translate3d(-7px, 0, 0);
-			}
-
-			.star--4,
-			.star--5,
-			.star--6 {
-				opacity: 1;
-				transform: translate3d(0, 0, 0);
-			}
-
-			.star--4 {
-				transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-			}
-
-			.star--5 {
-				transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-			}
-
-			.star--6 {
-				transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-			}
-		}
-	}
+    input {
+        display: none;
+        & + label {
+            border-radius: 50%;
+            width: 36px;
+            height: 36px;
+            position: relative;
+            box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
+            transform: scale(1) rotate(-2deg);
+            transition: box-shadow .5s ease 0s, transform .4s ease .1s;
+            &:before {
+                content: '';
+                width: inherit;
+                height: inherit;
+                border-radius: inherit;
+                position: absolute;
+                left: 0;
+                top: 0;
+                transition: background .3s ease;
+            }
+            &:after {
+                content: '';
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                margin: -4px 0 0 -4px;
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
+                transform: scale(0);
+                transition: all .3s ease;
+            }
+        }
+        &:checked + label {
+            box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
+            transform: scale(.5) rotate(0deg);
+            transition: transform .3s ease .1s, box-shadow .2s ease 0s;
+            &:before {
+                background: #fff;
+                transition: background .3s ease .1s;
+            }
+            &:after {
+                transform: scale(1.5);
+                transition: transform .5s ease .15s;
+            }
+        }
+    }
 }

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -121,3 +121,5 @@
 @import "07-utilities/a11y";
 @import "07-utilities/color-palette";
 @import "07-utilities/measure";
+
+@import "04-elements/night-day.scss";

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -490,9 +490,11 @@ function twenty_twenty_one_night_switch() {
 		return;
 	}
 	?>
-	<div id="night-day-toggle" aria-hidden="true">
+	<div id="night-day-toggle">
 		<input type="checkbox" id="night-day-toggle-input"/>
-		<label for="night-day-toggle-input"></label>
+		<label for="night-day-toggle-input">
+			<span class="screen-reader-text"><?php esc_html_e( 'Toggle color scheme', 'twentytwentyone' ); ?></span>
+		</label>
 	<script>
 		<?php include get_template_directory() . '/assets/js/night-day.js'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude ?>
 	</script>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -472,3 +472,43 @@ function twenty_twenty_one_password_form( $post = 0 ) {
 	return $output;
 }
 add_filter( 'the_password_form', 'twenty_twenty_one_password_form' );
+
+/**
+ * Add night/day switch.
+ *
+ * Inspired from https://codepen.io/waynedunkley/pen/YybgGo (MIT-licensed)
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function twenty_twenty_one_night_switch() {
+	if (
+		! get_theme_mod( 'respect_user_color_preference', true ) ||
+		127 > Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) )
+	) {
+		return;
+	}
+	?>
+	<div id="night-day-toggle">
+		<input type="checkbox" id="night-day-toggle-input"/>
+		<label for="night-day-toggle-input" class="toggle">
+			<span class="toggle__handler">
+				<span class="crater crater--1"></span>
+				<span class="crater crater--2"></span>
+				<span class="crater crater--3"></span>
+			</span>
+			<span class="star star--1"></span>
+			<span class="star star--2"></span>
+			<span class="star star--3"></span>
+			<span class="star star--4"></span>
+			<span class="star star--5"></span>
+			<span class="star star--6"></span>
+		</label>
+	</div>
+	<script>
+		<?php include get_template_directory() . '/assets/js/night-day.js'; ?>
+	</script>
+	<?php
+}
+add_action( 'wp_footer', 'twenty_twenty_one_night_switch' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -490,7 +490,7 @@ function twenty_twenty_one_night_switch() {
 		return;
 	}
 	?>
-	<div id="night-day-toggle">
+	<div id="night-day-toggle" aria-hidden="true">
 		<input type="checkbox" id="night-day-toggle-input"/>
 		<label for="night-day-toggle-input" class="toggle">
 			<span class="toggle__handler">

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -476,7 +476,7 @@ add_filter( 'the_password_form', 'twenty_twenty_one_password_form' );
 /**
  * Add night/day switch.
  *
- * Inspired from https://codepen.io/waynedunkley/pen/YybgGo (MIT-licensed)
+ * Inspired from https://codepen.io/aaroniker/pen/KGpXZo (MIT-licensed)
  *
  * @since 1.0.0
  *
@@ -492,20 +492,7 @@ function twenty_twenty_one_night_switch() {
 	?>
 	<div id="night-day-toggle" aria-hidden="true">
 		<input type="checkbox" id="night-day-toggle-input"/>
-		<label for="night-day-toggle-input" class="toggle">
-			<span class="toggle__handler">
-				<span class="crater crater--1"></span>
-				<span class="crater crater--2"></span>
-				<span class="crater crater--3"></span>
-			</span>
-			<span class="star star--1"></span>
-			<span class="star star--2"></span>
-			<span class="star star--3"></span>
-			<span class="star star--4"></span>
-			<span class="star star--5"></span>
-			<span class="star star--6"></span>
-		</label>
-	</div>
+		<label for="night-day-toggle-input"></label>
 	<script>
 		<?php include get_template_directory() . '/assets/js/night-day.js'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude ?>
 	</script>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -507,7 +507,7 @@ function twenty_twenty_one_night_switch() {
 		</label>
 	</div>
 	<script>
-		<?php include get_template_directory() . '/assets/js/night-day.js'; ?>
+		<?php include get_template_directory() . '/assets/js/night-day.js'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude ?>
 	</script>
 	<?php
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4975,190 +4975,63 @@ footer {
 }
 
 #night-day-toggle {
+	cursor: pointer;
 	position: fixed;
-	bottom: 10px;
+	bottom: 1em;
 	left: 1em;
-	overflow: hidden;
 }
 
 #night-day-toggle input {
-	position: absolute;
-	right: -99em;
+	display: none;
 }
 
-#night-day-toggle .toggle {
-	cursor: pointer;
-	display: inline-block;
+#night-day-toggle input + label {
+	border-radius: 50%;
+	width: 36px;
+	height: 36px;
 	position: relative;
-	width: 90px;
-	height: 50px;
-	background-color: #83d8ff;
-	border-radius: 84px;
-	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	box-shadow: inset -16px -16px 0 0 var(--global--color-dark-gray);
+	transform: scale(1) rotate(2deg);
+	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle .toggle__handler {
-	display: inline-block;
-	position: relative;
-	z-index: 1;
-	top: 3px;
-	right: -7px;
-	width: 44px;
-	height: 44px;
-	background-color: #ffcf96;
-	border-radius: 50px;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
-	transform: rotate(45deg);
-}
-
-#night-day-toggle .toggle__handler .crater {
+#night-day-toggle input + label:before {
+	content: '';
+	width: inherit;
+	height: inherit;
+	border-radius: inherit;
 	position: absolute;
-	background-color: #e8cda5;
-	opacity: 0;
-	transition: opacity 200ms ease-in-out;
-	border-radius: 100%;
+	right: 0;
+	top: 0;
+	transition: background .3s ease;
 }
 
-#night-day-toggle .toggle__handler .crater--1 {
-	top: 18px;
-	right: 10px;
-	width: 4px;
-	height: 4px;
-}
-
-#night-day-toggle .toggle__handler .crater--2 {
-	top: 28px;
-	right: 22px;
-	width: 6px;
-	height: 6px;
-}
-
-#night-day-toggle .toggle__handler .crater--3 {
-	top: 10px;
-	right: 25px;
+#night-day-toggle input + label:after {
+	content: '';
 	width: 8px;
 	height: 8px;
-}
-
-#night-day-toggle .star {
-	position: absolute;
-	background-color: #fff;
-	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
 	border-radius: 50%;
+	margin: -4px -4px 0 0;
+	position: absolute;
+	top: 50%;
+	right: 50%;
+	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, -23px 0 0 #fff, 23px 0 0 #fff, -15px 15px 0 #fff, 15px 15px 0 #fff, -15px -15px 0 #fff, 15px -15px 0 #fff;
+	transform: scale(0);
+	transition: all .3s ease;
 }
 
-#night-day-toggle .star--1 {
-	top: 10px;
-	right: 35px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label {
+	box-shadow: inset -32px -32px 0 0 var(--global--color-dark-gray);
+	transform: scale(0.5) rotate(0deg);
+	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
 }
 
-#night-day-toggle .star--2 {
-	top: 18px;
-	right: 28px;
-	z-index: 1;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label:before {
+	background: #fff;
+	transition: background .3s ease .1s;
 }
 
-#night-day-toggle .star--3 {
-	top: 27px;
-	right: 40px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
-}
-
-#night-day-toggle .star--4,
-#night-day-toggle .star--5,
-#night-day-toggle .star--6 {
-	opacity: 0;
-	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle .star--4 {
-	top: 16px;
-	right: 11px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(-3px, 0, 0);
-}
-
-#night-day-toggle .star--5 {
-	top: 32px;
-	right: 17px;
-	z-index: 0;
-	width: 3px;
-	height: 3px;
-	transform: translate3d(-3px, 0, 0);
-}
-
-#night-day-toggle .star--6 {
-	top: 36px;
-	right: 28px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(-3px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle {
-	background-color: #749dd6;
-}
-
-#night-day-toggle input:checked + .toggle:before {
-	color: #749ed7;
-}
-
-#night-day-toggle input:checked + .toggle:after {
-	color: #fff;
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler {
-	background-color: #ffe5b5;
-	transform: translate3d(-40px, 0, 0) rotate(0);
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler .crater {
-	opacity: 1;
-}
-
-#night-day-toggle input:checked + .toggle .star--1 {
-	width: 2px;
-	height: 2px;
-}
-
-#night-day-toggle input:checked + .toggle .star--2 {
-	width: 4px;
-	height: 4px;
-	transform: translate3d(5px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--3 {
-	width: 2px;
-	height: 2px;
-	transform: translate3d(7px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4,
-#night-day-toggle input:checked + .toggle .star--5,
-#night-day-toggle input:checked + .toggle .star--6 {
-	opacity: 1;
-	transform: translate3d(0, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4 {
-	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--5 {
-	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--6 {
-	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+#night-day-toggle input:checked + label:after {
+	transform: scale(1.5);
+	transition: transform .5s ease .15s;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5012,46 +5012,12 @@ footer {
 #night-day-toggle {
 	cursor: pointer;
 	position: fixed;
-	bottom: 1em;
-	left: 1em;
-	padding: 24px;
-}
-
-#night-day-toggle label {
-	border-radius: 50%;
-	width: 36px;
-	height: 36px;
-	position: absolute;
-	top: 5px;
-	right: 5px;
-	box-shadow: inset -16px -16px 0 0 var(--global--color-dark-gray);
-	transform: scale(1) rotate(2deg);
-	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-}
-
-#night-day-toggle label:before {
-	content: "";
-	width: inherit;
-	height: inherit;
-	border-radius: inherit;
-	position: absolute;
-	right: 0;
-	top: 0;
-	transition: background .3s ease;
-}
-
-#night-day-toggle label:after {
-	content: "";
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	margin: -4px -4px 0 0;
-	position: absolute;
-	top: 50%;
-	right: 50%;
-	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, -23px 0 0 #fff, 23px 0 0 #fff, -15px 15px 0 #fff, 15px 15px 0 #fff, -15px -15px 0 #fff, 15px -15px 0 #fff;
-	transform: scale(0);
-	transition: all .3s ease;
+	bottom: 5px;
+	left: 5px;
+	padding: 5px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 #night-day-toggle input {
@@ -5062,20 +5028,53 @@ footer {
 	position: absolute;
 }
 
-#night-day-toggle input:checked + label {
-	box-shadow: inset -32px -32px 0 0 var(--global--color-dark-gray);
-	transform: scale(0.5) rotate(0deg);
-	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
+#night-day-toggle *,
+#night-day-toggle *:after,
+#night-day-toggle *:before {
+	box-sizing: border-box;
 }
 
-#night-day-toggle input:checked + label:before {
-	background: #fff;
-	transition: background .3s ease .1s;
+#night-day-toggle label {
+	position: relative;
+	display: block;
+	width: 60px;
+	height: 33px;
+	border-radius: 33px;
+	background-color: currentColor;
+	overflow: hidden;
+	cursor: pointer;
+	margin: 0;
 }
 
-#night-day-toggle input:checked + label:after {
-	transform: scale(1.5);
-	transition: transform .5s ease .15s;
+#night-day-toggle label:before, #night-day-toggle label:after {
+	display: block;
+	position: absolute;
+	content: "";
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	top: 4.5px;
+	right: 4.5px;
+	transition: .1s ease-in-out;
+}
+
+#night-day-toggle label:before {
+	background-color: var(--global--color-background);
+}
+
+#night-day-toggle label:after {
+	background-color: currentColor;
+	right: -19px;
+	transform: scale(0.00001);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:before {
+	background-color: var(--global--color-background);
+	transform: translateX(-27px);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:after {
+	transform: translateX(-40px) scale(1);
 }
 
 #night-day-toggle.focused {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4996,7 +4996,7 @@ footer {
 }
 
 #night-day-toggle input + label:before {
-	content: '';
+	content: "";
 	width: inherit;
 	height: inherit;
 	border-radius: inherit;
@@ -5007,7 +5007,7 @@ footer {
 }
 
 #night-day-toggle input + label:after {
-	content: '';
+	content: "";
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4973,3 +4973,192 @@ section,
 footer {
 	max-width: none;
 }
+
+#night-day-toggle {
+	position: fixed;
+	bottom: 10px;
+	left: 1em;
+	overflow: hidden;
+}
+
+#night-day-toggle input {
+	position: absolute;
+	right: -99em;
+}
+
+#night-day-toggle .toggle {
+	cursor: pointer;
+	display: inline-block;
+	position: relative;
+	width: 90px;
+	height: 50px;
+	background-color: #83d8ff;
+	border-radius: 84px;
+	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .toggle__handler {
+	display: inline-block;
+	position: relative;
+	z-index: 1;
+	top: 3px;
+	right: -7px;
+	width: 44px;
+	height: 44px;
+	background-color: #ffcf96;
+	border-radius: 50px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
+	transform: rotate(45deg);
+}
+
+#night-day-toggle .toggle__handler .crater {
+	position: absolute;
+	background-color: #e8cda5;
+	opacity: 0;
+	transition: opacity 200ms ease-in-out;
+	border-radius: 100%;
+}
+
+#night-day-toggle .toggle__handler .crater--1 {
+	top: 18px;
+	right: 10px;
+	width: 4px;
+	height: 4px;
+}
+
+#night-day-toggle .toggle__handler .crater--2 {
+	top: 28px;
+	right: 22px;
+	width: 6px;
+	height: 6px;
+}
+
+#night-day-toggle .toggle__handler .crater--3 {
+	top: 10px;
+	right: 25px;
+	width: 8px;
+	height: 8px;
+}
+
+#night-day-toggle .star {
+	position: absolute;
+	background-color: #fff;
+	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	border-radius: 50%;
+}
+
+#night-day-toggle .star--1 {
+	top: 10px;
+	right: 35px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--2 {
+	top: 18px;
+	right: 28px;
+	z-index: 1;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--3 {
+	top: 27px;
+	right: 40px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--4,
+#night-day-toggle .star--5,
+#night-day-toggle .star--6 {
+	opacity: 0;
+	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .star--4 {
+	top: 16px;
+	right: 11px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(-3px, 0, 0);
+}
+
+#night-day-toggle .star--5 {
+	top: 32px;
+	right: 17px;
+	z-index: 0;
+	width: 3px;
+	height: 3px;
+	transform: translate3d(-3px, 0, 0);
+}
+
+#night-day-toggle .star--6 {
+	top: 36px;
+	right: 28px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(-3px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle {
+	background-color: #749dd6;
+}
+
+#night-day-toggle input:checked + .toggle:before {
+	color: #749ed7;
+}
+
+#night-day-toggle input:checked + .toggle:after {
+	color: #fff;
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler {
+	background-color: #ffe5b5;
+	transform: translate3d(-40px, 0, 0) rotate(0);
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler .crater {
+	opacity: 1;
+}
+
+#night-day-toggle input:checked + .toggle .star--1 {
+	width: 2px;
+	height: 2px;
+}
+
+#night-day-toggle input:checked + .toggle .star--2 {
+	width: 4px;
+	height: 4px;
+	transform: translate3d(5px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--3 {
+	width: 2px;
+	height: 2px;
+	transform: translate3d(7px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4,
+#night-day-toggle input:checked + .toggle .star--5,
+#night-day-toggle input:checked + .toggle .star--6 {
+	opacity: 1;
+	transform: translate3d(0, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4 {
+	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--5 {
+	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--6 {
+	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5014,23 +5014,22 @@ footer {
 	position: fixed;
 	bottom: 1em;
 	left: 1em;
+	padding: 24px;
 }
 
-#night-day-toggle input {
-	display: none;
-}
-
-#night-day-toggle input + label {
+#night-day-toggle label {
 	border-radius: 50%;
 	width: 36px;
 	height: 36px;
-	position: relative;
+	position: absolute;
+	top: 5px;
+	right: 5px;
 	box-shadow: inset -16px -16px 0 0 var(--global--color-dark-gray);
 	transform: scale(1) rotate(2deg);
 	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle input + label:before {
+#night-day-toggle label:before {
 	content: "";
 	width: inherit;
 	height: inherit;
@@ -5041,7 +5040,7 @@ footer {
 	transition: background .3s ease;
 }
 
-#night-day-toggle input + label:after {
+#night-day-toggle label:after {
 	content: "";
 	width: 8px;
 	height: 8px;
@@ -5053,6 +5052,14 @@ footer {
 	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, -23px 0 0 #fff, 23px 0 0 #fff, -15px 15px 0 #fff, 15px 15px 0 #fff, -15px -15px 0 #fff, 15px -15px 0 #fff;
 	transform: scale(0);
 	transition: all .3s ease;
+}
+
+#night-day-toggle input {
+	width: 1px;
+	height: 1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
 }
 
 #night-day-toggle input:checked + label {
@@ -5069,4 +5076,8 @@ footer {
 #night-day-toggle input:checked + label:after {
 	transform: scale(1.5);
 	transition: transform .5s ease .15s;
+}
+
+#night-day-toggle.focused {
+	box-shadow: 0 0 0 2px currentColor;
 }

--- a/style.css
+++ b/style.css
@@ -5005,7 +5005,7 @@ footer {
 }
 
 #night-day-toggle input + label:before {
-	content: '';
+	content: "";
 	width: inherit;
 	height: inherit;
 	border-radius: inherit;
@@ -5016,7 +5016,7 @@ footer {
 }
 
 #night-day-toggle input + label:after {
-	content: '';
+	content: "";
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;

--- a/style.css
+++ b/style.css
@@ -5022,46 +5022,12 @@ footer {
 #night-day-toggle {
 	cursor: pointer;
 	position: fixed;
-	bottom: 1em;
-	right: 1em;
-	padding: 24px;
-}
-
-#night-day-toggle label {
-	border-radius: 50%;
-	width: 36px;
-	height: 36px;
-	position: absolute;
-	top: 5px;
-	left: 5px;
-	box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
-	transform: scale(1) rotate(-2deg);
-	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
-}
-
-#night-day-toggle label:before {
-	content: "";
-	width: inherit;
-	height: inherit;
-	border-radius: inherit;
-	position: absolute;
-	left: 0;
-	top: 0;
-	transition: background .3s ease;
-}
-
-#night-day-toggle label:after {
-	content: "";
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	margin: -4px 0 0 -4px;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
-	transform: scale(0);
-	transition: all .3s ease;
+	bottom: 5px;
+	right: 5px;
+	padding: 5px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 #night-day-toggle input {
@@ -5072,20 +5038,53 @@ footer {
 	position: absolute;
 }
 
-#night-day-toggle input:checked + label {
-	box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
-	transform: scale(0.5) rotate(0deg);
-	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
+#night-day-toggle *,
+#night-day-toggle *:after,
+#night-day-toggle *:before {
+	box-sizing: border-box;
 }
 
-#night-day-toggle input:checked + label:before {
-	background: #fff;
-	transition: background .3s ease .1s;
+#night-day-toggle label {
+	position: relative;
+	display: block;
+	width: 60px;
+	height: 33px;
+	border-radius: 33px;
+	background-color: currentColor;
+	overflow: hidden;
+	cursor: pointer;
+	margin: 0;
 }
 
-#night-day-toggle input:checked + label:after {
-	transform: scale(1.5);
-	transition: transform .5s ease .15s;
+#night-day-toggle label:before, #night-day-toggle label:after {
+	display: block;
+	position: absolute;
+	content: "";
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	top: 4.5px;
+	left: 4.5px;
+	transition: .1s ease-in-out;
+}
+
+#night-day-toggle label:before {
+	background-color: var(--global--color-background);
+}
+
+#night-day-toggle label:after {
+	background-color: currentColor;
+	left: -19px;
+	transform: scale(0.00001);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:before {
+	background-color: var(--global--color-background);
+	transform: translateX(27px);
+}
+
+#night-day-toggle input[type="checkbox"]:checked + label:after {
+	transform: translateX(40px) scale(1);
 }
 
 #night-day-toggle.focused {

--- a/style.css
+++ b/style.css
@@ -4984,192 +4984,65 @@ footer {
 }
 
 #night-day-toggle {
+	cursor: pointer;
 	position: fixed;
-	bottom: 10px;
+	bottom: 1em;
 	right: 1em;
-	overflow: hidden;
 }
 
 #night-day-toggle input {
-	position: absolute;
-	left: -99em;
+	display: none;
 }
 
-#night-day-toggle .toggle {
-	cursor: pointer;
-	display: inline-block;
+#night-day-toggle input + label {
+	border-radius: 50%;
+	width: 36px;
+	height: 36px;
 	position: relative;
-	width: 90px;
-	height: 50px;
-	background-color: #83d8ff;
-	border-radius: 84px;
-	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
+	transform: scale(1) rotate(-2deg);
+	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle .toggle__handler {
-	display: inline-block;
-	position: relative;
-	z-index: 1;
-	top: 3px;
-	left: -7px;
-	width: 44px;
-	height: 44px;
-	background-color: #ffcf96;
-	border-radius: 50px;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
-	transform: rotate(-45deg);
-}
-
-#night-day-toggle .toggle__handler .crater {
+#night-day-toggle input + label:before {
+	content: '';
+	width: inherit;
+	height: inherit;
+	border-radius: inherit;
 	position: absolute;
-	background-color: #e8cda5;
-	opacity: 0;
-	transition: opacity 200ms ease-in-out;
-	border-radius: 100%;
+	left: 0;
+	top: 0;
+	transition: background .3s ease;
 }
 
-#night-day-toggle .toggle__handler .crater--1 {
-	top: 18px;
-	left: 10px;
-	width: 4px;
-	height: 4px;
-}
-
-#night-day-toggle .toggle__handler .crater--2 {
-	top: 28px;
-	left: 22px;
-	width: 6px;
-	height: 6px;
-}
-
-#night-day-toggle .toggle__handler .crater--3 {
-	top: 10px;
-	left: 25px;
+#night-day-toggle input + label:after {
+	content: '';
 	width: 8px;
 	height: 8px;
-}
-
-#night-day-toggle .star {
-	position: absolute;
-	background-color: #fff;
-	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
 	border-radius: 50%;
+	margin: -4px 0 0 -4px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
+	transform: scale(0);
+	transition: all .3s ease;
 }
 
-#night-day-toggle .star--1 {
-	top: 10px;
-	left: 35px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label {
+	box-shadow: inset 32px -32px 0 0 var(--global--color-dark-gray);
+	transform: scale(0.5) rotate(0deg);
+	transition: transform .3s ease .1s, box-shadow .2s ease 0s;
 }
 
-#night-day-toggle .star--2 {
-	top: 18px;
-	left: 28px;
-	z-index: 1;
-	width: 30px;
-	height: 3px;
+#night-day-toggle input:checked + label:before {
+	background: #fff;
+	transition: background .3s ease .1s;
 }
 
-#night-day-toggle .star--3 {
-	top: 27px;
-	left: 40px;
-	z-index: 0;
-	width: 30px;
-	height: 3px;
-}
-
-#night-day-toggle .star--4,
-#night-day-toggle .star--5,
-#night-day-toggle .star--6 {
-	opacity: 0;
-	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle .star--4 {
-	top: 16px;
-	left: 11px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle .star--5 {
-	top: 32px;
-	left: 17px;
-	z-index: 0;
-	width: 3px;
-	height: 3px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle .star--6 {
-	top: 36px;
-	left: 28px;
-	z-index: 0;
-	width: 2px;
-	height: 2px;
-	transform: translate3d(3px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle {
-	background-color: #749dd6;
-}
-
-#night-day-toggle input:checked + .toggle:before {
-	color: #749ed7;
-}
-
-#night-day-toggle input:checked + .toggle:after {
-	color: #fff;
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler {
-	background-color: #ffe5b5;
-	transform: translate3d(40px, 0, 0) rotate(0);
-}
-
-#night-day-toggle input:checked + .toggle .toggle__handler .crater {
-	opacity: 1;
-}
-
-#night-day-toggle input:checked + .toggle .star--1 {
-	width: 2px;
-	height: 2px;
-}
-
-#night-day-toggle input:checked + .toggle .star--2 {
-	width: 4px;
-	height: 4px;
-	transform: translate3d(-5px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--3 {
-	width: 2px;
-	height: 2px;
-	transform: translate3d(-7px, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4,
-#night-day-toggle input:checked + .toggle .star--5,
-#night-day-toggle input:checked + .toggle .star--6 {
-	opacity: 1;
-	transform: translate3d(0, 0, 0);
-}
-
-#night-day-toggle input:checked + .toggle .star--4 {
-	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--5 {
-	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-}
-
-#night-day-toggle input:checked + .toggle .star--6 {
-	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+#night-day-toggle input:checked + label:after {
+	transform: scale(1.5);
+	transition: transform .5s ease .15s;
 }
 
 /*# sourceMappingURL=style.css.map */

--- a/style.css
+++ b/style.css
@@ -4983,4 +4983,193 @@ footer {
 	max-width: none;
 }
 
+#night-day-toggle {
+	position: fixed;
+	bottom: 10px;
+	right: 1em;
+	overflow: hidden;
+}
+
+#night-day-toggle input {
+	position: absolute;
+	left: -99em;
+}
+
+#night-day-toggle .toggle {
+	cursor: pointer;
+	display: inline-block;
+	position: relative;
+	width: 90px;
+	height: 50px;
+	background-color: #83d8ff;
+	border-radius: 84px;
+	transition: background-color 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .toggle__handler {
+	display: inline-block;
+	position: relative;
+	z-index: 1;
+	top: 3px;
+	left: -7px;
+	width: 44px;
+	height: 44px;
+	background-color: #ffcf96;
+	border-radius: 50px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+	transition: all 400ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
+	transform: rotate(-45deg);
+}
+
+#night-day-toggle .toggle__handler .crater {
+	position: absolute;
+	background-color: #e8cda5;
+	opacity: 0;
+	transition: opacity 200ms ease-in-out;
+	border-radius: 100%;
+}
+
+#night-day-toggle .toggle__handler .crater--1 {
+	top: 18px;
+	left: 10px;
+	width: 4px;
+	height: 4px;
+}
+
+#night-day-toggle .toggle__handler .crater--2 {
+	top: 28px;
+	left: 22px;
+	width: 6px;
+	height: 6px;
+}
+
+#night-day-toggle .toggle__handler .crater--3 {
+	top: 10px;
+	left: 25px;
+	width: 8px;
+	height: 8px;
+}
+
+#night-day-toggle .star {
+	position: absolute;
+	background-color: #fff;
+	transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+	border-radius: 50%;
+}
+
+#night-day-toggle .star--1 {
+	top: 10px;
+	left: 35px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--2 {
+	top: 18px;
+	left: 28px;
+	z-index: 1;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--3 {
+	top: 27px;
+	left: 40px;
+	z-index: 0;
+	width: 30px;
+	height: 3px;
+}
+
+#night-day-toggle .star--4,
+#night-day-toggle .star--5,
+#night-day-toggle .star--6 {
+	opacity: 0;
+	transition: all 300ms 0 cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle .star--4 {
+	top: 16px;
+	left: 11px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle .star--5 {
+	top: 32px;
+	left: 17px;
+	z-index: 0;
+	width: 3px;
+	height: 3px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle .star--6 {
+	top: 36px;
+	left: 28px;
+	z-index: 0;
+	width: 2px;
+	height: 2px;
+	transform: translate3d(3px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle {
+	background-color: #749dd6;
+}
+
+#night-day-toggle input:checked + .toggle:before {
+	color: #749ed7;
+}
+
+#night-day-toggle input:checked + .toggle:after {
+	color: #fff;
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler {
+	background-color: #ffe5b5;
+	transform: translate3d(40px, 0, 0) rotate(0);
+}
+
+#night-day-toggle input:checked + .toggle .toggle__handler .crater {
+	opacity: 1;
+}
+
+#night-day-toggle input:checked + .toggle .star--1 {
+	width: 2px;
+	height: 2px;
+}
+
+#night-day-toggle input:checked + .toggle .star--2 {
+	width: 4px;
+	height: 4px;
+	transform: translate3d(-5px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--3 {
+	width: 2px;
+	height: 2px;
+	transform: translate3d(-7px, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4,
+#night-day-toggle input:checked + .toggle .star--5,
+#night-day-toggle input:checked + .toggle .star--6 {
+	opacity: 1;
+	transform: translate3d(0, 0, 0);
+}
+
+#night-day-toggle input:checked + .toggle .star--4 {
+	transition: all 300ms 200ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--5 {
+	transition: all 300ms 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+#night-day-toggle input:checked + .toggle .star--6 {
+	transition: all 300ms 400ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/style.css
+++ b/style.css
@@ -5024,23 +5024,22 @@ footer {
 	position: fixed;
 	bottom: 1em;
 	right: 1em;
+	padding: 24px;
 }
 
-#night-day-toggle input {
-	display: none;
-}
-
-#night-day-toggle input + label {
+#night-day-toggle label {
 	border-radius: 50%;
 	width: 36px;
 	height: 36px;
-	position: relative;
+	position: absolute;
+	top: 5px;
+	left: 5px;
 	box-shadow: inset 16px -16px 0 0 var(--global--color-dark-gray);
 	transform: scale(1) rotate(-2deg);
 	transition: box-shadow .5s ease 0s, transform .4s ease .1s;
 }
 
-#night-day-toggle input + label:before {
+#night-day-toggle label:before {
 	content: "";
 	width: inherit;
 	height: inherit;
@@ -5051,7 +5050,7 @@ footer {
 	transition: background .3s ease;
 }
 
-#night-day-toggle input + label:after {
+#night-day-toggle label:after {
 	content: "";
 	width: 8px;
 	height: 8px;
@@ -5063,6 +5062,14 @@ footer {
 	box-shadow: 0 -23px 0 #fff, 0 23px 0 #fff, 23px 0 0 #fff, -23px 0 0 #fff, 15px 15px 0 #fff, -15px 15px 0 #fff, 15px -15px 0 #fff, -15px -15px 0 #fff;
 	transform: scale(0);
 	transition: all .3s ease;
+}
+
+#night-day-toggle input {
+	width: 1px;
+	height: 1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
 }
 
 #night-day-toggle input:checked + label {
@@ -5079,6 +5086,10 @@ footer {
 #night-day-toggle input:checked + label:after {
 	transform: scale(1.5);
 	transition: transform .5s ease .15s;
+}
+
+#night-day-toggle.focused {
+	box-shadow: 0 0 0 2px currentColor;
 }
 
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
Came up in various tickets that we need a toggle for dark/light mode. Some users use dark mode on their OS but prefer light for webpages. Others prefer dark mode due to a11y. Whatever the reason, having a toggle makes things easier for end-users.

This PR is an example of how we can do it. It's pretty simple and effective... 
The one I went with here is MIT-licenced from https://codepen.io/waynedunkley/pen/YybgGo but there are many to choose from, or we can create one specifically for this theme (would be preferable).

![Peek 2020-10-21 07-58](https://user-images.githubusercontent.com/588688/96675718-33230800-1374-11eb-8fc6-8f50de1459dd.gif)

The switch used in this PR feels a bit out of context and doesn't match the overall design, @melchoyce could we create something for toggling between dark mode and light mode?