### PR TITLE
Prevent :focus styles for links from effecting buttons too. 

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -377,13 +377,10 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
+	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-button__link:focus:not(.has-background) {
-	color: #39414d;
 }
 
 .wp-block-button__link:disabled {
@@ -807,13 +804,10 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-file .wp-block-file__button:focus:not(.has-background) {
-	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -2129,13 +2123,10 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
+	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-search .wp-block-search__button:focus:not(.has-background) {
-	color: #39414d;
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -377,10 +377,17 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-button__link:focus {
+	color: #39414d;
+}
+
+.wp-block-button__link:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-button__link:disabled {
@@ -804,10 +811,17 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -2123,10 +2137,17 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-search .wp-block-search__button:focus {
+	color: #39414d;
+}
+
+.wp-block-search .wp-block-search__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -377,10 +377,13 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-button__link:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-button__link:disabled {
@@ -804,10 +807,13 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -2123,10 +2129,13 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-search .wp-block-search__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -369,14 +369,16 @@ a:hover {
 }
 
 .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button__link:focus {
+	color: #39414d;
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -794,14 +796,16 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -2111,14 +2115,16 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search .wp-block-search__button:focus {
+	color: #39414d;
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -809,23 +809,23 @@ template {
 @media only screen and (min-width: 482px) {
 	.entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		/*rtl:ignore*/
 		margin-right: 25px;
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-left: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -835,21 +835,21 @@ template {
 		/*rtl:ignore*/
 		margin-left: 25px;
 		/*rtl:ignore*/
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px)*1);
+		margin-right: calc(1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -2141,50 +2141,76 @@ input[type="reset"]:after,
 }
 
 .site .button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="submit"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 input[type="reset"]:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .site .button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="submit"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 input[type="reset"]:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
-.site .button:focus,
-input[type="submit"]:focus,
-input[type="reset"]:focus,
-.wp-block-search__button:focus,
+.site .button:focus {
+	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
+}
+
+input[type="submit"]:focus {
+	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
+}
+
+input[type="reset"]:focus {
+	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
+}
+
+.wp-block-search__button:focus {
+	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
+}
+
 .wp-block-button .wp-block-button__link:focus {
+	color: #39414d;
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -2224,7 +2250,17 @@ input[type="reset"]:disabled {
 	background-color: #d1e4dd;
 }
 
+.site .button:focus {
+	color: #39414d;
+	background-color: #d1e4dd;
+}
+
 input[type="submit"]:active {
+	color: #39414d;
+	background-color: #d1e4dd;
+}
+
+input[type="submit"]:focus {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
@@ -2234,12 +2270,27 @@ input[type="reset"]:active {
 	background-color: #d1e4dd;
 }
 
+input[type="reset"]:focus {
+	color: #39414d;
+	background-color: #d1e4dd;
+}
+
 .wp-block-search .wp-block-search__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
 
+.wp-block-search .wp-block-search__button:focus {
+	color: #39414d;
+	background-color: #d1e4dd;
+}
+
 .wp-block-file .wp-block-file__button:active {
+	color: #39414d;
+	background-color: #d1e4dd;
+}
+
+.wp-block-file .wp-block-file__button:focus {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
@@ -2847,14 +2898,16 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
+	margin-bottom: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
+	margin-top: -calc(1em + 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -2870,11 +2923,11 @@ input[type="reset"]:hover {
 }
 
 .wp-block-gallery .blocks-gallery-image {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-item {
-	width: calc(50% - 10px);
+	width: calc((100% - 20px)/2);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption {
@@ -4770,21 +4823,21 @@ table.wp-calendar-table caption {
 		margin-bottom: 30px;
 	}
 	.entry-content > .alignleft {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignleft{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }
@@ -4833,21 +4886,21 @@ table.wp-calendar-table caption {
 		margin-left: 25px;
 	}
 	.entry-content > .alignright {
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 482px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 	@media only screen and (min-width: 822px){
 		.entry-content > .alignright{
-		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px)*1);
+		max-width: calc(50% - 1*(100vw - min(calc(100vw - 4 * 25px), 610px)));
 		}
 	}
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2180,34 +2180,39 @@ input[type="reset"]:after {
 	margin-top: -calc(1em + 0);
 }
 
-.site .button:focus,
-input[type="submit"]:focus,
-input[type="reset"]:focus,
-.wp-block-search__button:focus,
-.wp-block-button .wp-block-button__link:focus {
+.site .button:focus {
+	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
 
-.site .button:focus:not(.has-background) {
+input[type="submit"]:focus {
 	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
 }
 
-input[type="submit"]:focus:not(.has-background) {
+input[type="reset"]:focus {
 	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
 }
 
-input[type="reset"]:focus:not(.has-background) {
+.wp-block-search__button:focus {
 	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
 }
 
-.wp-block-search__button:focus:not(.has-background) {
+.wp-block-button .wp-block-button__link:focus {
 	color: #39414d;
-}
-
-.wp-block-button .wp-block-button__link:focus:not(.has-background) {
-	color: #39414d;
+	background: transparent;
+	outline-offset: -6px;
+	outline: 2px dotted currentColor;
 }
 
 .site .button:disabled {
@@ -2901,13 +2906,10 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-file .wp-block-file__button:focus:not(.has-background) {
-	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2269,17 +2269,7 @@ input[type="reset"]:disabled {
 	background-color: #d1e4dd;
 }
 
-.site .button:focus {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
 input[type="submit"]:active {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
-input[type="submit"]:focus {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
@@ -2289,27 +2279,12 @@ input[type="reset"]:active {
 	background-color: #d1e4dd;
 }
 
-input[type="reset"]:focus {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
 .wp-block-search .wp-block-search__button:active {
 	color: #39414d;
 	background-color: #d1e4dd;
 }
 
-.wp-block-search .wp-block-search__button:focus {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
 .wp-block-file .wp-block-file__button:active {
-	color: #39414d;
-	background-color: #d1e4dd;
-}
-
-.wp-block-file .wp-block-file__button:focus {
 	color: #39414d;
 	background-color: #d1e4dd;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2180,39 +2180,58 @@ input[type="reset"]:after {
 	margin-top: -calc(1em + 0);
 }
 
-.site .button:focus {
-	color: #39414d;
+.site .button:focus,
+input[type="submit"]:focus,
+input[type="reset"]:focus,
+.wp-block-search__button:focus,
+.wp-block-button .wp-block-button__link:focus {
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
 
+.has-background-dark .site .button:focus {
+	color: #39414d;
+}
+
+.has-background-dark
 input[type="submit"]:focus {
 	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
 }
 
+.has-background-dark
 input[type="reset"]:focus {
 	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
 }
 
+.has-background-dark
 .wp-block-search__button:focus {
 	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
 }
 
+.has-background-dark
 .wp-block-button .wp-block-button__link:focus {
 	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
+}
+
+.site .button:focus:not(.has-background) {
+	color: #39414d;
+}
+
+input[type="submit"]:focus:not(.has-background) {
+	color: #39414d;
+}
+
+input[type="reset"]:focus:not(.has-background) {
+	color: #39414d;
+}
+
+.wp-block-search__button:focus:not(.has-background) {
+	color: #39414d;
+}
+
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .site .button:disabled {
@@ -2906,10 +2925,17 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-file .wp-block-file__button:focus {
+	color: #39414d;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2180,39 +2180,34 @@ input[type="reset"]:after {
 	margin-top: -calc(1em + 0);
 }
 
-.site .button:focus {
-	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
-}
-
-input[type="submit"]:focus {
-	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
-}
-
-input[type="reset"]:focus {
-	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
-}
-
-.wp-block-search__button:focus {
-	color: #39414d;
-	background: transparent;
-	outline-offset: -6px;
-	outline: 2px dotted currentColor;
-}
-
+.site .button:focus,
+input[type="submit"]:focus,
+input[type="reset"]:focus,
+.wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.site .button:focus:not(.has-background) {
+	color: #39414d;
+}
+
+input[type="submit"]:focus:not(.has-background) {
+	color: #39414d;
+}
+
+input[type="reset"]:focus:not(.has-background) {
+	color: #39414d;
+}
+
+.wp-block-search__button:focus:not(.has-background) {
+	color: #39414d;
+}
+
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .site .button:disabled {
@@ -2906,10 +2901,13 @@ input[type="reset"]:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: #39414d;
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: #39414d;
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -515,10 +515,17 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-button__link:focus {
+	color: var(--button--color-background);
+}
+
+.wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-button__link:disabled {
@@ -776,10 +783,17 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-background);
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -1635,10 +1649,17 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-search .wp-block-search__button:focus {
+	color: var(--button--color-background);
+}
+
+.wp-block-search .wp-block-search__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -515,10 +515,13 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-button__link:disabled {
@@ -776,10 +779,13 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -1635,10 +1641,13 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-search .wp-block-search__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -515,13 +515,10 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-button__link:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .wp-block-button__link:disabled {
@@ -779,13 +776,10 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-file .wp-block-file__button:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {
@@ -1641,13 +1635,10 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-search .wp-block-search__button:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .wp-block-search .wp-block-search__button:disabled {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -515,6 +515,8 @@ a:hover {
 }
 
 .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -774,6 +776,8 @@ a:hover {
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -1631,6 +1635,8 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-search .wp-block-search__button:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -58,13 +58,10 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:focus {
+		color: var(--button--color-text-hover);
 		background: transparent;
 		outline-offset: -6px;
 		outline: 2px dotted currentColor;
-
-		&:not(.has-background) {
-			color: var(--button--color-text-hover);
-		}
 	}
 
 	&:disabled {

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -58,10 +58,17 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:focus {
-		color: var(--button--color-text-hover);
 		background: transparent;
 		outline-offset: -6px;
 		outline: 2px dotted currentColor;
+
+		.has-background-dark & {
+			color: var(--button--color-background);
+		}
+
+		&:not(.has-background) {
+			color: var(--button--color-text-hover);
+		}
 	}
 
 	&:disabled {

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -58,10 +58,13 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:focus {
-		color: var(--button--color-text-hover);
 		background: transparent;
 		outline-offset: -6px;
 		outline: 2px dotted currentColor;
+
+		&:not(.has-background) {
+			color: var(--button--color-text-hover);
+		}
 	}
 
 	&:disabled {

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -58,6 +58,8 @@
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
 	&:focus {
+		color: var(--button--color-text-hover);
+		background: transparent;
 		outline-offset: -6px;
 		outline: 2px dotted currentColor;
 	}

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -16,8 +16,7 @@ input[type="reset"],
 .wp-block-search .wp-block-search__button,
 .wp-block-file .wp-block-file__button {
 
-	&:active,
-	&:focus {
+	&:active {
 		color: var(--button--color-text-active);
 		background-color: var(--button--color-background-active);
 	}

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -16,7 +16,8 @@ input[type="reset"],
 .wp-block-search .wp-block-search__button,
 .wp-block-file .wp-block-file__button {
 
-	&:active {
+	&:active,
+	&:focus {
 		color: var(--button--color-text-active);
 		background-color: var(--button--color-background-active);
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1603,17 +1603,10 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.site .button:focus:not(.has-background),
-input[type="submit"]:focus:not(.has-background),
-input[type="reset"]:focus:not(.has-background),
-.wp-block-search__button:focus:not(.has-background),
-.wp-block-button .wp-block-button__link:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1993,13 +1986,10 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-file .wp-block-file__button:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1634,15 +1634,11 @@ input[type="reset"]:disabled,
 	color: var(--button--color-text-active);
 }
 
-.site .button:active, .site .button:focus,
+.site .button:active,
 input[type="submit"]:active,
-input[type="submit"]:focus,
 input[type="reset"]:active,
-input[type="reset"]:focus,
 .wp-block-search .wp-block-search__button:active,
-.wp-block-search .wp-block-search__button:focus,
-.wp-block-file .wp-block-file__button:active,
-.wp-block-file .wp-block-file__button:focus {
+.wp-block-file .wp-block-file__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1603,6 +1603,8 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -1617,11 +1619,15 @@ input[type="reset"]:disabled,
 	color: var(--button--color-text-active);
 }
 
-.site .button:active,
+.site .button:active, .site .button:focus,
 input[type="submit"]:active,
+input[type="submit"]:focus,
 input[type="reset"]:active,
+input[type="reset"]:focus,
 .wp-block-search .wp-block-search__button:active,
-.wp-block-file .wp-block-file__button:active {
+.wp-block-search .wp-block-search__button:focus,
+.wp-block-file .wp-block-file__button:active,
+.wp-block-file .wp-block-file__button:focus {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
@@ -1980,6 +1986,8 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1603,10 +1603,17 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.site .button:focus:not(.has-background),
+input[type="submit"]:focus:not(.has-background),
+input[type="reset"]:focus:not(.has-background),
+.wp-block-search__button:focus:not(.has-background),
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1986,10 +1993,13 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1603,10 +1603,25 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .site .button:focus, .has-background-dark
+input[type="submit"]:focus, .has-background-dark
+input[type="reset"]:focus, .has-background-dark
+.wp-block-search__button:focus, .has-background-dark
+.wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-background);
+}
+
+.site .button:focus:not(.has-background),
+input[type="submit"]:focus:not(.has-background),
+input[type="reset"]:focus:not(.has-background),
+.wp-block-search__button:focus:not(.has-background),
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1986,10 +2001,17 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-background);
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/style.css
+++ b/style.css
@@ -1608,10 +1608,17 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.site .button:focus:not(.has-background),
+input[type="submit"]:focus:not(.has-background),
+input[type="reset"]:focus:not(.has-background),
+.wp-block-search__button:focus:not(.has-background),
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1991,10 +1998,13 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/style.css
+++ b/style.css
@@ -1608,17 +1608,10 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.site .button:focus:not(.has-background),
-input[type="submit"]:focus:not(.has-background),
-input[type="reset"]:focus:not(.has-background),
-.wp-block-search__button:focus:not(.has-background),
-.wp-block-button .wp-block-button__link:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1998,13 +1991,10 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
-}
-
-.wp-block-file .wp-block-file__button:focus:not(.has-background) {
-	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {

--- a/style.css
+++ b/style.css
@@ -1639,15 +1639,11 @@ input[type="reset"]:disabled,
 	color: var(--button--color-text-active);
 }
 
-.site .button:active, .site .button:focus,
+.site .button:active,
 input[type="submit"]:active,
-input[type="submit"]:focus,
 input[type="reset"]:active,
-input[type="reset"]:focus,
 .wp-block-search .wp-block-search__button:active,
-.wp-block-search .wp-block-search__button:focus,
-.wp-block-file .wp-block-file__button:active,
-.wp-block-file .wp-block-file__button:focus {
+.wp-block-file .wp-block-file__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }

--- a/style.css
+++ b/style.css
@@ -1608,6 +1608,8 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }
@@ -1622,11 +1624,15 @@ input[type="reset"]:disabled,
 	color: var(--button--color-text-active);
 }
 
-.site .button:active,
+.site .button:active, .site .button:focus,
 input[type="submit"]:active,
+input[type="submit"]:focus,
 input[type="reset"]:active,
+input[type="reset"]:focus,
 .wp-block-search .wp-block-search__button:active,
-.wp-block-file .wp-block-file__button:active {
+.wp-block-search .wp-block-search__button:focus,
+.wp-block-file .wp-block-file__button:active,
+.wp-block-file .wp-block-file__button:focus {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
@@ -1985,6 +1991,8 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-text-hover);
+	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
 }

--- a/style.css
+++ b/style.css
@@ -1608,10 +1608,25 @@ input[type="submit"]:focus,
 input[type="reset"]:focus,
 .wp-block-search__button:focus,
 .wp-block-button .wp-block-button__link:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .site .button:focus, .has-background-dark
+input[type="submit"]:focus, .has-background-dark
+input[type="reset"]:focus, .has-background-dark
+.wp-block-search__button:focus, .has-background-dark
+.wp-block-button .wp-block-button__link:focus {
+	color: var(--button--color-background);
+}
+
+.site .button:focus:not(.has-background),
+input[type="submit"]:focus:not(.has-background),
+input[type="reset"]:focus:not(.has-background),
+.wp-block-search__button:focus:not(.has-background),
+.wp-block-button .wp-block-button__link:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .site .button:disabled,
@@ -1991,10 +2006,17 @@ input[type="reset"]:hover,
 }
 
 .wp-block-file .wp-block-file__button:focus {
-	color: var(--button--color-text-hover);
 	background: transparent;
 	outline-offset: -6px;
 	outline: 2px dotted currentColor;
+}
+
+.has-background-dark .wp-block-file .wp-block-file__button:focus {
+	color: var(--button--color-background);
+}
+
+.wp-block-file .wp-block-file__button:focus:not(.has-background) {
+	color: var(--button--color-text-hover);
 }
 
 .wp-block-file .wp-block-file__button:disabled {


### PR DESCRIPTION
Fixes #747. Alternate to #749. 

## Summary

The link focus style uses .site a:focus, this specificity is used to make sure that the themes link styles does not affect the WordPress admin bar.

Because of this specificity, the background color for the focus state was affecting the button block links. This PR solves that by implementing `:focus` style rules specifically for buttons, avoiding the need for a `.site` selector here, as used in #749. 

## Test instructions

This PR can be tested by following these steps:

1. Add a button with a link and a background color. It does not need to be a custom background color, so the filled button will work. Save.
2. View the front and focus on the button link.
3. Confirm that the background color is correct.
4. Change the body background color.
5. Focus on the link.
6. Confirm that the background color is still correct.

## Screenshots

Default Button State|Focus (Before)| Focus (This PR)
---|---|---
<img width="353" alt="Screen Shot 2020-11-02 at 11 24 45 AM" src="https://user-images.githubusercontent.com/1202812/97892842-88f59980-1cfe-11eb-86e7-38beb5dc8d21.png">|<img width="340" alt="Screen Shot 2020-11-02 at 11 26 12 AM" src="https://user-images.githubusercontent.com/1202812/97892853-8abf5d00-1cfe-11eb-8bb6-a2bbe0c3bef7.png">|<img width="334" alt="Screen Shot 2020-11-02 at 11 31 35 AM" src="https://user-images.githubusercontent.com/1202812/97895279-952f2600-1d01-11eb-87cf-eb0e47a39adb.png">



Default Button State (Dark Background)|Focus (Before)| Focus (This PR)
---|---|---
<img width="379" alt="Screen Shot 2020-11-02 at 11 47 43 AM" src="https://user-images.githubusercontent.com/1202812/97895209-7d57a200-1d01-11eb-83bd-7e3663f049ec.png">|<img width="340" alt="Screen Shot 2020-11-02 at 11 48 52 AM" src="https://user-images.githubusercontent.com/1202812/97895215-7fb9fc00-1d01-11eb-926b-a06c7e56bf6e.png">|<img width="350" alt="Screen Shot 2020-11-02 at 11 48 07 AM" src="https://user-images.githubusercontent.com/1202812/97895223-821c5600-1d01-11eb-839b-acb41059fb56.png">
