### PR TITLE
let overlapping columns use the outer block background color

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -656,6 +656,7 @@ a:hover {
 		margin-left: -50px;
 		margin-top: 63px;
 		z-index: 2;
+		background: inherit;
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background) {
 		background-color: #d1e4dd;
@@ -696,6 +697,396 @@ a:hover {
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: #d1e4dd;
 		padding: 20px;
+	}
+	.has-black-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #000;
+	}
+	.has-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #39414d;
+	}
+	.has-dark-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #28303d;
+	}
+	.has-green-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1e4dd;
+	}
+	.has-blue-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1dfe4;
+	}
+	.has-purple-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1d1e4;
+	}
+	.has-red-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #e4d1d1;
+	}
+	.has-orange-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #e4dad1;
+	}
+	.has-yellow-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #eeeadd;
+	}
+	.has-white-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #fff;
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2349,6 +2349,396 @@ a:hover {
 		background-color: #d1e4dd;
 		padding: 20px;
 	}
+	.has-black-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #000;
+	}
+	.has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #000;
+	}
+	.has-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #39414d;
+	}
+	.has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #39414d;
+	}
+	.has-dark-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #28303d;
+	}
+	.has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #28303d;
+	}
+	.has-green-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1e4dd;
+	}
+	.has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1e4dd;
+	}
+	.has-blue-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1dfe4;
+	}
+	.has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1dfe4;
+	}
+	.has-purple-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #d1d1e4;
+	}
+	.has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #d1d1e4;
+	}
+	.has-red-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #e4d1d1;
+	}
+	.has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #e4d1d1;
+	}
+	.has-orange-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #e4dad1;
+	}
+	.has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #e4dad1;
+	}
+	.has-yellow-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #eeeadd;
+	}
+	.has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #eeeadd;
+	}
+	.has-white-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6 {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol {
+		background-color: #fff;
+	}
+	.has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: #fff;
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background) {
 		padding-left: 50px;
 	}

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -614,6 +614,7 @@ a:hover {
 		margin-left: calc(-2 * var(--global--spacing-horizontal));
 		margin-top: calc(2.5 * var(--global--spacing-horizontal));
 		z-index: 2;
+		background: inherit;
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p:not(.has-background),
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1:not(.has-background),
@@ -627,6 +628,126 @@ a:hover {
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre:not(.has-background) {
 		background-color: var(--global--color-background);
 		padding: var(--global--spacing-unit);
+	}
+	.has-black-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-black);
+	}
+	.has-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-gray);
+	}
+	.has-dark-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-dark-gray);
+	}
+	.has-green-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-green);
+	}
+	.has-blue-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-blue);
+	}
+	.has-purple-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-purple);
+	}
+	.has-red-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-red);
+	}
+	.has-orange-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-orange);
+	}
+	.has-yellow-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-yellow);
+	}
+	.has-white-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-white);
 	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background),
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {

--- a/assets/sass/05-blocks/columns/_editor.scss
+++ b/assets/sass/05-blocks/columns/_editor.scss
@@ -14,6 +14,7 @@
 				margin-left: calc(-2 * var(--global--spacing-horizontal));
 				margin-top: calc(2.5 * var(--global--spacing-horizontal));
 				z-index: 2;
+				background: inherit;
 
 				// Provide text-based child blocks with a default background color to ensure they're readable.
 				> p,
@@ -31,6 +32,47 @@
 						background-color: var(--global--color-background);
 						padding: var(--global--spacing-unit);
 					}
+
+					.has-black-background-color[class] & {
+						background-color: var(--global--color-black);
+					}
+
+					.has-gray-background-color[class] & {
+						background-color: var(--global--color-gray);
+					}
+
+					.has-dark-gray-background-color[class] & {
+						background-color: var(--global--color-dark-gray);
+					}
+
+					.has-green-background-color[class] & {
+						background-color: var(--global--color-green);
+					}
+
+					.has-blue-background-color[class] & {
+						background-color: var(--global--color-blue);
+					}
+
+					.has-purple-background-color[class] & {
+						background-color: var(--global--color-purple);
+					}
+
+					.has-red-background-color[class] & {
+						background-color: var(--global--color-red);
+					}
+
+					.has-orange-background-color[class] & {
+						background-color: var(--global--color-orange);
+					}
+
+					.has-yellow-background-color[class] & {
+						background-color: var(--global--color-yellow);
+					}
+
+					.has-white-background-color[class] & {
+						background-color: var(--global--color-white);
+					}
+
 				}
 
 				// Lists should still have their usual left padding.

