### PR TITLE
Add a variable for admin-bar height

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -27,6 +27,7 @@
 	/* Block: Pull quote */
 	/* Block: Table */
 	/* Widgets */
+	/* Admin-bar height */
 }
 
 /**

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -118,6 +118,7 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	/* Block: Pull quote */
 	/* Block: Table */
 	/* Widgets */
+	/* Admin-bar height */
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -4939,9 +4940,6 @@ a.custom-logo-link {
 		margin-top: 0;
 		top: 0;
 	}
-	.admin-bar .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
-		top: 46px;
-	}
 	.primary-navigation-open .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
 		display: none;
 	}
@@ -5925,10 +5923,20 @@ h1.page-title {
 		transform: translateY(0) translateX(100%);
 	}
 	.admin-bar .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
+		top: 32px;
+	}
+	@media only screen and (max-width: 782px){
+		.admin-bar .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container{
 		top: 46px;
+		}
 	}
 	.admin-bar .primary-navigation > .primary-menu-container {
+		height: calc(100vh - 32px);
+	}
+	@media only screen and (max-width: 782px){
+		.admin-bar .primary-navigation > .primary-menu-container{
 		height: calc(100vh - 46px);
+		}
 	}
 	.primary-navigation > .primary-menu-container:focus {
 		border: 2px solid #28303d;
@@ -5954,10 +5962,6 @@ h1.page-title {
 	.primary-navigation-open .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
 		transform: translateX(0) translateY(0);
 	}
-}
-
-.admin-bar .primary-navigation {
-	top: 46px;
 }
 
 @media only screen and (min-width: 482px) {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -197,6 +197,18 @@
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+	/* Admin-bar height */
+	--global--admin-bar--height: 0;
+}
+
+.admin-bar {
+	--global--admin-bar--height: 32px;
+}
+
+@media only screen and (max-width: 782px) {
+	.admin-bar {
+		--global--admin-bar--height: 46px;
+	}
 }
 
 @media only screen and (min-width: 652px) {

--- a/assets/sass/01-settings/global.scss
+++ b/assets/sass/01-settings/global.scss
@@ -226,6 +226,16 @@ $baseline-unit: 10px;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
 
+	/* Admin-bar height */
+	--global--admin-bar--height: 0;
+}
+
+.admin-bar {
+	--global--admin-bar--height: 32px;
+
+	@media only screen and (max-width: 782px) {
+		--global--admin-bar--height: 46px;
+	}
 }
 
 @media only screen and (min-width: 652px) { // Not using the mixin because it's compiled after this file

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -133,11 +133,7 @@ a.custom-logo-link {
 						position: absolute;
 						padding-top: calc(0.5 * var(--global--spacing-vertical));
 						margin-top: 0;
-						top: 0;
-
-						.admin-bar & {
-							top: 46px;
-						}
+						top: var(--global--admin-bar--height);
 
 						.primary-navigation-open & {
 							display: none;

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -82,7 +82,7 @@
 
 .primary-navigation {
 	position: absolute;
-	top: 0;
+	top: var(--global--admin-bar--height);
 	right: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
@@ -121,11 +121,11 @@
 			}
 
 			.admin-bar .has-logo.has-title-and-tagline & {
-				top: 46px;
+				top: var(--global--admin-bar--height);
 			}
 
 			.admin-bar & {
-				height: calc(100vh - 46px);
+				height: calc(100vh - var(--global--admin-bar--height));
 			}
 
 			&:focus {
@@ -158,11 +158,6 @@
 				transform: translateX(0) translateY(0);
 			}
 		}
-	}
-
-	// Adjust positions when logged-in
-	.admin-bar & {
-		top: 46px;
 	}
 
 	@include media(mobile) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -288,6 +288,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+	/* Admin-bar height */
+	--global--admin-bar--height: 0;
+}
+
+.admin-bar {
+	--global--admin-bar--height: 32px;
+}
+
+@media only screen and (max-width: 782px) {
+	.admin-bar {
+		--global--admin-bar--height: 46px;
+	}
 }
 
 @media only screen and (min-width: 652px) {
@@ -3453,10 +3465,7 @@ a.custom-logo-link {
 		position: absolute;
 		padding-top: calc(0.5 * var(--global--spacing-vertical));
 		margin-top: 0;
-		top: 0;
-	}
-	.admin-bar .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
-		top: 46px;
+		top: var(--global--admin-bar--height);
 	}
 	.primary-navigation-open .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
 		display: none;
