### PR TITLE
Enable dark-mode in the editor when needed

### DIFF
--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -1,0 +1,6 @@
+if (
+	document.body.classList.contains( 'twentytwentyone-supports-dark-theme' ) &&
+	window.matchMedia( '(prefers-color-scheme: dark)' ).matches
+) {
+	document.body.classList.add( 'is-dark-theme' );
+}

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -29,6 +29,9 @@ class Twenty_Twenty_One_Custom_Colors {
 
 		// Add body-class if needed.
 		add_filter( 'body_class', array( $this, 'body_class' ) );
+
+		// Filter admin body classes.
+		add_filter( 'admin_body_class', array( $this, 'admin_body_classes' ) );
 	}
 
 	/**
@@ -178,6 +181,35 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-background-dark';
 		} else {
 			$classes[] = 'is-background-light';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Adds a class to the <body> element in the editor to accommodate dark-mode.
+	 *
+	 * @access public
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $classes The admin body-classes.
+	 *
+	 * @return string
+	 */
+	public function admin_body_classes( $classes ) {
+		global $current_screen;
+		if ( empty( $current_screen ) ) {
+			set_current_screen();
+		}
+
+		if ( $current_screen->is_block_editor() ) {
+			$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', true ); // @phpstan-ignore-line. Passing true instead of default value of false to get_theme_mod.
+			$background_color            = get_theme_mod( 'background_color', 'D1E4DD' );
+
+			if ( $should_respect_color_scheme && self::get_relative_luminance_from_hex( $background_color ) > 127 ) {
+				$classes .= ' twentytwentyone-supports-dark-theme';
+			}
 		}
 
 		return $classes;

--- a/functions.php
+++ b/functions.php
@@ -445,6 +445,7 @@ add_action( 'wp_enqueue_scripts', 'twenty_twenty_one_scripts' );
 function twentytwentyone_block_editor_script() {
 
 	wp_enqueue_script( 'twentytwentyone-unregister-block-style', get_theme_file_uri( '/assets/js/unregister-block-style.js' ), array( 'wp-blocks', 'wp-dom' ), wp_get_theme()->get( 'Version' ), true );
+	wp_enqueue_script( 'twentytwentyone-editor-dark-mode-support', get_theme_file_uri( '/assets/js/editor-dark-mode-support.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 }
 
 add_action( 'enqueue_block_editor_assets', 'twentytwentyone_block_editor_script' );


### PR DESCRIPTION
When a light color is selected as background AND the user has chosen to respect the visitors color-scheme AND a post-author is using dark-mode in their OS, the color-scheme in the editor is dark but the editor itself is not. That can lead to some things being unreadable.
Example: The post-title placeholder.
![Screenshot_2020-10-21 Edit Post ‹ My Blog — WordPress(4)](https://user-images.githubusercontent.com/588688/96724562-a484aa00-13b8-11eb-938e-b8bc33caa9d4.png)

This PR will check if we're in the editor, if the `respect_user_color_preference` option is enabled, the default background is light, and if all of the above is true then it adds a `twentytwentyone-supports-dark-theme` to `<body>` on the admin.
Then, via JS we check if the class exists in the body and if the client's browser has dark-mode enabled. If yes, then we add the `is-dark-theme` class to `<body>` which changes the editor UI to dark mode.

![Screenshot_2020-10-21 Edit Post ‹ My Blog — WordPress(3)](https://user-images.githubusercontent.com/588688/96724940-06451400-13b9-11eb-922c-f8b87056615c.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
