### PR TITLE
Do not apply the image size filter to the logo

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -411,6 +411,11 @@ add_filter( 'the_password_form', 'twenty_twenty_one_password_form' );
  * @return array
  */
 function twenty_twenty_one_get_attachment_image_attributes( $attr, $attachment, $size ) {
+
+	if ( 'custom-logo' === $attr['class'] ) {
+		return $attr;
+	}
+
 	$width  = false;
 	$height = false;
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -412,7 +412,7 @@ add_filter( 'the_password_form', 'twenty_twenty_one_password_form' );
  */
 function twenty_twenty_one_get_attachment_image_attributes( $attr, $attachment, $size ) {
 
-	if ( 'custom-logo' === $attr['class'] ) {
+	if ( isset( $attr['class'] ) && false !== strpos( $attr['class'], 'custom-logo' ) ) {
 		return $attr;
 	}
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/760

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Inside `twenty_twenty_one_get_attachment_image_attributes`, check if the image has the custom-logo CSS class.
If it does, return the attributes early without adding the filtered image size attribute.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a custom logo, save and view the front
1. Check that the image is not stretched
1. View source to confirm that the inline size attribute is not filtered for the logo.
1. In the archive, view a post with a featured image.
1. View source to confirm that the filter is still applied to the featured image.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
