### PR TITLE
Update the position of the latest comments block

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1301,10 +1301,6 @@ h6 {
 	padding: 20px;
 }
 
-.wp-block-latest-comments {
-	margin-left: 0;
-}
-
 .wp-block-latest-posts {
 	padding-left: 0;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -3217,10 +3217,6 @@ img {
 	padding: 20px;
 }
 
-.wp-block-latest-comments {
-	margin-left: 0;
-}
-
 .wp-block-latest-comments .wp-block-latest-comments__comment {
 	font-size: 1.125rem;
 	line-height: 1.7;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -938,10 +938,6 @@ h6,
 	padding: var(--global--spacing-unit);
 }
 
-.wp-block-latest-comments {
-	margin-left: 0;
-}
-
 .wp-block-latest-posts {
 	padding-left: 0;
 }

--- a/assets/sass/05-blocks/blocks-editor.scss
+++ b/assets/sass/05-blocks/blocks-editor.scss
@@ -14,7 +14,6 @@
 @import "heading/editor";
 @import "html/editor";
 @import "image/editor";
-@import "latest-comments/editor";
 @import "latest-posts/editor";
 @import "legacy/editor"; // "Blocks" from the legacy WP editor, ie: galleries, .button class, etc.
 @import "list/editor";

--- a/assets/sass/05-blocks/latest-comments/_editor.scss
+++ b/assets/sass/05-blocks/latest-comments/_editor.scss
@@ -1,3 +1,0 @@
-.wp-block-latest-comments {
-	margin-left: 0;
-}

--- a/assets/sass/05-blocks/latest-comments/_style.scss
+++ b/assets/sass/05-blocks/latest-comments/_style.scss
@@ -1,5 +1,4 @@
 .wp-block-latest-comments {
-	margin-left: 0;
 
 	.wp-block-latest-comments__comment {
 		font-size: var(--global--font-size-sm);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2150,10 +2150,6 @@ img {
 	padding: var(--global--spacing-unit);
 }
 
-.wp-block-latest-comments {
-	margin-right: 0;
-}
-
 .wp-block-latest-comments .wp-block-latest-comments__comment {
 	font-size: var(--global--font-size-sm);
 	line-height: var(--global--line-height-body);

--- a/style.css
+++ b/style.css
@@ -2155,10 +2155,6 @@ img {
 	padding: var(--global--spacing-unit);
 }
 
-.wp-block-latest-comments {
-	margin-left: 0;
-}
-
 .wp-block-latest-comments .wp-block-latest-comments__comment {
 	font-size: var(--global--font-size-sm);
 	line-height: var(--global--line-height-body);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/736

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Deleted the blocks editor style, since the CSS inside it caused the incorrect positioning of the block.

While testing this solution, I noticed that the block was also positioned to the left on the front
when it was set to wide align. 
Removing `margin-left: 0;` from` .wp-block-latest-comments` solved this issue.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a latest comments block. 
1. Clone this block multiple times to test all different alignments.
1. Compare the positions in the editor and the front.
<!-- Don't forget to test the unhappy-paths! -->

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
