### PR TITLE
Fix margins on Media & Text with vertical alignment

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1541,9 +1541,16 @@ dt {
 	font-weight: bold;
 }
 
-.wp-block-media-text .block-editor-inner-blocks {
-	padding-right: 25px;
-	padding-left: 25px;
+.wp-block-media-text .wp-block-media-text__content {
+	padding: 25px;
+}
+
+.wp-block-media-text .wp-block-media-text__content [data-block]:first-child {
+	margin-top: 0;
+}
+
+.wp-block-media-text .wp-block-media-text__content [data-block]:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-media-text.is-style-twentytwentyone-border {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1155,9 +1155,16 @@ dt {
 	font-weight: bold;
 }
 
-.wp-block-media-text .block-editor-inner-blocks {
-	padding-right: var(--global--spacing-horizontal);
-	padding-left: var(--global--spacing-horizontal);
+.wp-block-media-text .wp-block-media-text__content {
+	padding: var(--global--spacing-horizontal);
+}
+
+.wp-block-media-text .wp-block-media-text__content [data-block]:first-child {
+	margin-top: 0;
+}
+
+.wp-block-media-text .wp-block-media-text__content [data-block]:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-media-text.is-style-twentytwentyone-border {

--- a/assets/sass/05-blocks/media-text/_editor.scss
+++ b/assets/sass/05-blocks/media-text/_editor.scss
@@ -1,8 +1,15 @@
 .wp-block-media-text {
 
-	.block-editor-inner-blocks {
-		padding-right: var(--global--spacing-horizontal);
-		padding-left: var(--global--spacing-horizontal);
+	.wp-block-media-text__content {
+		padding: var(--global--spacing-horizontal);
+
+		[data-block]:first-child {
+			margin-top: 0;
+		}
+
+		[data-block]:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	// Block Styles


### PR DESCRIPTION
Fixes #727

> When the vertical top alignment is chosen for the text part of the Media & text block, the vertical spacing is not the same in the editor and the front.

## Test instructions

This PR can be tested by following these steps:
1. Add a Media & Text block, with some content in the text part
2. Set the vertical alignment to "top"
3. The content should move upward, but there's still some space above the text
4. View the frontend, it should look the same

## Screenshots
Editor
![Screen Shot 2020-10-28 at 5 31 57 PM](https://user-images.githubusercontent.com/541093/97499980-2e96ba80-1945-11eb-8db1-e6f4df5a7ecc.png)

Frontend
![Screen Shot 2020-10-28 at 5 32 04 PM](https://user-images.githubusercontent.com/541093/97499983-2f2f5100-1945-11eb-8a72-713799414778.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
