### PR TITLE
Set the menu fallback to false

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -32,6 +32,7 @@
 							'depth'          => 1,
 							'link_before'    => '<span>',
 							'link_after'     => '</span>',
+							'fallback_cb'    => 'false',
 						)
 					);
 					?>

--- a/template-parts/header/site-nav.php
+++ b/template-parts/header/site-nav.php
@@ -28,6 +28,7 @@
 				'menu_class'      => 'menu-wrapper',
 				'container_class' => 'primary-menu-container',
 				'items_wrap'      => '<ul id="primary-menu-list" class="%2$s">%3$s</ul>',
+				'fallback_cb'     => 'false',
 			)
 		);
 		?>


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/770

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Set the menu fallback call back to false

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:

1. Make sure that no menu is set to the menu locations.
2. Activate a different theme
3. Make sure that no menu is set to the menu locations.
4. Switch to Twenty Twenty-One
5. Confirm that no fallback menu is showing.

<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
