### PR TITLE
Fix space below columns in mobile devices

### DIFF
--- a/assets/sass/05-blocks/columns/_style.scss
+++ b/assets/sass/05-blocks/columns/_style.scss
@@ -32,9 +32,7 @@
 			margin-bottom: var(--global--spacing-vertical);
 		}
 
-		@include media(laptop) {
-
-			/* Resetting margins to match _block-container.scss */
+		@include media(desktop) {
 			margin-bottom: 0;
 		}
 	}

--- a/style.css
+++ b/style.css
@@ -1746,9 +1746,8 @@ input[type="reset"]:hover,
 	}
 }
 
-@media only screen and (min-width: 652px) {
+@media only screen and (min-width: 822px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
-		/* Resetting margins to match _block-container.scss */
 		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #751 

## Summary

Currently, the code applies `margin-bottom: 0` to screens bigger than `652px` (`$breakpoint_lg` or `mobile` in `assets/sass/03-generic/breakpoints.scss`). As stated in #751, that becomes a problem when 3 columns are being used.

The code in this PR applies that `margin-bottom: 0` to screens bigger than `822px` (`$breakpoint_xl` or `desktop` in `assets/sass/03-generic/breakpoints.scss`).

It also removes a comment that references a file called "_block-container.scss" as I could not find that file anywhere...

## Test instructions

This PR can be tested by following these steps:
1. See how things look like in #751 
1. Apply the code
1. Check it again

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
