### PR TITLE
Fix RTL issue

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5022,6 +5022,10 @@ h1.entry-title {
 	display: block;
 }
 
+.entry-footer > span {
+	display: inline-block;
+}
+
 .entry-footer a {
 	color: currentColor;
 }

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -80,6 +80,10 @@ h1.entry-title {
 	font-size: var(--global--font-size-xs);
 	display: block;
 
+	> span {
+		display: inline-block;
+	}
+
 	a {
 		color: currentColor;
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3545,6 +3545,10 @@ h1.entry-title {
 	display: block;
 }
 
+.entry-footer > span {
+	display: inline-block;
+}
+
 .entry-footer a {
 	color: currentColor;
 }

--- a/style.css
+++ b/style.css
@@ -3555,6 +3555,10 @@ h1.entry-title {
 	display: block;
 }
 
+.entry-footer > span {
+	display: inline-block;
+}
+
 .entry-footer a {
 	color: currentColor;
 }


### PR DESCRIPTION
fixes #638

The problem was that the edit link was going between the date parts. Fixed by adding `display:inline-block`.

Before:

![Screenshot_2020-10-22 My Blog(1)](https://user-images.githubusercontent.com/588688/96825561-1fda7000-143a-11eb-9843-e034ebaa7682.png)

After:

![Screenshot_2020-10-22 My Blog](https://user-images.githubusercontent.com/588688/96825579-27017e00-143a-11eb-8109-543fd5bc840e.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
