### PR TITLE
Update the underline for the continue reading link

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5015,10 +5015,6 @@ h1.entry-title {
 	word-wrap: break-word;
 }
 
-.entry-content .more-link:hover {
-	text-decoration: none;
-}
-
 .entry-content > iframe[style] {
 	margin: 30px 0 !important;
 	max-width: 100% !important;

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -48,13 +48,6 @@ h1.entry-title {
 		word-wrap: break-word;
 	}
 
-	.more-link {
-
-		&:hover {
-			text-decoration: none;
-		}
-	}
-
 	// Overwrite iframe embeds that have inline styles.
 	> iframe[style] {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3538,10 +3538,6 @@ h1.entry-title {
 	word-wrap: break-word;
 }
 
-.entry-content .more-link:hover {
-	text-decoration: none;
-}
-
 .entry-content > iframe[style] {
 	margin: var(--global--spacing-vertical) 0 !important;
 	max-width: 100% !important;

--- a/style.css
+++ b/style.css
@@ -3548,10 +3548,6 @@ h1.entry-title {
 	word-wrap: break-word;
 }
 
-.entry-content .more-link:hover {
-	text-decoration: none;
-}
-
 .entry-content > iframe[style] {
 	margin: var(--global--spacing-vertical) 0 !important;
 	max-width: 100% !important;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/652

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Removes the `text-decoration: none;` hover style from the continue reading link.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View an archive page that displays excerpts
1. Hover over the continue reading link.
1. See that the default dotted underline is used.
<!-- Don't forget to test the unhappy-paths! -->


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
