### PR TITLE
IE11: Update styles that affects the width

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6830,4 +6830,12 @@ footer {
 .is-IE.has-background-dark .skip-link:focus {
 	color: #21759b;
 }
+
+.is-IE .navigation .nav-links {
+	display: block;
+}
+
+.is-IE .post-thumbnail .wp-post-image {
+	min-width: auto;
+}
 /*# sourceMappingURL=ie.css.map */

--- a/assets/sass/07-utilities/ie.scss
+++ b/assets/sass/07-utilities/ie.scss
@@ -42,4 +42,12 @@
 			color: #21759b;
 		}
 	}
+
+	.navigation .nav-links {
+		display: block;
+	}
+
+	.post-thumbnail .wp-post-image {
+		min-width: auto;
+	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5067,3 +5067,11 @@ footer {
 .is-IE.has-background-dark .skip-link:focus {
 	color: #21759b;
 }
+
+.is-IE .navigation .nav-links {
+	display: block;
+}
+
+.is-IE .post-thumbnail .wp-post-image {
+	min-width: auto;
+}

--- a/style.css
+++ b/style.css
@@ -5078,4 +5078,12 @@ footer {
 	color: #21759b;
 }
 
+.is-IE .navigation .nav-links {
+	display: block;
+}
+
+.is-IE .post-thumbnail .wp-post-image {
+	min-width: auto;
+}
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/665

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Replaces `display: flex` with `display: block` for the next/previous pagination in ie11.
Removes the `calc` for the minimum width for featured images. The original style caused an horizontal scroll.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View a page with comment pagination, using Internet Explorer 11
1. View the archive pagination, using Internet Explorer 11
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

<details>
<summary>Desktop (Extra Large)</summary>

![ie11-pagination](https://user-images.githubusercontent.com/7422055/97182391-c4431600-179c-11eb-9053-aaa9c7d3d23c.png)


</details>


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
