### PR TITLE
Update link focus background color

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -394,14 +394,29 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid #28303d;
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	background: rgba(255, 255, 255, 0.9);
+}
+
+.has-background-dark .site a:focus {
+	color: #d1e4dd;
+}
+
+.has-background-white .site a:focus {
+	background: rgba(0, 0, 0, 0.9);
+	color: #fff;
 }
 
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+.site a:focus.skip-link:focus {
+	color: #21759b;
+	background-color: #f1f1f1;
 }
 
 .has-background:not(.has-background-background-color) .has-link-color a {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2138,14 +2138,29 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid #28303d;
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	background: rgba(255, 255, 255, 0.9);
+}
+
+.has-background-dark .site a:focus {
+	color: #d1e4dd;
+}
+
+.has-background-white .site a:focus {
+	background: rgba(0, 0, 0, 0.9);
+	color: #fff;
 }
 
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+.site a:focus.skip-link:focus {
+	color: #21759b;
+	background-color: #f1f1f1;
 }
 
 .has-background:not(.has-background-background-color) .has-link-color a {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -467,14 +467,29 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	background: rgba(255, 255, 255, 0.9);
+}
+
+.has-background-dark .site a:focus {
+	color: var(--wp--style--color--link, var(--global--color-background));
+}
+
+.has-background-white .site a:focus {
+	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+.site a:focus.skip-link:focus {
+	color: #21759b;
+	background-color: #f1f1f1;
 }
 
 .has-background:not(.has-background-background-color) .has-link-color a,

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -17,14 +17,32 @@ a:hover {
 
 .site a:focus {
 
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+
+	background: rgba(255, 255, 255, .9);
+
+	// Change text color when the body background is dark.
+	.has-background-dark & {
+		color: var(--wp--style--color--link, var(--global--color-background));
+	}
+
+	// Change colors when the body background is white.
+	.has-background-white & {
+		background: rgba(0, 0, 0, .9);
+		color: var(--wp--style--color--link, var(--global--color-white));
+	}
 
 	&.skip-link {
 
 		/* Only visible in Windows High Contrast mode */
 		outline: 2px solid transparent;
 		outline-offset: -2px;
+
+		&:focus {
+			color: #21759b;
+			background-color: #f1f1f1;
+		}
 	}
 }
 

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -180,6 +180,10 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'has-background-light';
 		}
 
+		if ( 'ffffff' ===  strtolower( $background_color ) ) {
+			$classes[] = 'has-background-white';
+		}
+
 		return $classes;
 	}
 }

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -180,7 +180,7 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'has-background-light';
 		}
 
-		if ( 'ffffff' ===  strtolower( $background_color ) ) {
+		if ( 'ffffff' === strtolower( $background_color ) ) {
 			$classes[] = 'has-background-white';
 		}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1534,14 +1534,29 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	background: rgba(255, 255, 255, 0.9);
+}
+
+.has-background-dark .site a:focus {
+	color: var(--wp--style--color--link, var(--global--color-background));
+}
+
+.has-background-white .site a:focus {
+	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+.site a:focus.skip-link:focus {
+	color: #21759b;
+	background-color: #f1f1f1;
 }
 
 .has-background:not(.has-background-background-color) .has-link-color a,

--- a/style.css
+++ b/style.css
@@ -1539,14 +1539,29 @@ a:hover {
 }
 
 .site a:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: none;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	background: rgba(255, 255, 255, 0.9);
+}
+
+.has-background-dark .site a:focus {
+	color: var(--wp--style--color--link, var(--global--color-background));
+}
+
+.has-background-white .site a:focus {
+	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
 .site a:focus.skip-link {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+.site a:focus.skip-link:focus {
+	color: #21759b;
+	background-color: #f1f1f1;
 }
 
 .has-background:not(.has-background-background-color) .has-link-color a,


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/444

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

**Light body background:** Nearly white focus background color.
**Dark body background:** Nearly white focus background color, dark text `var(--global--color-background);`
**White body background:** Nearly black focus background color, white text.

Known bug: The body classes used to change the color does not change in the customizer without reloading the browser window.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Focus on different links with different background color settings.
1.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

![black](https://user-images.githubusercontent.com/7422055/97023870-64f3c480-1556-11eb-8a89-601e25032930.gif)

![white](https://user-images.githubusercontent.com/7422055/97024483-27dc0200-1557-11eb-9e24-d621ec11e7c5.gif)

![pink](https://user-images.githubusercontent.com/7422055/97024325-f82cfa00-1556-11eb-8e39-a868f007cd91.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [ ] I have checked that this code does not affect the accessibility negatively
