### PR TITLE
Fix aria-expanded on nav hover

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5769,7 +5769,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -5856,14 +5856,6 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] .icon-plus {
-	display: none;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-minus {
-	display: flex;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-plus {
 	display: none;
 }
 

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -122,22 +122,11 @@ function twentytwentyoneExpandSubMenu( el ) { // eslint-disable-line no-unused-v
 		} );
 
 		document.getElementById( 'site-navigation' ).querySelectorAll( '.menu-wrapper > .menu-item-has-children' ).forEach( function( li ) {
-			var i;
 			li.addEventListener( 'mouseenter', function() {
-				if ( 'false' === this.querySelector( '.sub-menu-toggle' ).getAttribute( 'aria-expanded' ) ) {
-					for ( i = 0; i < this.children.length; i++ ) {
-						if ( this.children[ i ].classList.contains( 'sub-menu-toggle' ) ) {
-							this.children[ i ].setAttribute( 'aria-expanded', 'true' );
-						}
-					}
-				}
+				this.querySelector( '.sub-menu-toggle' ).setAttribute( 'aria-expanded', 'true' );
 			} );
 			li.addEventListener( 'mouseleave', function() {
-				for ( i = 0; i < this.children.length; i++ ) {
-					if ( this.children[ i ].classList.contains( 'sub-menu-toggle' ) ) {
-						this.children[ i ].setAttribute( 'aria-expanded', 'false' );
-					}
-				}
+				this.querySelector( '.sub-menu-toggle' ).setAttribute( 'aria-expanded', 'false' );
 			} );
 		} );
 	};

--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -39,13 +39,6 @@ function twentytwentyoneCollapseMenuOnClickOutside( event ) {
  * @param {Element} el - The element.
  */
 function twentytwentyoneExpandSubMenu( el ) { // eslint-disable-line no-unused-vars
-	// Close submenu that was opened from a hover action.
-	// We'll return early in this case to avoid changing the aria-expanded attribute.
-	if ( el.parentNode.classList.contains( 'hover' ) ) {
-		el.parentNode.classList.remove( 'hover' );
-		return;
-	}
-
 	// Close other expanded items.
 	el.closest( 'nav' ).querySelectorAll( '.sub-menu-toggle' ).forEach( function( button ) {
 		if ( button !== el ) {
@@ -129,13 +122,22 @@ function twentytwentyoneExpandSubMenu( el ) { // eslint-disable-line no-unused-v
 		} );
 
 		document.getElementById( 'site-navigation' ).querySelectorAll( '.menu-wrapper > .menu-item-has-children' ).forEach( function( li ) {
+			var i;
 			li.addEventListener( 'mouseenter', function() {
 				if ( 'false' === this.querySelector( '.sub-menu-toggle' ).getAttribute( 'aria-expanded' ) ) {
-					this.classList.add( 'hover' );
+					for ( i = 0; i < this.children.length; i++ ) {
+						if ( this.children[ i ].classList.contains( 'sub-menu-toggle' ) ) {
+							this.children[ i ].setAttribute( 'aria-expanded', 'true' );
+						}
+					}
 				}
 			} );
 			li.addEventListener( 'mouseleave', function() {
-				this.classList.remove( 'hover' );
+				for ( i = 0; i < this.children.length; i++ ) {
+					if ( this.children[ i ].classList.contains( 'sub-menu-toggle' ) ) {
+						this.children[ i ].setAttribute( 'aria-expanded', 'false' );
+					}
+				}
 			} );
 		} );
 	};

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -186,7 +186,7 @@
 		}
 
 		// Hide sub-sub-menus
-		> .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
+		> .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 			display: none;
 		}
 
@@ -278,17 +278,6 @@
 				.icon-plus {
 					display: none;
 				}
-			}
-		}
-
-		.hover .sub-menu-toggle {
-
-			.icon-minus {
-				display: flex;
-			}
-
-			.icon-plus {
-				display: none;
 			}
 		}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4132,7 +4132,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -4219,14 +4219,6 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] .icon-plus {
-	display: none;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-minus {
-	display: flex;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-plus {
 	display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -4142,7 +4142,7 @@ h1.page-title {
 	.primary-navigation #toggle-menu {
 		display: none;
 	}
-	.primary-navigation > .primary-menu-container ul > li:not(.hover) .sub-menu-toggle[aria-expanded="false"] ~ ul {
+	.primary-navigation > .primary-menu-container ul > li .sub-menu-toggle[aria-expanded="false"] ~ ul {
 		display: none;
 	}
 	.admin-bar .primary-navigation {
@@ -4229,14 +4229,6 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle[aria-expanded="true"] .icon-plus {
-	display: none;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-minus {
-	display: flex;
-}
-
-.primary-navigation > div > .menu-wrapper .hover .sub-menu-toggle .icon-plus {
 	display: none;
 }
 


### PR DESCRIPTION
Fixes #633 

## Summary
Changes the `aria-expanded` attribute in nav dropdown-buttons when the menu-item is hovered.
Since the attribute now changes correctly I removed the specific styles for the `.hover` class, they were no longer necessary.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
