### PR TITLE
Update margin for the first social link

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2137,8 +2137,9 @@ hr {
 	border-color: currentColor;
 }
 
-.wp-block-social-links li.wp-block-social-link:first-child {
-	margin-top: 30px;
+.wp-block-social-links [data-block] {
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -2138,7 +2138,7 @@ hr {
 }
 
 .wp-block-social-links li.wp-block-social-link:first-child {
-	margin-top: auto;
+	margin-top: 30px;
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1631,8 +1631,9 @@ hr {
 	border-color: currentColor;
 }
 
-.wp-block-social-links li.wp-block-social-link:first-child {
-	margin-top: var(--global--spacing-vertical);
+.wp-block-social-links [data-block] {
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1632,7 +1632,7 @@ hr {
 }
 
 .wp-block-social-links li.wp-block-social-link:first-child {
-	margin-top: auto;
+	margin-top: var(--global--spacing-vertical);
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color button {

--- a/assets/sass/05-blocks/social-icons/_editor.scss
+++ b/assets/sass/05-blocks/social-icons/_editor.scss
@@ -1,8 +1,9 @@
 .wp-block-social-links {
 
-	// Override the [data-block]:first-child margin from utilities _editor.scss.
-	li.wp-block-social-link:first-child {
-		margin-top: var(--global--spacing-vertical);
+	// Social icons are horizontal, so they don't need vertical spacing.
+	[data-block] {
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 
 	&.is-style-twentytwentyone-social-icons-color {

--- a/assets/sass/05-blocks/social-icons/_editor.scss
+++ b/assets/sass/05-blocks/social-icons/_editor.scss
@@ -1,7 +1,8 @@
 .wp-block-social-links {
 
+	// Override the [data-block]:first-child margin from utilities _editor.scss.
 	li.wp-block-social-link:first-child {
-		margin-top: auto;
+		margin-top: var(--global--spacing-vertical);
 	}
 
 	&.is-style-twentytwentyone-social-icons-color {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/716

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Replaces `margin-top: auto` with `margin-top: var(--global--spacing-vertical);` to override the generic top margin for the first child inside a block.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a social icons block with two icons, no more, no less.
1. Confirm that the icons are aligned next to each other in the editor.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
