### PR TITLE
Update the widget grid columns

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6433,7 +6433,15 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
-@media only screen and (min-width: 822px) {
+@media only screen and (min-width: 652px) {
+	.widget-area {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: 50px;
+	}
+}
+
+@media only screen and (min-width: 1024px) {
 	.widget-area {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -13,7 +13,6 @@
 	}
 
 	@include media(wide) {
-		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -6,7 +6,13 @@
 	font-size: var(--footer--font-size);
 	font-family: var(--footer--font-family);
 
-	@include media(desktop) {
+	@include media(laptop) {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: calc(2 * var(--global--spacing-horizontal));
+	}
+
+	@include media(wide) {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		column-gap: calc(2 * var(--global--spacing-horizontal));

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -14,7 +14,6 @@
 
 	@include media(wide) {
 		grid-template-columns: repeat(3, 1fr);
-		column-gap: calc(2 * var(--global--spacing-horizontal));
 	}
 
 	ul {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4725,7 +4725,15 @@ h1.page-title {
 	font-family: var(--footer--font-family);
 }
 
-@media only screen and (min-width: 822px) {
+@media only screen and (min-width: 652px) {
+	.widget-area {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: calc(2 * var(--global--spacing-horizontal));
+	}
+}
+
+@media only screen and (min-width: 1024px) {
 	.widget-area {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);

--- a/style.css
+++ b/style.css
@@ -4735,7 +4735,15 @@ h1.page-title {
 	font-family: var(--footer--font-family);
 }
 
-@media only screen and (min-width: 822px) {
+@media only screen and (min-width: 652px) {
+	.widget-area {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: calc(2 * var(--global--spacing-horizontal));
+	}
+}
+
+@media only screen and (min-width: 1024px) {
 	.widget-area {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/657

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

At minimum 652px, split the the widget area into 2 columns
At minimum 1024px width, split the widget area into 3 columns.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add at least 3 widgets to the footer widget area
1. Test with different browser window widths.
1.
<!-- Don't forget to test the unhappy-paths! -->


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
