### PR TITLE
Add has-background to the text color utility styles

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2712,6 +2712,10 @@ a {
 	color: #fff;
 }
 
+:not(.has-text-color).has-background {
+	color: #28303d;
+}
+
 :not(.has-text-color).has-green-background-color[class] {
 	color: #28303d;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6705,6 +6705,10 @@ h1.page-title {
 	color: #fff;
 }
 
+:not(.has-text-color).has-background {
+	color: #28303d;
+}
+
 :not(.has-text-color).has-green-background-color[class] {
 	color: #28303d;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1935,7 +1935,7 @@ a {
 	color: var(--global--color-white);
 }
 
-:not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
+:not(.has-text-color).has-background, :not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
 	color: var(--global--color-dark-gray);
 }
 

--- a/assets/sass/07-utilities/color-palette.scss
+++ b/assets/sass/07-utilities/color-palette.scss
@@ -103,6 +103,7 @@
 		color: var(--global--color-white);
 	}
 
+	&.has-background,
 	&.has-green-background-color[class],
 	&.has-blue-background-color[class],
 	&.has-purple-background-color[class],

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4972,7 +4972,7 @@ h1.page-title {
 	color: var(--global--color-white);
 }
 
-:not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
+:not(.has-text-color).has-background, :not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
 	color: var(--global--color-dark-gray);
 }
 

--- a/style.css
+++ b/style.css
@@ -4982,7 +4982,7 @@ h1.page-title {
 	color: var(--global--color-white);
 }
 
-:not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
+:not(.has-text-color).has-background, :not(.has-text-color).has-green-background-color[class], :not(.has-text-color).has-blue-background-color[class], :not(.has-text-color).has-purple-background-color[class], :not(.has-text-color).has-red-background-color[class], :not(.has-text-color).has-orange-background-color[class], :not(.has-text-color).has-yellow-background-color[class], :not(.has-text-color).has-white-background-color[class] {
 	color: var(--global--color-dark-gray);
 }
 


### PR DESCRIPTION
## Summary

_This description only applies to blocks that has no custom text color._

When the body background is changed to dark, the primary text color is changed to white.
When a block is placed inside a block and that block has a background color, 
changing the text color to white automatically can make the text unreadable.

A style was created to make sure that if the parent blocks background color is black, dark grey or grey, the text color is white. 
And if any other palette color is selected, the text color is dark grey.

-This PR adds the has-background class to this style, so that if a **custom** background color is selected,
not from the palette but with the picker, the text color is dark grey.

_This does not solve the problem where the dark grey has a low contrast with the background, for that scenario, the user has to select a readable text color._

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Change the body background to dark
1. Add a group block with a background color not from the palette
1. Add some blocks inside of it, for example quote, verse, table
1. Duplicate this and change the background color to one from the palette.
1. Compare the editor and front.

<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Before:
Left, editor, right, front.

![before](https://user-images.githubusercontent.com/7422055/97158259-7963d700-1779-11eb-9fb9-0604f13944d3.png)

After:
Left, editor, right, front.
![after](https://user-images.githubusercontent.com/7422055/97158302-8680c600-1779-11eb-92f7-fde52cb4c4e4.png)



## Quality assurance
* [x] I have thought about any security implications this code might add.
* [ ] I have checked that this code doesn't impact performance (greatly).
* [ ] I have tested this code to the best of my abilities
* [ ] I have checked that this code does not affect the accessibility negatively
