### PR TITLE
Take the post-type label into account on post-navigation links

### DIFF
--- a/single.php
+++ b/single.php
@@ -36,10 +36,27 @@ while ( have_posts() ) :
 		// Previous/next post navigation.
 		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
 		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
+
+		$twentytwentyone_post_type      = get_post_type_object( get_post_type() );
+		$twentytwentyone_post_type_name = '';
+		if (
+			is_object( $twentytwentyone_post_type ) &&
+			property_exists( $twentytwentyone_post_type, 'labels' ) &&
+			is_object( $twentytwentyone_post_type->labels ) &&
+			property_exists( $twentytwentyone_post_type->labels, 'singular_name' )
+		) {
+			$twentytwentyone_post_type_name = $twentytwentyone_post_type->labels->singular_name;
+		}
+
+		/* translators: %s: The post-type singlular name (example: Post, Page etc) */
+		$twentytwentyone_next_label = sprintf( esc_html__( 'Next %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
+		/* translators: %s: The post-type singlular name (example: Post, Page etc) */
+		$twentytwentyone_previous_label = sprintf( esc_html__( 'Previous %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
+
 		the_post_navigation(
 			array(
-				'next_text' => '<p class="meta-nav">' . esc_html__( 'Next Post', 'twentytwentyone' ) . $twentytwentyone_next . '</p><p class="post-title">%title</p>',
-				'prev_text' => '<p class="meta-nav">' . $twentytwentyone_prev . esc_html__( 'Previous Post', 'twentytwentyone' ) . '</p><p class="post-title">%title</p>',
+				'next_text' => '<p class="meta-nav">' . $twentytwentyone_next_label . $twentytwentyone_next . '</p><p class="post-title">%title</p>',
+				'prev_text' => '<p class="meta-nav">' . $twentytwentyone_prev . $twentytwentyone_previous_label . '</p><p class="post-title">%title</p>',
 			)
 		);
 	}

--- a/single.php
+++ b/single.php
@@ -32,7 +32,7 @@ while ( have_posts() ) :
 		comments_template();
 	}
 
-	if ( is_singular( 'post' ) ) {
+	if ( is_singular() ) {
 		// Previous/next post navigation.
 		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
 		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #761 

## Summary
Uses the post-type singular label if it exists. If a label does not exist then it will fallback to the WordPress defaults and use `Post` for non-hierarchical post-types, and `Page` for hierarchical post-types.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
