### PR TITLE
Style submenus container

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3471,7 +3471,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid #28303d;
+	border: 1px solid #39414d;
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -6035,7 +6035,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: 13px;
-	border: 1px solid #28303d;
+	border: 1px solid #39414d;
 }
 
 @media only screen and (min-width: 482px) {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6034,6 +6034,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: 13px;
+	border: 1px solid #39414d;
 }
 
 @media only screen and (min-width: 482px) {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3466,12 +3466,40 @@ dd {
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container {
 	background: #d1e4dd;
-	box-shadow: 1px 1px 3px 0 rgba(0, 0, 0, 0.2);
 	margin: 0;
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid #39414d;
+	border: 1px solid #28303d;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:before {
+	content: "";
+	display: block;
+	position: absolute;
+	width: 0;
+	top: -10px;
+	left: 25px;
+	border-style: solid;
+	border-color: #28303d transparent;
+	border-width: 0 7px 10px 7px;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	content: "";
+	display: block;
+	position: absolute;
+	width: 0;
+	top: -10px;
+	left: 25px;
+	border-style: solid;
+	border-color: #28303d transparent;
+	border-width: 0 7px 10px 7px;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	top: -9px;
+	border-color: #d1e4dd transparent;
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -3488,6 +3516,11 @@ dd {
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: #28303d;
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover {
+	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -5943,13 +5976,35 @@ h1.page-title {
 		transition: all 0.5s ease;
 		z-index: 88888;
 	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:before {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 0;
+		top: -10px;
+		left: 25px;
+		border-style: solid;
+		border-color: #28303d transparent;
+		border-width: 0 7px 10px 7px;
+	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 0;
+		top: -10px;
+		left: 25px;
+		border-style: solid;
+		border-color: #28303d transparent;
+		border-width: 0 7px 10px 7px;
+	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		top: -9px;
+		border-color: #d1e4dd transparent;
+	}
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 		background: #d1e4dd;
 	}
-}
-
-.primary-navigation > div > .menu-wrapper > li > .sub-menu .sub-menu {
-	width: 100%;
 }
 
 .primary-navigation .primary-menu > .menu-item:hover > a {
@@ -6035,7 +6090,11 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: 13px;
-	border: 1px solid #39414d;
+	border: 1px solid #28303d;
+}
+
+.primary-navigation .sub-menu .sub-menu {
+	border: none;
 }
 
 @media only screen and (min-width: 482px) {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3471,6 +3471,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
+	border: 1px solid #28303d;
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -6034,7 +6035,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: 13px;
-	border: 1px solid #39414d;
+	border: 1px solid #28303d;
 }
 
 @media only screen and (min-width: 482px) {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -152,6 +152,7 @@
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--border-color: var(--global--color-primary);
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -172,6 +172,7 @@ $baseline-unit: 10px;
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--border-color: var(--global--color-primary);
 
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);

--- a/assets/sass/05-blocks/navigation/_style.scss
+++ b/assets/sass/05-blocks/navigation/_style.scss
@@ -113,6 +113,11 @@
 				&:focus {
 					color: var(--primary-nav--color-link-hover);
 				}
+
+				&:hover {
+					text-decoration: underline;
+					text-decoration-style: dotted;
+				}
 			}
 		}
 

--- a/assets/sass/05-blocks/navigation/_style.scss
+++ b/assets/sass/05-blocks/navigation/_style.scss
@@ -70,7 +70,7 @@
 				padding: 0;
 				position: absolute;
 				top: 100%;
-				border: 1px solid var(--global--color-dark-gray);
+				border: 1px solid var(--global--color-gray);
 			}
 		}
 	}

--- a/assets/sass/05-blocks/navigation/_style.scss
+++ b/assets/sass/05-blocks/navigation/_style.scss
@@ -65,12 +65,29 @@
 
 			> .wp-block-navigation__container {
 				background: var(--global--color-background);
-				box-shadow: var(--global--elevation);
 				margin: 0;
 				padding: 0;
 				position: absolute;
 				top: 100%;
-				border: 1px solid var(--global--color-gray);
+				border: 1px solid var(--primary-nav--border-color);
+
+				&:before,
+				&:after {
+					content: "";
+					display: block;
+					position: absolute;
+					width: 0;
+					top: -10px;
+					left: var(--global--spacing-horizontal);
+					border-style: solid;
+					border-color: var(--primary-nav--border-color) transparent;
+					border-width: 0 7px 10px 7px;
+				}
+
+				&:after {
+					top: -9px;
+					border-color: var(--global--color-background) transparent;
+				}
 			}
 		}
 	}

