### PR TITLE
Hide dark-mode toggle if Javascript is not available

### DIFF
--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -38,6 +38,10 @@ html.is-dark-mode img {
 	z-index: 9998;
 }
 
+.no-js #dark-mode-toggler {
+	display: none !important;
+}
+
 .wp-admin #dark-mode-toggler {
 	z-index: 99999;
 

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -37,6 +37,10 @@ html.is-dark-mode {
 	color: var(--button--color-background);
 	z-index: 9998;
 
+	.no-js & {
+		display: none;
+	}
+
 	.wp-admin & {
 		z-index: 99999; /* Necessary for the editor. */
 	}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -28,6 +28,9 @@ add_action( 'wp_print_styles', 'twenty_twenty_one_deregister_styles', 100 );
  */
 function twenty_twenty_one_body_classes( $classes ) {
 
+	// Helps detect if JS is enabled or not.
+	$classes[] = 'no-js';
+
 	// Adds `singular` to singular pages, and `hfeed` to all other pages.
 	$classes[] = is_singular() ? 'singular' : 'hfeed';
 
@@ -74,6 +77,18 @@ function twenty_twenty_one_pingback_header() {
 	}
 }
 add_action( 'wp_head', 'twenty_twenty_one_pingback_header' );
+
+/**
+ * Remove the `no-js` class from body if JS is supported.
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function twenty_twenty_one_supports_js() {
+	echo '<script>document.body.classList.remove("no-js");</script>';
+}
+add_action( 'wp_footer', 'twenty_twenty_one_supports_js' );
 
 /**
  * Changes comment form default fields.


### PR DESCRIPTION
## Summary
If Javascript is not available (or is disabled) on the browser, the dark-mode toggle should be hidden.
This PR adds a `no-js` class to `<body>` which gets removed via JS. If the `no-js` class exists, then the toggle is hidden.

Tested in Firefox using the [Disable JS](https://addons.mozilla.org/en-US/firefox/addon/disable-javascript/) addon.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