--- a/assets/sass/05-blocks/columns/_style.scss
+++ b/assets/sass/05-blocks/columns/_style.scss
@@ -68,6 +68,47 @@
 							background-color: var(--global--color-background);
 							padding: var(--global--spacing-unit);
 						}
+
+						.has-black-background-color[class] & {
+							background-color: var(--global--color-black);
+						}
+
+						.has-gray-background-color[class] & {
+							background-color: var(--global--color-gray);
+						}
+
+						.has-dark-gray-background-color[class] & {
+							background-color: var(--global--color-dark-gray);
+						}
+
+						.has-green-background-color[class] & {
+							background-color: var(--global--color-green);
+						}
+
+						.has-blue-background-color[class] & {
+							background-color: var(--global--color-blue);
+						}
+
+						.has-purple-background-color[class] & {
+							background-color: var(--global--color-purple);
+						}
+
+						.has-red-background-color[class] & {
+							background-color: var(--global--color-red);
+						}
+
+						.has-orange-background-color[class] & {
+							background-color: var(--global--color-orange);
+						}
+
+						.has-yellow-background-color[class] & {
+							background-color: var(--global--color-yellow);
+						}
+
+						.has-white-background-color[class] & {
+							background-color: var(--global--color-white);
+						}
+
 					}
 
 					// Lists should still have their usual left padding.

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1663,6 +1663,126 @@ a:hover {
 		background-color: var(--global--color-background);
 		padding: var(--global--spacing-unit);
 	}
+	.has-black-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-black);
+	}
+	.has-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-gray);
+	}
+	.has-dark-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-dark-gray);
+	}
+	.has-green-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-green);
+	}
+	.has-blue-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-blue);
+	}
+	.has-purple-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-purple);
+	}
+	.has-red-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-red);
+	}
+	.has-orange-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-orange);
+	}
+	.has-yellow-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-yellow);
+	}
+	.has-white-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-white);
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background),
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		padding-right: calc(2 * var(--global--spacing-horizontal));

--- a/style.css
+++ b/style.css
@@ -1668,6 +1668,126 @@ a:hover {
 		background-color: var(--global--color-background);
 		padding: var(--global--spacing-unit);
 	}
+	.has-black-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-black-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-black);
+	}
+	.has-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-gray);
+	}
+	.has-dark-gray-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-dark-gray-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-dark-gray);
+	}
+	.has-green-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-green-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-green);
+	}
+	.has-blue-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-blue-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-blue);
+	}
+	.has-purple-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-purple-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-purple);
+	}
+	.has-red-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-red-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-red);
+	}
+	.has-orange-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-orange-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-orange);
+	}
+	.has-yellow-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-yellow-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-yellow);
+	}
+	.has-white-background-color[class] .wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > p, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h1, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h2, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h3, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h4, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h5, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > h6, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol, .has-white-background-color[class]
+	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > pre {
+		background-color: var(--global--color-white);
+	}
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ul:not(.has-background),
 	.wp-block-columns.is-style-twentytwentyone-columns-overlap .wp-block-column:nth-child(2n) > ol:not(.has-background) {
 		padding-left: calc(2 * var(--global--spacing-horizontal));


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/682

Partial fix only. In my opinion, this style is **huge** and I don't think it is worth adding, it is a lot of CSS for a small win.

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Since the paragraph can not inherit the great grandparents background color,
add the same background color to the paragraph, _if the palette color is used._

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a group block and cover block with a background color setting
1. Add a two column block inside, and select the overlapping style.
1. Add content like an image to the left, and a paragraph to the second, overlapping column.
1. Compare the background color of the outer block and the paragraph.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [ ] I have checked that this code doesn't impact performance (greatly).
* [ ] I have tested this code to the best of my abilities
* [ ] I have checked that this code does not affect the accessibility negatively
