### PR TITLE
Tidy up full-width group block children when the group has padding

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -825,6 +825,12 @@ a:hover {
 	padding: 30px;
 }
 
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > [data-align="full"] {
+	max-width: calc(100% + 60px);
+	width: calc(100% + 60px);
+	margin-left: -30px;
+}
+
 .wp-block-group .wp-block-group__inner-container > *:last-child {
 	margin-bottom: 0;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -357,11 +357,11 @@ a:hover {
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:focus {
@@ -777,11 +777,11 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {
@@ -2072,11 +2072,11 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:focus {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -809,23 +809,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -835,21 +835,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2129,43 +2129,43 @@ input[type="reset"]:after,
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .site .button:focus,
@@ -2828,11 +2828,11 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {
@@ -2851,11 +2851,11 @@ input[type="reset"]:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -2920,6 +2920,22 @@ input[type="reset"]:hover {
 .wp-block-group.is-style-twentytwentyone-border {
 	border: 3px solid #28303d;
 	padding: 30px;
+}
+
+.wp-block-group.has-background .wp-block-group__inner-container > .alignfull {
+	max-width: calc(100% + 60px);
+	width: calc(100% + 60px);
+	margin-left: auto;
+	margin-right: auto;
+	transform: translateX(-30px);
+}
+
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+	max-width: calc(100% + 60px);
+	width: calc(100% + 60px);
+	margin-left: auto;
+	margin-right: auto;
+	transform: translateX(-30px);
 }
 
 h1 {
@@ -4666,21 +4682,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4729,21 +4745,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2925,17 +2925,13 @@ input[type="reset"]:hover {
 .wp-block-group.has-background .wp-block-group__inner-container > .alignfull {
 	max-width: calc(100% + 60px);
 	width: calc(100% + 60px);
-	margin-left: auto;
-	margin-right: auto;
-	transform: translateX(-30px);
+	margin-left: -30px;
 }
 
 .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
 	max-width: calc(100% + 60px);
 	width: calc(100% + 60px);
-	margin-left: auto;
-	margin-right: auto;
-	transform: translateX(-30px);
+	margin-left: -30px;
 }
 
 h1 {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2928,7 +2928,19 @@ input[type="reset"]:hover {
 	margin-left: -30px;
 }
 
+.wp-block-group.has-background .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
+	max-width: calc(100% + 60px);
+	width: calc(100% + 60px);
+	margin-left: -30px;
+}
+
 .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+	max-width: calc(100% + 60px);
+	width: calc(100% + 60px);
+	margin-left: -30px;
+}
+
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
 	max-width: calc(100% + 60px);
 	width: calc(100% + 60px);
 	margin-left: -30px;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -800,6 +800,12 @@ a:hover {
 	padding: var(--global--spacing-vertical);
 }
 
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > [data-align="full"] {
+	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	margin-left: calc(-1 * var(--global--spacing-vertical));
+}
+
 .wp-block-group .wp-block-group__inner-container > *:last-child {
 	margin-bottom: 0;
 }

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -23,6 +23,12 @@
 	&.is-style-twentytwentyone-border {
 		border: calc(3 * var(--separator--height)) solid var(--global--color-border);
 		padding: var(--global--spacing-vertical);
+
+		.wp-block-group__inner-container > [data-align="full"] {
+			max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+			width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+			margin-left: calc(-1 * var(--global--spacing-vertical));
+		}
 	}
 
 	.wp-block-group__inner-container > *:last-child {

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -63,9 +63,7 @@
 		.wp-block-group__inner-container > .alignfull {
 			max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 			width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
-			margin-left: auto;
-			margin-right: auto;
-			transform: translateX(calc(-1 * var(--global--spacing-vertical)));
+			margin-left: calc(-1 * var(--global--spacing-vertical));
 		}
 	}
 }

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -55,4 +55,17 @@
 		border: calc(3 * var(--separator--height)) solid var(--global--color-border);
 		padding: var(--global--spacing-vertical);
 	}
+
+	// Adjust alignfull items to account for left and right padding.
+	&.has-background,
+	&.is-style-twentytwentyone-border {
+
+		.wp-block-group__inner-container > .alignfull {
+			max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+			width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+			margin-left: auto;
+			margin-right: auto;
+			transform: translateX(calc(-1 * var(--global--spacing-vertical)));
+		}
+	}
 }

--- a/assets/sass/05-blocks/group/_style.scss
+++ b/assets/sass/05-blocks/group/_style.scss
@@ -60,7 +60,8 @@
 	&.has-background,
 	&.is-style-twentytwentyone-border {
 
-		.wp-block-group__inner-container > .alignfull {
+		.wp-block-group__inner-container > .alignfull,
+		.wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
 			max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 			width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 			margin-left: calc(-1 * var(--global--spacing-vertical));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2038,6 +2038,14 @@ input[type="reset"]:hover,
 	padding: var(--global--spacing-vertical);
 }
 
+.wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	margin-right: auto;
+	margin-left: auto;
+	transform: translateX(calc(-1*(-1 * var(--global--spacing-vertical))));
+}
+
 h1,
 .h1,
 h2,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2038,7 +2038,9 @@ input[type="reset"]:hover,
 	padding: var(--global--spacing-vertical);
 }
 
-.wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+.wp-block-group.has-background .wp-block-group__inner-container > .alignfull,
+.wp-block-group.has-background .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull,
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
 	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	margin-right: calc(-1 * var(--global--spacing-vertical));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2041,9 +2041,7 @@ input[type="reset"]:hover,
 .wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
 	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
-	margin-right: auto;
-	margin-left: auto;
-	transform: translateX(calc(-1*(-1 * var(--global--spacing-vertical))));
+	margin-right: calc(-1 * var(--global--spacing-vertical));
 }
 
 h1,

--- a/style.css
+++ b/style.css
@@ -2046,9 +2046,7 @@ input[type="reset"]:hover,
 .wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
 	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
-	margin-left: auto;
-	margin-right: auto;
-	transform: translateX(calc(-1 * var(--global--spacing-vertical)));
+	margin-left: calc(-1 * var(--global--spacing-vertical));
 }
 
 h1,

