### PR TITLE
Update pullquote margins to change the default position

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1553,8 +1553,6 @@ p.has-background {
 
 .wp-block-pullquote {
 	padding: 40px 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: center;
 	border-width: 3px;
 	border-bottom-style: solid;
@@ -1616,6 +1614,8 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color {
+	margin-left: auto;
+	margin-right: auto;
 	padding: 50px;
 	border-width: 3px;
 	border-style: solid;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1109,8 +1109,6 @@ p.has-background {
 
 .wp-block-pullquote {
 	padding: calc(2 * var(--global--spacing-unit)) 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: center;
 	border-width: var(--pullquote--border-width);
 	border-bottom-style: solid;
@@ -1156,6 +1154,8 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color {
+	margin-left: auto;
+	margin-right: auto;
 	padding: calc(2.5 * var(--global--spacing-unit));
 	border-width: var(--pullquote--border-width);
 	border-style: solid;

--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -1,7 +1,5 @@
 .wp-block-pullquote {
 	padding: calc(2 * var(--global--spacing-unit)) 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: center;
 	border-width: var(--pullquote--border-width);
 	border-bottom-style: solid;
@@ -47,6 +45,8 @@
 	}
 
 	&.is-style-solid-color {
+		margin-left: auto;
+		margin-right: auto;
 		padding: calc(2.5 * var(--global--spacing-unit));
 		border-width: var(--pullquote--border-width);
 		border-style: solid;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/646

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Removes the margin: 0 from the default pullquote style, and overrides it for the solid style.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add two pullquotes, one with the default style and one with the solid style.
1. See that the blocks are positioned in the middle, when no alignment option has been changed.
1. Confirm that the new styles does not affect the block negatively in the different positions, screen widths, and in combination with other blocks.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>


![pullquote-after](https://user-images.githubusercontent.com/7422055/96850444-1e6b7080-1457-11eb-95ca-4aab6628c05b.png)



</details>


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