@@ -4199,7 +4208,7 @@ h1.page-title {
 
 .primary-navigation {
 	position: absolute;
-	top: 0;
+	top: var(--global--admin-bar--height);
 	left: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
@@ -4238,10 +4247,10 @@ h1.page-title {
 		transform: translateY(0) translateX(-100%);
 	}
 	.admin-bar .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
-		top: 46px;
+		top: var(--global--admin-bar--height);
 	}
 	.admin-bar .primary-navigation > .primary-menu-container {
-		height: calc(100vh - 46px);
+		height: calc(100vh - var(--global--admin-bar--height));
 	}
 	.primary-navigation > .primary-menu-container:focus {
 		border: 2px solid var(--global--color-primary);
@@ -4267,10 +4276,6 @@ h1.page-title {
 	.primary-navigation-open .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
 		transform: translateX(0) translateY(0);
 	}
-}
-
-.admin-bar .primary-navigation {
-	top: 46px;
 }
 
 @media only screen and (min-width: 482px) {

--- a/style.css
+++ b/style.css
@@ -288,6 +288,18 @@ Twenty Twenty-One is distributed under the terms of the GNU GPL.
 	--widget--line-height-title: 1.4;
 	--widget--font-weight-title: 700;
 	--widget--spacing-menu: calc(0.66 * var(--global--spacing-unit));
+	/* Admin-bar height */
+	--global--admin-bar--height: 0;
+}
+
+.admin-bar {
+	--global--admin-bar--height: 32px;
+}
+
+@media only screen and (max-width: 782px) {
+	.admin-bar {
+		--global--admin-bar--height: 46px;
+	}
 }
 
 @media only screen and (min-width: 652px) {
@@ -3463,10 +3475,7 @@ a.custom-logo-link {
 		position: absolute;
 		padding-top: calc(0.5 * var(--global--spacing-vertical));
 		margin-top: 0;
-		top: 0;
-	}
-	.admin-bar .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
-		top: 46px;
+		top: var(--global--admin-bar--height);
 	}
 	.primary-navigation-open .site-header.has-logo:not(.has-title-and-tagline).has-menu .site-logo {
 		display: none;
@@ -4209,7 +4218,7 @@ h1.page-title {
 
 .primary-navigation {
 	position: absolute;
-	top: 0;
+	top: var(--global--admin-bar--height);
 	right: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
@@ -4248,10 +4257,10 @@ h1.page-title {
 		transform: translateY(0) translateX(100%);
 	}
 	.admin-bar .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
-		top: 46px;
+		top: var(--global--admin-bar--height);
 	}
 	.admin-bar .primary-navigation > .primary-menu-container {
-		height: calc(100vh - 46px);
+		height: calc(100vh - var(--global--admin-bar--height));
 	}
 	.primary-navigation > .primary-menu-container:focus {
 		border: 2px solid var(--global--color-primary);
@@ -4277,10 +4286,6 @@ h1.page-title {
 	.primary-navigation-open .has-logo.has-title-and-tagline .primary-navigation > .primary-menu-container {
 		transform: translateX(0) translateY(0);
 	}
-}
-
-.admin-bar .primary-navigation {
-	top: 46px;
 }
 
 @media only screen and (min-width: 482px) {


### PR DESCRIPTION
Adds a `--global--admin-bar--height`variable which can be used consistently everywhere instead of having to add hardcoded values like 32px, 46px etc depending on the viewport.