### PR TITLE
Verse Block: Inherit the parent text color

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2239,6 +2239,7 @@ table.wp-calendar-table caption {
 
 pre.wp-block-verse {
 	padding: 0;
+	color: currentColor;
 }
 
 :root .is-extra-small-text {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1624,6 +1624,7 @@ table.wp-calendar-table caption {
 
 pre.wp-block-verse {
 	padding: 0;
+	color: currentColor;
 }
 
 :root .is-extra-small-text,

--- a/assets/sass/05-blocks/verse/_editor.scss
+++ b/assets/sass/05-blocks/verse/_editor.scss
@@ -1,3 +1,4 @@
 pre.wp-block-verse {
 	padding: 0;
+	color: currentColor;
 }


### PR DESCRIPTION
Noticed this while testing #696 — the verse block has a set color from Gutenberg, so it's not previewed correctly in the editor. On the frontend, it correctly inherits the text color from the parent blocks. The following screenshots show 

| Frontend | Editor (before) | Editor (after) |
|----------|----------------|--------------|
| ![Screen Shot 2020-10-26 at 12 17 48 PM](https://user-images.githubusercontent.com/541093/97199420-5ee42a80-1786-11eb-939f-ec4b7d4169df.png) | ![Screen Shot 2020-10-26 at 12 17 33 PM](https://user-images.githubusercontent.com/541093/97199421-5ee42a80-1786-11eb-9ff9-999ae4420459.png) | ![Screen Shot 2020-10-26 at 12 23 17 PM](https://user-images.githubusercontent.com/541093/97199414-5d1a6700-1786-11eb-9682-587f999ca3e6.png) |
| ![Screen Shot 2020-10-26 at 12 19 03 PM](https://user-images.githubusercontent.com/541093/97199416-5e4b9400-1786-11eb-9305-8bed34e1bb4d.png) | ![Screen Shot 2020-10-26 at 12 18 52 PM](https://user-images.githubusercontent.com/541093/97199418-5e4b9400-1786-11eb-9634-a1c3eb2ba367.png) _in top group, the verse is slightly lighter_ | ![Screen Shot 2020-10-26 at 12 22 24 PM](https://user-images.githubusercontent.com/541093/97199415-5db2fd80-1786-11eb-8690-6c80c654c4d4.png) |
| ![Screen Shot 2020-10-26 at 12 33 38 PM](https://user-images.githubusercontent.com/541093/97200354-7bcd2d80-1787-11eb-8c2c-302fa229568c.png) | ![Screen Shot 2020-10-26 at 12 33 08 PM](https://user-images.githubusercontent.com/541093/97200367-7ff94b00-1787-11eb-9132-164ca854281b.png) | ![Screen Shot 2020-10-26 at 12 34 04 PM](https://user-images.githubusercontent.com/541093/97200397-8ab3e000-1787-11eb-886b-ba0b51b22d45.png) |

## Test instructions

This PR can be tested by following these steps:

1. Switch site to dark background
2. Add a verse block
3. It should be in white text, matching the rest of the post

or

1. Regardless of site background, add a group block
2. Add a verse block
3. Set a text color on the group
4. The verse should use that custom text color

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
