### PR TITLE
Customizer: Add `has-background-white` class to the customizer preview

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -52,6 +52,13 @@
 				document.body.classList.remove( 'has-background-dark' );
 			}
 
+			// Toggle the white background class.
+			if ( '#ffffff' === to ) {
+				document.body.classList.add( 'has-background-white' );
+			} else {
+				document.body.classList.remove( 'has-background-white' );
+			}
+
 			document.documentElement.style.setProperty( '--global--color-primary', textColor );
 			document.documentElement.style.setProperty( '--global--color-secondary', textColor );
 			document.documentElement.style.setProperty( '--global--color-background', to );


### PR DESCRIPTION
## Summary

In the customizer, if you change your background to white, the `has-background-white` class is not added. This means the focus color added in #676 stays white (invisible) in the customizer preview. The same thing happens in reverse if you have a white background & change it, the focus background stays black.

## Test instructions

This PR can be tested by following these steps:
1. Open the customizer, change your background color to white
2. Click into the preview, start tabbing to see the focus styling
3. You should see a black background on the focused links