--- a/style.css
+++ b/style.css
@@ -2043,6 +2043,14 @@ input[type="reset"]:hover,
 	padding: var(--global--spacing-vertical);
 }
 
+.wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
+	margin-left: auto;
+	margin-right: auto;
+	transform: translateX(calc(-1 * var(--global--spacing-vertical)));
+}
+
 h1,
 .h1,
 h2,

--- a/style.css
+++ b/style.css
@@ -2043,7 +2043,9 @@ input[type="reset"]:hover,
 	padding: var(--global--spacing-vertical);
 }
 
-.wp-block-group.has-background .wp-block-group__inner-container > .alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull {
+.wp-block-group.has-background .wp-block-group__inner-container > .alignfull,
+.wp-block-group.has-background .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull, .wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > .alignfull,
+.wp-block-group.is-style-twentytwentyone-border .wp-block-group__inner-container > hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
 	max-width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	width: calc(var(--responsive--alignfull-width) + (2 * var(--global--spacing-vertical)));
 	margin-left: calc(-1 * var(--global--spacing-vertical));


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentytwentyone/issues/729

Group blocks get inner padding when they have a background color assigned, or when Twenty Twenty-One's "Frame" block style is active. When this is the case, full-width children need width and margin adjustments to compensate and remain full-width. 

To test: 

1. Add a Group block
2. Assign it a background color _or_ assign it the "Frame" block style.
3. Add a block inside the Group block, make it full width.
4. Ensure that it stretches all the way to the edges of the group block in the front end and editor. 

## Screenshots

Front End

Before|After
---|---
![Screen Shot 2020-10-29 at 2 10 24 PM](https://user-images.githubusercontent.com/1202812/97615161-55122f80-19f1-11eb-8941-de01fa36dfb1.png)|![Screen Shot 2020-10-29 at 2 09 00 PM](https://user-images.githubusercontent.com/1202812/97615172-57748980-19f1-11eb-8e2d-af00c48b4307.png)


Editor

Before|After
---|---
![Screen Shot 2020-10-29 at 2 10 37 PM](https://user-images.githubusercontent.com/1202812/97615067-314ee980-19f1-11eb-9be7-0a314550eeef.png)|![Screen Shot 2020-10-29 at 2 08 10 PM](https://user-images.githubusercontent.com/1202812/97615109-3f9d0580-19f1-11eb-89c7-e10757219abb.png)