### PR TITLE
Update button-only centered search block styles

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2026,6 +2026,10 @@ pre.wp-block-preformatted {
 	text-align: center;
 }
 
+.wp-block[data-align="center"] .wp-block-search__button-only .wp-block-search__inside-wrapper {
+	justify-content: center;
+}
+
 .wp-block-separator {
 	border-bottom: 1px solid #28303d;
 	clear: both;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4075,6 +4075,10 @@ pre.wp-block-preformatted {
 	background-color: #fff;
 }
 
+.wp-block-search__button-only.aligncenter .wp-block-search__inside-wrapper {
+	justify-content: center;
+}
+
 .wp-block-search .wp-block-search__label {
 	font-size: 1.125rem;
 	font-weight: 500;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1476,6 +1476,10 @@ pre.wp-block-preformatted {
 	text-align: center;
 }
 
+.wp-block[data-align="center"] .wp-block-search__button-only .wp-block-search__inside-wrapper {
+	justify-content: center;
+}
+
 .wp-block-separator,
 hr {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);

--- a/assets/sass/05-blocks/search/_editor.scss
+++ b/assets/sass/05-blocks/search/_editor.scss
@@ -39,3 +39,13 @@
 .wp-block[data-align="center"] > * {
 	text-align: center;
 }
+
+.wp-block[data-align="center"] {
+
+	.wp-block-search__button-only {
+
+		.wp-block-search__inside-wrapper {
+			justify-content: center;
+		}
+	}
+}

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -8,6 +8,13 @@
 		}
 	}
 
+	&__button-only.aligncenter {
+
+		.wp-block-search__inside-wrapper {
+			justify-content: center;
+		}
+	}
+
 	.wp-block-search__label {
 		font-size: var(--form--font-size);
 		font-weight: var(--form--label-weight);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2851,6 +2851,10 @@ pre.wp-block-preformatted {
 	background-color: var(--global--color-white);
 }
 
+.wp-block-search__button-only.aligncenter .wp-block-search__inside-wrapper {
+	justify-content: center;
+}
+
 .wp-block-search .wp-block-search__label {
 	font-size: var(--form--font-size);
 	font-weight: var(--form--label-weight);

--- a/style.css
+++ b/style.css
@@ -2856,6 +2856,10 @@ pre.wp-block-preformatted {
 	background-color: var(--global--color-white);
 }
 
+.wp-block-search__button-only.aligncenter .wp-block-search__inside-wrapper {
+	justify-content: center;
+}
+
 .wp-block-search .wp-block-search__label {
 	font-size: var(--form--font-size);
 	font-weight: var(--form--label-weight);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #641.

## Summary
Update button-only centered search block styles.

## Relevant technical choices:
No

## Test instructions

1.     Add a search block.
2.     Duplicate the block and change the alignment to center.


## Screenshots
Editor 
![Capture d’écran du 2020-10-23 15-27-18](https://user-images.githubusercontent.com/33403964/97016496-b72bea00-1544-11eb-85ff-82df43b4f2e0.png)

Frontend
![Capture d’écran du 2020-10-23 15-27-31](https://user-images.githubusercontent.com/33403964/97016519-bf842500-1544-11eb-935f-f5d5fc7b249d.png)




## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
