### PR TITLE
Fix bottom margin inside group blocks

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -779,7 +779,7 @@ a:hover {
 	padding: 30px;
 }
 
-.wp-block-group .wp-block-group__inner-container *:last-child {
+.wp-block-group .wp-block-group__inner-container > :last-child {
 	margin-bottom: 0;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -754,7 +754,7 @@ a:hover {
 	padding: var(--global--spacing-vertical);
 }
 
-.wp-block-group .wp-block-group__inner-container *:last-child {
+.wp-block-group .wp-block-group__inner-container > :last-child {
 	margin-bottom: 0;
 }
 

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -25,7 +25,7 @@
 		padding: var(--global--spacing-vertical);
 	}
 
-	.wp-block-group__inner-container *:last-child {
+	.wp-block-group__inner-container > :last-child {
 		margin-bottom: 0;
 	}
 }

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -25,7 +25,7 @@
 		padding: var(--global--spacing-vertical);
 	}
 
-	.wp-block-group__inner-container > :last-child {
+	.wp-block-group__inner-container > *:last-child {
 		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/715
Fixes https://github.com/WordPress/twentytwentyone/issues/717

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

The removal of the bottom margin was targeting all elements, not only the blocks, the selector 
`*` was changed to `>`

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a group block
1. Inside the  group block, add a gallery (or any block that has more than one element)
1. Confirm that the style is applied to the block and not the last element of that block.
<!-- Don't forget to test the unhappy-paths! -->


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
