### PR TITLE
Add styles for the tag cloud block

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2228,6 +2228,10 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
+.wp-block-tag-cloud.aligncenter {
+	text-align: center;
+}
+
 pre.wp-block-verse {
 	padding: 0;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4320,6 +4320,11 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
+.wp-block-tag-cloud {
+	padding-left: 20px;
+	padding-right: 20px;
+}
+
 .wp-block-verse {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4320,7 +4320,7 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
-.wp-block-tag-cloud {
+.wp-block-tag-cloud.alignfull {
 	padding-left: 20px;
 	padding-right: 20px;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1618,6 +1618,10 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
+.wp-block-tag-cloud.aligncenter {
+	text-align: center;
+}
+
 pre.wp-block-verse {
 	padding: 0;
 }

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -27,6 +27,7 @@
 @import "separator/editor";
 @import "social-icons/editor";
 @import "table/editor";
+@import "tag-clould/editor";
 @import "verse/editor";
 @import "utilities/font-sizes";
 @import "utilities/editor"; // Import LAST to cascade properly

--- a/assets/sass/05-blocks/blocks.scss
+++ b/assets/sass/05-blocks/blocks.scss
@@ -30,6 +30,7 @@
 @import "social-icons/style";
 @import "spacer/style";
 @import "table/style";
+@import "tag-clould/style";
 @import "verse/style";
 @import "video/style";
 @import "utilities/font-sizes";

--- a/assets/sass/05-blocks/tag-clould/_editor.scss
+++ b/assets/sass/05-blocks/tag-clould/_editor.scss
@@ -1,0 +1,6 @@
+.wp-block-tag-cloud {
+
+	&.aligncenter {
+		text-align: center;
+	}
+}

--- a/assets/sass/05-blocks/tag-clould/_style.scss
+++ b/assets/sass/05-blocks/tag-clould/_style.scss
@@ -1,0 +1,4 @@
+.wp-block-tag-cloud {
+	padding-left: var(--global--spacing-unit);
+	padding-right: var(--global--spacing-unit);
+}

--- a/assets/sass/05-blocks/tag-clould/_style.scss
+++ b/assets/sass/05-blocks/tag-clould/_style.scss
@@ -1,4 +1,7 @@
 .wp-block-tag-cloud {
-	padding-left: var(--global--spacing-unit);
-	padding-right: var(--global--spacing-unit);
+
+	&.alignfull {
+		padding-left: var(--global--spacing-unit);
+		padding-right: var(--global--spacing-unit);
+	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3036,6 +3036,11 @@ table.wp-calendar-table caption {
 	float: left;
 }
 
+.wp-block-tag-cloud {
+	padding-right: var(--global--spacing-unit);
+	padding-left: var(--global--spacing-unit);
+}
+
 .wp-block-verse {
 	font-family: var(--entry-content--font-family);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3036,7 +3036,7 @@ table.wp-calendar-table caption {
 	float: left;
 }
 
-.wp-block-tag-cloud {
+.wp-block-tag-cloud.alignfull {
 	padding-right: var(--global--spacing-unit);
 	padding-left: var(--global--spacing-unit);
 }

--- a/style.css
+++ b/style.css
@@ -3041,7 +3041,7 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
-.wp-block-tag-cloud {
+.wp-block-tag-cloud.alignfull {
 	padding-left: var(--global--spacing-unit);
 	padding-right: var(--global--spacing-unit);
 }

--- a/style.css
+++ b/style.css
@@ -3041,6 +3041,11 @@ table.wp-calendar-table caption {
 	float: right;
 }
 
+.wp-block-tag-cloud {
+	padding-left: var(--global--spacing-unit);
+	padding-right: var(--global--spacing-unit);
+}
+
 .wp-block-verse {
 	font-family: var(--entry-content--font-family);
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #644.

## Summary
Add styles for the tag cloud block.

## Relevant technical choices:
No

## Test instructions

This PR can be tested by following these steps:
1.
1.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Before
![Capture d’écran du 2020-10-22 10-50-11](https://user-images.githubusercontent.com/33403964/96855272-689f2280-1454-11eb-938f-f5d8c62cd3cd.png)

![Capture d’écran du 2020-10-22 10-49-37](https://user-images.githubusercontent.com/33403964/96855300-6f2d9a00-1454-11eb-8d2c-32c95a272718.png)



After
![Capture d’écran du 2020-10-22 10-46-43](https://user-images.githubusercontent.com/33403964/96855074-270e7780-1454-11eb-955e-9753eafeb110.png)

![Capture d’écran du 2020-10-22 10-47-06](https://user-images.githubusercontent.com/33403964/96855097-2e358580-1454-11eb-8ead-cb1fa8b4f937.png)



## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