--- a/assets/sass/05-blocks/navigation/_style.scss
+++ b/assets/sass/05-blocks/navigation/_style.scss
@@ -70,6 +70,7 @@
 				padding: 0;
 				position: absolute;
 				top: 100%;
+				border: 1px solid var(--global--color-dark-gray);
 			}
 		}
 	}

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -296,13 +296,27 @@
 				transition: all 0.5s ease;
 				z-index: 88888;
 
+				&:before,
+				&:after {
+					content: "";
+					display: block;
+					position: absolute;
+					width: 0;
+					top: -10px;
+					left: var(--global--spacing-horizontal);
+					border-style: solid;
+					border-color: var(--primary-nav--border-color) transparent;
+					border-width: 0 7px 10px 7px;
+				}
+
+				&:after {
+					top: -9px;
+					border-color: var(--global--color-background) transparent;
+				}
+
 				li {
 					background: var(--global--color-background);
 				}
-			}
-
-			.sub-menu {
-				width: 100%;
 			}
 		}
 	}
@@ -389,7 +403,11 @@
 		padding: 0;
 		list-style: none;
 		margin-left: var(--primary-nav--padding);
-		border: 1px solid var(--global--color-gray);
+		border: 1px solid var(--primary-nav--border-color);
+
+		.sub-menu {
+			border: none;
+		}
 
 		// Sub-menu items om wide screens.
 		@include media(mobile) {

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -389,6 +389,7 @@
 		padding: 0;
 		list-style: none;
 		margin-left: var(--primary-nav--padding);
+		border: 1px solid var(--global--color-gray);
 
 		// Sub-menu items om wide screens.
 		@include media(mobile) {

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -389,7 +389,7 @@
 		padding: 0;
 		list-style: none;
 		margin-left: var(--primary-nav--padding);
-		border: 1px solid var(--global--color-dark-gray);
+		border: 1px solid var(--global--color-gray);
 
 		// Sub-menu items om wide screens.
 		@include media(mobile) {

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -389,7 +389,7 @@
 		padding: 0;
 		list-style: none;
 		margin-left: var(--primary-nav--padding);
-		border: 1px solid var(--global--color-gray);
+		border: 1px solid var(--global--color-dark-gray);
 
 		// Sub-menu items om wide screens.
 		@include media(mobile) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4384,6 +4384,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-right: var(--primary-nav--padding);
+	border: 1px solid var(--global--color-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2418,7 +2418,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid var(--global--color-dark-gray);
+	border: 1px solid var(--global--color-gray);
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -4385,7 +4385,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-right: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-dark-gray);
+	border: 1px solid var(--global--color-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -244,6 +244,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--border-color: var(--global--color-primary);
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
@@ -2413,12 +2414,28 @@ dd {
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container {
 	background: var(--global--color-background);
-	box-shadow: var(--global--elevation);
 	margin: 0;
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--primary-nav--border-color);
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:before, .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	content: "";
+	display: block;
+	position: absolute;
+	width: 0;
+	top: -10px;
+	right: var(--global--spacing-horizontal);
+	border-style: solid;
+	border-color: var(--primary-nav--border-color) transparent;
+	border-width: 0 7px 10px 7px;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	top: -9px;
+	border-color: var(--global--color-background) transparent;
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -2431,6 +2448,11 @@ dd {
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: var(--primary-nav--color-link-hover);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover {
+	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -4301,13 +4323,24 @@ h1.page-title {
 		transition: all 0.5s ease;
 		z-index: 88888;
 	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:before, .primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 0;
+		top: -10px;
+		right: var(--global--spacing-horizontal);
+		border-style: solid;
+		border-color: var(--primary-nav--border-color) transparent;
+		border-width: 0 7px 10px 7px;
+	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		top: -9px;
+		border-color: var(--global--color-background) transparent;
+	}
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 		background: var(--global--color-background);
 	}
-}
-
-.primary-navigation > div > .menu-wrapper > li > .sub-menu .sub-menu {
-	width: 100%;
 }
 
 .primary-navigation .primary-menu > .menu-item:hover > a {
@@ -4385,7 +4418,11 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-right: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--primary-nav--border-color);
+}
+
+.primary-navigation .sub-menu .sub-menu {
+	border: none;
 }
 
 @media only screen and (min-width: 482px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2418,6 +2418,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
+	border: 1px solid var(--global--color-dark-gray);
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -4384,7 +4385,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-right: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -4394,6 +4394,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: var(--primary-nav--padding);
+	border: 1px solid var(--global--color-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -2423,7 +2423,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid var(--global--color-dark-gray);
+	border: 1px solid var(--global--color-gray);
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -4395,7 +4395,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-dark-gray);
+	border: 1px solid var(--global--color-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -2423,6 +2423,7 @@ dd {
 	padding: 0;
 	position: absolute;
 	top: 100%;
+	border: 1px solid var(--global--color-dark-gray);
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -4394,7 +4395,7 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--global--color-dark-gray);
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -244,6 +244,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-primary);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit));
+	--primary-nav--border-color: var(--global--color-primary);
 	/* Pagination */
 	--pagination--color-text: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
@@ -2418,12 +2419,28 @@ dd {
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container {
 	background: var(--global--color-background);
-	box-shadow: var(--global--elevation);
 	margin: 0;
 	padding: 0;
 	position: absolute;
 	top: 100%;
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--primary-nav--border-color);
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:before, .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	content: "";
+	display: block;
+	position: absolute;
+	width: 0;
+	top: -10px;
+	left: var(--global--spacing-horizontal);
+	border-style: solid;
+	border-color: var(--primary-nav--border-color) transparent;
+	border-width: 0 7px 10px 7px;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
+	top: -9px;
+	border-color: var(--global--color-background) transparent;
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
@@ -2436,6 +2453,11 @@ dd {
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: var(--primary-nav--color-link-hover);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover {
+	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
@@ -4311,13 +4333,24 @@ h1.page-title {
 		transition: all 0.5s ease;
 		z-index: 88888;
 	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:before, .primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 0;
+		top: -10px;
+		left: var(--global--spacing-horizontal);
+		border-style: solid;
+		border-color: var(--primary-nav--border-color) transparent;
+		border-width: 0 7px 10px 7px;
+	}
+	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
+		top: -9px;
+		border-color: var(--global--color-background) transparent;
+	}
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 		background: var(--global--color-background);
 	}
-}
-
-.primary-navigation > div > .menu-wrapper > li > .sub-menu .sub-menu {
-	width: 100%;
 }
 
 .primary-navigation .primary-menu > .menu-item:hover > a {
@@ -4395,7 +4428,11 @@ h1.page-title {
 	padding: 0;
 	list-style: none;
 	margin-left: var(--primary-nav--padding);
-	border: 1px solid var(--global--color-gray);
+	border: 1px solid var(--primary-nav--border-color);
+}
+
+.primary-navigation .sub-menu .sub-menu {
+	border: none;
 }
 
 @media only screen and (min-width: 482px) {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #660 & #680.

## Summary
Style primary submenu container.

## Relevant technical choices:
No

## Test instructions

This PR can be tested by following these 

1. Add a menu to the theme which contain submenus
2. Hover over the menus items with ths "+" symbol

## Screenshots
![Capture d’écran du 2020-10-26 09-59-12](https://user-images.githubusercontent.com/33403964/97152934-f9863e80-1771-11eb-9f8a-2abaf0c7a990.png)
![Capture d’écran du 2020-10-26 09-56-10](https://user-images.githubusercontent.com/33403964/97152936-fab76b80-1771-11eb-9692-becbd5f4fd7f.png)
![Capture d’écran du 2020-10-26 09-55-29](https://user-images.githubusercontent.com/33403964/97152940-fb500200-1771-11eb-86a9-36449ce72264.png)



## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
