### PR TITLE
Pullquote: open quote position and i18n

### DIFF
--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1247,6 +1247,7 @@ pre.wp-block-preformatted {
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
+	position: static;
 }
 
 .wp-block-pullquote p {

--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -15,6 +15,7 @@
 		font-size: 3rem;
 		font-weight: 500;
 		line-height: 1;
+		position: static;
 	}
 
 	p {

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -13,6 +13,7 @@
 		font-size: 3rem;
 		font-weight: 500;
 		line-height: 1;
+		position: static;
 	}
 
 	p {

--- a/functions.php
+++ b/functions.php
@@ -493,7 +493,8 @@ add_action( 'wp_print_footer_scripts', 'twenty_twenty_one_skip_link_focus_fix' )
  * @return void
  */
 function twenty_twenty_one_non_latin_languages() {
-	$custom_css = twenty_twenty_one_get_non_latin_css( 'front-end' );
+	$custom_css  = twenty_twenty_one_get_non_latin_css( 'front-end' );
+	$custom_css .= twenty_twenty_one_get_open_pullquote_css( 'front-end' );
 
 	if ( $custom_css ) {
 		wp_add_inline_style( 'twenty-twenty-one-style', $custom_css );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -316,6 +316,47 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 }
 
 /**
+ * Return the custom CSS needed for the open quote sign in the
+ * blockquote block.
+ *
+ * @param string $type Whether to return CSS for the "front-end", "block-editor" or "classic-editor".
+ *
+ * @return string
+ */
+function twenty_twenty_one_get_open_pullquote_css( $type = 'front-end' ) {
+	/* translators: Open quotes for the pullquote block */
+	$open_quotes = __( '“', 'twentytwentyone' );
+
+	// If open quotes sign isn't different in the current language, return.
+	if ( '“' === $open_quotes ) {
+		return;
+	}
+
+	$pullquote_block_open_quote = "'{$open_quotes}'";
+
+	$selectors = array(
+		'front-end'      => '.wp-block-pullquote blockquote::before',
+		'block-editor'   => '.editor-styles-wrapper .wp-block-pullquote blockquote::before',
+		'classic-editor' => 'body#tinymce.wp-editor .wp-block-pullquote blockquote::before',
+	);
+
+	// Include file if function doesn't exist.
+	if ( ! function_exists( 'twenty_twenty_one_generate_css' ) ) {
+		require_once get_theme_file_path( 'inc/custom-css.php' ); // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
+	}
+
+	// Return the specified styles.
+	return twenty_twenty_one_generate_css( // @phpstan-ignore-line.
+		$selectors[ $type ],
+		'content',
+		$pullquote_block_open_quote,
+		null,
+		null,
+		false
+	);
+}
+
+/**
  * Print the first instance of a block in the content, and then break away.
  *
  * @since 1.0.0

--- a/style.css
+++ b/style.css
@@ -2677,6 +2677,7 @@ pre.wp-block-preformatted {
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
+	position: static;
 }
 
 .wp-block-pullquote p {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #759 and #763 

## Summary

By default, `blockquote::before` will have a position absolute. This PR changes that behavior for blockquotes inside the Pullquote block.

It also provides a way to translate the open quote sign.

## Relevant technical choices:

The function that adds the Custom CSS could be placed somewhere else or merged with the existent one (if we change its name). As it is tricky to escape quotes, I'm calling simply `__()` instead of `esc_attr__()`, for example. Perhaps that could be changed.

## Test instructions

This PR can be tested by following these steps:
1. Change the translation of the character using
```
add_filter(
	'gettext',
	function( $translation, $text ) {
		if ( '“' === $text ) {
			return '«';
		}
		return $translation;
	},
	10,
	2
);
```
2. Check how it changes

## Quality assurance
* [ ] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
