### PR TITLE
Update the HTML blocks text color

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1245,6 +1245,12 @@ h6 {
 	line-height: 1.3;
 }
 
+[data-type="core/html"] textarea {
+	color: #28303d;
+	border-radius: 0;
+	padding: 20px;
+}
+
 /* Center image block by default in the editor */
 .wp-block-image > div {
 	text-align: center;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -830,6 +830,12 @@ h6,
 	line-height: var(--heading--line-height-h6);
 }
 
+[data-type="core/html"] textarea {
+	color: var(--global--color-dark-gray);
+	border-radius: 0;
+	padding: var(--global--spacing-unit);
+}
+
 /* Center image block by default in the editor */
 .wp-block-image > div {
 	text-align: center;

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -12,6 +12,7 @@
 @import "gallery/editor";
 @import "group/editor";
 @import "heading/editor";
+@import "html/editor";
 @import "image/editor";
 @import "latest-comments/editor";
 @import "latest-posts/editor";

--- a/assets/sass/05-blocks/html/_editor.scss
+++ b/assets/sass/05-blocks/html/_editor.scss
@@ -1,0 +1,6 @@
+[data-type="core/html"] textarea {
+	// Make sure that the color is not white on white when a dark body background is used.
+	color: var(--global--color-dark-gray);
+	border-radius: 0;
+	padding: var(--global--spacing-unit);
+}


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/683

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Adds the dark grey text color to the block instead of the primary color.
Adds padding for readability, and removes the border radius to better match the code block.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
Does not fix the issue with the HTML preview which uses an iframe and is out of scope for the theme.

## Test instructions

This PR can be tested by following these steps:
1. Change the body background color in the customizer.
1. Add an HTML block
1. Confirm that the text is readable.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
