### PR TITLE
Cover Block: Fix default overlay color

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2479,7 +2479,7 @@ input[type="reset"]:hover {
 }
 
 .wp-block-cover {
-	background-color: #fff;
+	background-color: #000;
 	min-height: 450px;
 	margin-top: inherit;
 	margin-bottom: inherit;
@@ -2489,7 +2489,7 @@ input[type="reset"]:hover {
 }
 
 .wp-block-cover-image {
-	background-color: #fff;
+	background-color: #000;
 	min-height: 450px;
 	margin-top: inherit;
 	margin-bottom: inherit;

--- a/assets/sass/05-blocks/cover/_style.scss
+++ b/assets/sass/05-blocks/cover/_style.scss
@@ -1,7 +1,7 @@
 .wp-block-cover,
 .wp-block-cover-image {
 
-	background-color: var(--cover--color-foreground);
+	background-color: var(--cover--color-background);
 	min-height: var(--cover--height);
 	margin-top: inherit;
 	margin-bottom: inherit;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1747,7 +1747,7 @@ input[type="reset"]:hover,
 
 .wp-block-cover,
 .wp-block-cover-image {
-	background-color: var(--cover--color-foreground);
+	background-color: var(--cover--color-background);
 	min-height: var(--cover--height);
 	margin-top: inherit;
 	margin-bottom: inherit;

--- a/style.css
+++ b/style.css
@@ -1752,7 +1752,7 @@ input[type="reset"]:hover,
 
 .wp-block-cover,
 .wp-block-cover-image {
-	background-color: var(--cover--color-foreground);
+	background-color: var(--cover--color-background);
 	min-height: var(--cover--height);
 	margin-top: inherit;
 	margin-bottom: inherit;


### PR DESCRIPTION
Fixes #721 — #404 & #427 fixed the Cover block in the editor, but missed updating the variable for the frontend style. The background should be using `var(--cover--color-background)`.

## Test instructions

This PR can be tested by following these steps:
1. Add a cover block, leave the defaults in place (the code from #721 is a good test case)
2. View the post on the frontend of the site
3. The editor & frontend should use the same overlay color (black)

Try other combinations of colors to make sure this didn't cause other issues.
