### PR TITLE
Fix button focus offset

### DIFF
--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -58,7 +58,7 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:focus {
-		outline-offset: -4px;
+		outline-offset: -6px;
 		outline: 2px dotted currentColor;
 	}
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
When the button extend style was replaced with a mixin, the focus offset change in https://github.com/WordPress/twentytwentyone/pull/701 was reverted, 
because it was not added to the mixin.

This changes the focus offset back to `outline-offset: -6px;` as intended.

