### PR TITLE
pre tag is not preserving whitespace

### DIFF
--- a/assets/sass/04-elements/misc.scss
+++ b/assets/sass/04-elements/misc.scss
@@ -12,5 +12,6 @@ i {
 }
 
 pre {
-	white-space: pre-wrap;
+	white-space: pre;
+	overflow-x: auto;
 }

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -20,6 +20,7 @@
 @import "media-text/editor";
 @import "navigation/editor";
 @import "paragraph/editor";
+@import "preformatted/editor";
 @import "pullquote/editor";
 @import "quote/editor";
 @import "rss/editor";

--- a/assets/sass/05-blocks/blocks.scss
+++ b/assets/sass/05-blocks/blocks.scss
@@ -22,6 +22,7 @@
 @import "navigation/style";
 @import "paragraph/style";
 @import "password/style";
+@import "preformatted/style";
 @import "pullquote/style";
 @import "quote/style";
 @import "rss/style";

--- a/assets/sass/05-blocks/code/_editor.scss
+++ b/assets/sass/05-blocks/code/_editor.scss
@@ -8,4 +8,5 @@
 	border-style: solid;
 	border-width: 0.1rem;
 	padding: var(--global--spacing-unit);
+	color: currentColor;
 }

--- a/assets/sass/05-blocks/code/_editor.scss
+++ b/assets/sass/05-blocks/code/_editor.scss
@@ -1,5 +1,7 @@
 .wp-block-code code {
 	font-size: var(--global--font-size-xs);
+	white-space: pre !important;
+	overflow-x: auto;
 }
 
 .wp-block-code {

--- a/assets/sass/05-blocks/code/_style.scss
+++ b/assets/sass/05-blocks/code/_style.scss
@@ -7,6 +7,8 @@
 
 	code {
 		font-size: var(--global--font-size-xs);
-		overflow: auto;
+		white-space: pre;
+		overflow-x: auto;
+		display: block;
 	}
 }

--- a/assets/sass/05-blocks/preformatted/_editor.scss
+++ b/assets/sass/05-blocks/preformatted/_editor.scss
@@ -1,0 +1,6 @@
+pre.wp-block-preformatted {
+	overflow-x: auto;
+	white-space: pre !important;
+	font-size: var(--global--font-size-xs);
+
+}

--- a/assets/sass/05-blocks/preformatted/_style.scss
+++ b/assets/sass/05-blocks/preformatted/_style.scss
@@ -1,0 +1,4 @@
+pre.wp-block-preformatted {
+	overflow-x: auto;
+	white-space: pre;
+}


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #553

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
New 
- Added a `preformatted` block
- editor preformatted block font size now matches with the front

Changes
- the `code` block its color to `currentColor` in the editor
- misc.scss: pre tag inside a `html` block will preserve whitespace too


## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a `preformatted` and `code` block to a post/page
1. Add some content to those blocks to confirm it's preserving whitespace
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
