### PR TITLE
Update the more block link

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -224,7 +224,7 @@ add_filter( 'excerpt_more', 'twenty_twenty_one_continue_reading_link_excerpt' );
  */
 function twenty_twenty_one_continue_reading_link() {
 	if ( ! is_admin() ) {
-		return '<div class="more-link-container"><a class="more-link" href="' . esc_url( get_permalink() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></div>';
+		return '<div class="more-link-container"><a class="more-link" href="' . esc_url( get_permalink() ) . '#more-' . esc_attr( get_the_ID() ) . '">' . twenty_twenty_one_continue_reading_text() . '</a></div>';
 	}
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/658

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Adds the `#more-` and post ID to the more blocks continue reading link.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Go to Customizer and choose to show full content on archive pages.
1. Select a post or page with a lot of content. Place the more block in the middle, this makes it easier to test that the link fragment works.
1. View this post or page on an archive page
1. Click the more blocks continue reading link, and make sure that the link takes you to the position where you placed the block.

<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
