### PR TITLE
Update post pagination spacing

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6486,6 +6486,10 @@ h1.page-title {
 	flex-direction: column;
 }
 
+.navigation .nav-links .dots {
+	text-align: center;
+}
+
 @media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
@@ -6618,11 +6622,20 @@ h1.page-title {
 	}
 }
 
+.pagination .nav-links {
+	margin-top: -30px;
+}
+
+.comments-pagination .nav-links {
+	margin-top: -30px;
+}
+
 .pagination .nav-links > * {
 	color: #28303d;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.5rem;
 	font-weight: normal;
+	margin-top: 30px;
 	margin-left: 13px;
 	margin-right: 13px;
 }
@@ -6632,6 +6645,7 @@ h1.page-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1.5rem;
 	font-weight: normal;
+	margin-top: 30px;
 	margin-left: 13px;
 	margin-right: 13px;
 }
@@ -6672,7 +6686,7 @@ h1.page-title {
 	margin-right: auto;
 }
 
-@media only screen and (max-width: 591px) {
+@media only screen and (max-width: 821px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
 		display: flex;

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -2,7 +2,6 @@
 
 // All navigation
 .navigation {
-
 	color: var(--global--color-primary);
 
 	a {
@@ -34,6 +33,10 @@
 		.nav-previous a {
 			display: flex;
 			flex-direction: column;
+		}
+
+		.dots {
+			text-align: center;
 		}
 
 		@include media(tablet) {
@@ -146,11 +149,17 @@
 
 	@extend %responsive-alignwide-width;
 
+	// Resets the top margin added to the .nav-links items below.
+	.nav-links {
+		margin-top: calc(-1 * var(--global--spacing-vertical));
+	}
+
 	.nav-links > * {
 		color: var(--pagination--color-text);
 		font-family: var(--pagination--font-family);
 		font-size: var(--pagination--font-size);
 		font-weight: var(--pagination--font-weight);
+		margin-top: var(--global--spacing-vertical);
 		margin-left: calc(0.66 * var(--global--spacing-unit));
 		margin-right: calc(0.66 * var(--global--spacing-unit));
 
@@ -179,7 +188,7 @@
 		}
 	}
 
-	@include media(tablet-only) {
+	@include media(desktop-only) {
 
 		.nav-links {
 			display: flex;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4726,6 +4726,10 @@ h1.page-title {
 	flex-direction: column;
 }
 
+.navigation .nav-links .dots {
+	text-align: center;
+}
+
 @media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
@@ -4834,12 +4838,18 @@ h1.page-title {
 	}
 }
 
+.pagination .nav-links,
+.comments-pagination .nav-links {
+	margin-top: calc(-1 * var(--global--spacing-vertical));
+}
+
 .pagination .nav-links > *,
 .comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);
 	font-family: var(--pagination--font-family);
 	font-size: var(--pagination--font-size);
 	font-weight: var(--pagination--font-weight);
+	margin-top: var(--global--spacing-vertical);
 	margin-right: calc(0.66 * var(--global--spacing-unit));
 	margin-left: calc(0.66 * var(--global--spacing-unit));
 }
@@ -4874,7 +4884,7 @@ h1.page-title {
 	margin-left: auto;
 }
 
-@media only screen and (max-width: 591px) {
+@media only screen and (max-width: 821px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
 		display: flex;

--- a/style.css
+++ b/style.css
@@ -4744,6 +4744,10 @@ h1.page-title {
 	flex-direction: column;
 }
 
+.navigation .nav-links .dots {
+	text-align: center;
+}
+
 @media only screen and (min-width: 592px) {
 	.navigation .nav-links {
 		display: flex;
@@ -4852,12 +4856,18 @@ h1.page-title {
 	}
 }
 
+.pagination .nav-links,
+.comments-pagination .nav-links {
+	margin-top: calc(-1 * var(--global--spacing-vertical));
+}
+
 .pagination .nav-links > *,
 .comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);
 	font-family: var(--pagination--font-family);
 	font-size: var(--pagination--font-size);
 	font-weight: var(--pagination--font-weight);
+	margin-top: var(--global--spacing-vertical);
 	margin-left: calc(0.66 * var(--global--spacing-unit));
 	margin-right: calc(0.66 * var(--global--spacing-unit));
 }
@@ -4892,7 +4902,7 @@ h1.page-title {
 	margin-right: auto;
 }
 
-@media only screen and (max-width: 591px) {
+@media only screen and (max-width: 821px) {
 	.pagination .nav-links,
 	.comments-pagination .nav-links {
 		display: flex;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/659

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Hide the page numbers on screens up to 822px using `desktop-only`
Added a top margin to increase the vertical spacing when the pagination wraps.
Centered the dots.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View an archive with pagination
1. Reduce the browser window width
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before:
![pagination-before](https://user-images.githubusercontent.com/7422055/97869188-4c7f6900-1d11-11eb-952a-6f50838ed05b.png)


After:
![pagination](https://user-images.githubusercontent.com/7422055/97869041-09bd9100-1d11-11eb-9463-907043e3b594.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
