### PR TITLE
rename searchform label to aria_label argument.

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -18,7 +18,7 @@
  */
 $twentytwentyone_unique_id = wp_unique_id( 'search-form-' );
 
-$twentytwentyone_aria_label = ! empty( $args['label'] ) ? 'aria-label="' . esc_attr( $args['label'] ) . '"' : '';
+$twentytwentyone_aria_label = ! empty( $args['aria_label'] ) ? 'aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
 ?>
 <form role="search" <?php echo $twentytwentyone_aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $twentytwentyone_unique_id ); ?>"><?php _e( 'Search&hellip;', 'twentytwentyone' ); // phpcs:ignore: WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></label>


### PR DESCRIPTION
Fixes #628

Discussed with @carolinan and @afercia and came to the conclusion that the searchforms don't need a specific aria-label. Using an aria-label to differentiate searchforms would only make sense if they were performing different search queries (example: one for posts, one for products via a plugin). Since all existing forms in the theme perform the default search, making them different is not necessary.
This PR swill simply fix the argument name from `label` to `aria_label`.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
