### PR TITLE
Update text color for the focused post navigation

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -310,8 +310,16 @@ a:hover {
 	color: #d1e4dd;
 }
 
+.has-background-dark .site a:focus .meta-nav {
+	color: #d1e4dd;
+}
+
 .has-background-white .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
+	color: #fff;
+}
+
+.has-background-white .site a:focus .meta-nav {
 	color: #fff;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2013,8 +2013,16 @@ a:hover {
 	color: #d1e4dd;
 }
 
+.has-background-dark .site a:focus .meta-nav {
+	color: #d1e4dd;
+}
+
 .has-background-white .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
+	color: #fff;
+}
+
+.has-background-white .site a:focus .meta-nav {
 	color: #fff;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -439,12 +439,17 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus {
+.has-background-dark .site a:focus,
+.has-background-dark .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .has-background-white .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
+}
+
+.has-background-white .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -23,7 +23,8 @@ a:hover {
 	background: rgba(255, 255, 255, .9);
 
 	// Change text color when the body background is dark.
-	.has-background-dark & {
+	.has-background-dark &,
+	.has-background-dark & .meta-nav {
 		color: var(--wp--style--color--link, var(--global--color-background));
 	}
 
@@ -31,6 +32,10 @@ a:hover {
 	.has-background-white & {
 		background: rgba(0, 0, 0, .9);
 		color: var(--wp--style--color--link, var(--global--color-white));
+
+		.meta-nav {
+			color: var(--wp--style--color--link, var(--global--color-white));
+		}
 	}
 
 	&.skip-link {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1494,12 +1494,17 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus {
+.has-background-dark .site a:focus,
+.has-background-dark .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .has-background-white .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
+}
+
+.has-background-white .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 

--- a/style.css
+++ b/style.css
@@ -1499,12 +1499,17 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus {
+.has-background-dark .site a:focus,
+.has-background-dark .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .has-background-white .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
+	color: var(--wp--style--color--link, var(--global--color-white));
+}
+
+.has-background-white .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/738

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Changes the  text color for the .meta-nav text: previous post, next post.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Change the background color to dark or white.
1. View a single post
1. Focus on the next and previous post navigation links
1. Confirm that the text is readable
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before:
![next-previous-focus](https://user-images.githubusercontent.com/7422055/97583843-acb39980-19f7-11eb-8e75-bdae773d4bac.png)

After:
![next-previous-focus-after](https://user-images.githubusercontent.com/7422055/97583780-9c9bba00-19f7-11eb-81c3-57997ab9cafc.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
