### PR TITLE
Update the widget area top margin on mobile

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5653,6 +5653,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: 180px;
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: 30px;
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: 30px;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5656,7 +5656,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: 30px;
+		margin-top: 90px;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7388,6 +7388,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: 30px;
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -12,7 +12,7 @@
 	@include media(mobile-only) {
 
 		.no-widgets & {
-			margin-top: var(--global--spacing-vertical);
+			margin-top: calc(3 * var(--global--spacing-vertical));
 		}
 	}
 }

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -8,6 +8,13 @@
 	.no-widgets & {
 		margin-top: calc(6 * var(--global--spacing-vertical));
 	}
+
+	@include media(mobile-only) {
+
+		.no-widgets & {
+			margin-top: var(--global--spacing-vertical);
+		}
+	}
 }
 
 // Footer Branding

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -17,7 +17,7 @@
 	}
 
 	@include media(mobile-only) {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 
 	ul {

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -16,6 +16,10 @@
 		grid-template-columns: repeat(3, 1fr);
 	}
 
+	@include media(mobile-only) {
+		margin-top: var(--global--spacing-vertical);
+	}
+
 	ul {
 		list-style-type: none;
 		padding: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3948,6 +3948,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: calc(6 * var(--global--spacing-vertical));
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: var(--global--spacing-vertical);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3951,7 +3951,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5359,6 +5359,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;

--- a/style.css
+++ b/style.css
@@ -3968,6 +3968,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: calc(6 * var(--global--spacing-vertical));
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: var(--global--spacing-vertical);

--- a/style.css
+++ b/style.css
@@ -3971,7 +3971,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 
@@ -5404,7 +5404,7 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 
 	.widget-area {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -5395,6 +5395,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #541.
To fix the issue, the margin top of the widget area has been changed from `6 * var(--global--spacing-vertical)` to `var(--global--spacing-vertical`

## Summary
Update the widget area top margin on mobile.


## Relevant technical choices:
No


## Test instructions
1. On a post page scroll to the pagination navigation. 
2. The space between the pagination and the widget area on mobile device should not be too high.


## Screenshots


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
