### PR TITLE
Adjust text color for visited button links

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -400,10 +400,6 @@ a:hover {
 	padding: 15px 30px;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:visited {
-	color: #39414d;
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link:active {
 	background-color: #39414d;
 	color: #d1e4dd;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2304,10 +2304,6 @@ input[type="reset"]:hover {
 	color: #39414d;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):visited {
-	color: #39414d;
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link.has-background {
 	border: 3px solid currentColor;
 }
@@ -2801,8 +2797,11 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file a.wp-block-file__button:visited {
+	color: #d1e4dd;
+}
+
+.wp-block-file a.wp-block-file__button:visited:hover {
 	color: #39414d;
-	opacity: inherit;
 }
 
 .wp-block-file .wp-block-file__button {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -541,10 +541,6 @@ a:hover {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:visited {
-	color: var(--button--color-background);
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link:active, .wp-block-button.is-style-outline .wp-block-button__link:hover {
 	background-color: var(--button--color-background);
 	color: var(--button--color-text);

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -49,10 +49,6 @@
 			border: var(--button--border-width) solid currentColor;
 			padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
-			&:visited {
-				color: var(--button--color-background);
-			}
-
 			&:active,
 			&:hover {
 				background-color: var(--button--color-background);

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -89,9 +89,6 @@ input[type="reset"],
 					color: var(--button--color-background);
 				}
 
-				&:visited {
-					color: var(--button--color-background);
-				}
 			}
 
 			&.has-background,

--- a/assets/sass/05-blocks/file/_style.scss
+++ b/assets/sass/05-blocks/file/_style.scss
@@ -3,10 +3,17 @@
 	// Undo Gutenberg hover defaults
 	a.wp-block-file__button:active,
 	a.wp-block-file__button:focus,
-	a.wp-block-file__button:hover,
-	a.wp-block-file__button:visited {
+	a.wp-block-file__button:hover {
 		color: var(--button--color-text-hover);
 		opacity: inherit;
+	}
+
+	a.wp-block-file__button:visited {
+		color: var(--button--color-text);
+
+		&:hover {
+			color: var(--button--color-text-hover);
+		}
 	}
 
 	.wp-block-file__button {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1667,10 +1667,6 @@ input[type="reset"]:hover,
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):visited {
-	color: var(--button--color-background);
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link.has-background, .wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
 	border: var(--button--border-width) solid currentColor;
 }
@@ -1923,10 +1919,17 @@ input[type="reset"]:hover,
 
 .wp-block-file a.wp-block-file__button:active,
 .wp-block-file a.wp-block-file__button:focus,
-.wp-block-file a.wp-block-file__button:hover,
-.wp-block-file a.wp-block-file__button:visited {
+.wp-block-file a.wp-block-file__button:hover {
 	color: var(--button--color-text-hover);
 	opacity: inherit;
+}
+
+.wp-block-file a.wp-block-file__button:visited {
+	color: var(--button--color-text);
+}
+
+.wp-block-file a.wp-block-file__button:visited:hover {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button {

--- a/style.css
+++ b/style.css
@@ -1672,10 +1672,6 @@ input[type="reset"]:hover,
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):visited {
-	color: var(--button--color-background);
-}
-
 .wp-block-button.is-style-outline .wp-block-button__link.has-background, .wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
 	border: var(--button--border-width) solid currentColor;
 }
@@ -1928,10 +1924,17 @@ input[type="reset"]:hover,
 
 .wp-block-file a.wp-block-file__button:active,
 .wp-block-file a.wp-block-file__button:focus,
-.wp-block-file a.wp-block-file__button:hover,
-.wp-block-file a.wp-block-file__button:visited {
+.wp-block-file a.wp-block-file__button:hover {
 	color: var(--button--color-text-hover);
 	opacity: inherit;
+}
+
+.wp-block-file a.wp-block-file__button:visited {
+	color: var(--button--color-text);
+}
+
+.wp-block-file a.wp-block-file__button:visited:hover {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/745

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

The problem with the invisible text for visited button links did not only affect the file block, but the button block too. 

The PR corrects the text color for the visited button links and file download button link.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a button block with a link
1. Add a file block with a download button
1. Visit the link, or use the browser dev tools to set the status to visited.
1. Hover over the button link.
1. Confirm that the text is readable.
1. Change the body background color and confirm that the text is readable.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
