### PR TITLE
Split navigation to separate template-part

### DIFF
--- a/template-parts/header/site-header.php
+++ b/template-parts/header/site-header.php
@@ -7,40 +7,15 @@
  * @since 1.0.0
  */
 
-$has_primary_nav = has_nav_menu( 'primary' );
-
 $wrapper_classes  = 'site-header';
 $wrapper_classes .= has_custom_logo() ? ' has-logo' : '';
 $wrapper_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
-$wrapper_classes .= $has_primary_nav ? ' has-menu' : '';
+$wrapper_classes .= has_nav_menu( 'primary' ) ? ' has-menu' : '';
 ?>
 
 <header id="masthead" class="<?php echo esc_attr( $wrapper_classes ); ?>" role="banner">
 
 	<?php get_template_part( 'template-parts/header/site-branding' ); ?>
+	<?php get_template_part( 'template-parts/header/site-nav' ); ?>
 
-	<?php if ( $has_primary_nav ) : ?>
-		<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary menu', 'twentytwentyone' ); ?>">
-			<div class="menu-button-container">
-				<button id="primary-mobile-menu" class="button" aria-controls="primary-menu-list" aria-expanded="false">
-					<span class="dropdown-icon open"><?php esc_html_e( 'Menu', 'twentytwentyone' ); ?>
-						<?php echo twenty_twenty_one_get_icon_svg( 'ui', 'menu' ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
-					</span>
-					<span class="dropdown-icon close"><?php esc_html_e( 'Close', 'twentytwentyone' ); ?>
-						<?php echo twenty_twenty_one_get_icon_svg( 'ui', 'close' ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
-					</span>
-				</button><!-- #primary-mobile-menu -->
-			</div><!-- .menu-button-container -->
-			<?php
-			wp_nav_menu(
-				array(
-					'theme_location'  => 'primary',
-					'menu_class'      => 'menu-wrapper',
-					'container_class' => 'primary-menu-container',
-					'items_wrap'      => '<ul id="primary-menu-list" class="%2$s">%3$s</ul>',
-				)
-			);
-			?>
-		</nav><!-- #site-navigation -->
-	<?php endif; ?>
 </header><!-- #masthead -->

--- a/template-parts/header/site-nav.php
+++ b/template-parts/header/site-nav.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Displays the site navigation.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_One
+ * @since 1.0.0
+ */
+
+?>
+
+<?php if ( has_nav_menu( 'primary' ) ) : ?>
+	<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary menu', 'twentytwentyone' ); ?>">
+		<div class="menu-button-container">
+			<button id="primary-mobile-menu" class="button" aria-controls="primary-menu-list" aria-expanded="false">
+				<span class="dropdown-icon open"><?php esc_html_e( 'Menu', 'twentytwentyone' ); ?>
+					<?php echo twenty_twenty_one_get_icon_svg( 'ui', 'menu' ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+				</span>
+				<span class="dropdown-icon close"><?php esc_html_e( 'Close', 'twentytwentyone' ); ?>
+					<?php echo twenty_twenty_one_get_icon_svg( 'ui', 'close' ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+				</span>
+			</button><!-- #primary-mobile-menu -->
+		</div><!-- .menu-button-container -->
+		<?php
+		wp_nav_menu(
+			array(
+				'theme_location'  => 'primary',
+				'menu_class'      => 'menu-wrapper',
+				'container_class' => 'primary-menu-container',
+				'items_wrap'      => '<ul id="primary-menu-list" class="%2$s">%3$s</ul>',
+			)
+		);
+		?>
+	</nav><!-- #site-navigation -->
+<?php endif; ?>


### PR DESCRIPTION
## Summary
Splits the nav template to a separate template-part.
Makes it easier to override the nav without having to rewrite the header.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
