### PR TITLE
Fix eslint warning for document.activeElement

### DIFF
--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -114,7 +114,7 @@ function twentytwentyoneExpandSubMenu( el ) { // eslint-disable-line no-unused-v
 			tabKey = event.keyCode === 9;
 			shiftKey = event.shiftKey;
 			escKey = event.keyCode === 27;
-			activeEl = document.activeElement;
+			activeEl = document.activeElement; // eslint-disable-line @wordpress/no-global-active-element
 			lastEl = elements[ elements.length - 1 ];
 			firstEl = elements[0];
 


### PR DESCRIPTION
## Summary

Sorry for the 1-line change PR but while running `npm run lint:js` I get a warning:

```
wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
  117:15  warning  Avoid global active element  @wordpress/no-global-active-element

✖ 1 problem (0 errors, 1 warning)
```

This PR disables that rule in that row (it seems to make sense to use the active element on the whole page).

## Test instructions

This PR can be tested by following these steps:
1. run `npm run lint:js`
1. see the error
1. use the PR code
1. the error is gone

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
