### PR TITLE
Fix inconsistent use of classes for dark/light mode between editor & front

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -656,14 +656,12 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover h2 {
 		font-size: 3rem;
 	}
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover h2 {
@@ -679,14 +677,12 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover-image h2 {
 		font-size: 3rem;
 	}
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover-image h2 {
@@ -1484,7 +1480,6 @@ h6 {
 	line-height: 1.3;
 	margin-bottom: 10px;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-latest-posts > li > a {
@@ -1774,7 +1769,6 @@ pre.wp-block-preformatted {
 	line-height: 1.3;
 	margin: 0;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-pullquote p {
@@ -1847,7 +1841,6 @@ pre.wp-block-preformatted {
 .wp-block-pullquote.is-style-solid-color blockquote p {
 	font-size: 2rem;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-pullquote.is-style-solid-color blockquote p {
@@ -1945,7 +1938,6 @@ pre.wp-block-preformatted {
 	font-style: normal;
 	line-height: 1.35;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-large p {
@@ -1958,7 +1950,6 @@ pre.wp-block-preformatted {
 	font-style: normal;
 	line-height: 1.35;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-style-large p {
@@ -1971,7 +1962,6 @@ pre.wp-block-preformatted {
 	line-height: 1.35;
 	left: -25px;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-large:before {
@@ -1984,7 +1974,6 @@ pre.wp-block-preformatted {
 	line-height: 1.35;
 	left: -25px;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-style-large:before {
@@ -2129,7 +2118,6 @@ pre.wp-block-preformatted {
 	line-height: 1.3;
 	margin-bottom: 10px;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block-rss .wp-block-rss__item-title > a {
@@ -2624,14 +2612,12 @@ hr[style*="text-align: right"] {
 .wp-block-separator:not(.is-style-dots) {
 	max-width: calc(100vw - 30px);
 }
-
 @media only screen and (min-width: 482px) {
 
 	.wp-block-separator:not(.is-style-dots) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
-
 @media only screen and (min-width: 822px) {
 
 	.wp-block-separator:not(.is-style-dots) {
@@ -2642,14 +2628,12 @@ hr[style*="text-align: right"] {
 hr:not(.is-style-dots) {
 	max-width: calc(100vw - 30px);
 }
-
 @media only screen and (min-width: 482px) {
 
 	hr:not(.is-style-dots) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
-
 @media only screen and (min-width: 822px) {
 
 	hr:not(.is-style-dots) {
@@ -2905,7 +2889,6 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .is-larger-text {
@@ -2917,7 +2900,6 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .has-larger-font-size {
@@ -2929,7 +2911,6 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .is-extra-large-text {
@@ -2941,7 +2922,6 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .has-extra-large-font-size {
@@ -2954,7 +2934,6 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .is-huge-text {
@@ -2967,7 +2946,6 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .has-huge-font-size {
@@ -2980,7 +2958,6 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .is-gigantic-text {
@@ -2993,7 +2970,6 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
-
 @media only screen and (min-width: 652px) {
 
 	:root .has-gigantic-font-size {
@@ -3031,7 +3007,6 @@ pre.wp-block-verse {
 	font-weight: 300;
 	line-height: 1.1;
 }
-
 @media only screen and (min-width: 652px) {
 
 	.wp-block.editor-post-title__block .editor-post-title__input {
@@ -3119,14 +3094,12 @@ pre.wp-block-verse {
 .wp-block[data-align=wide] {
 	max-width: calc(100vw - 30px);
 }
-
 @media only screen and (min-width: 482px) {
 
 	.wp-block[data-align=wide] {
 		max-width: calc(100vw - 100px);
 	}
 }
-
 @media only screen and (min-width: 822px) {
 
 	.wp-block[data-align=wide] {
@@ -3137,14 +3110,12 @@ pre.wp-block-verse {
 .wp-block.alignwide {
 	max-width: calc(100vw - 30px);
 }
-
 @media only screen and (min-width: 482px) {
 
 	.wp-block.alignwide {
 		max-width: calc(100vw - 100px);
 	}
 }
-
 @media only screen and (min-width: 822px) {
 
 	.wp-block.alignwide {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -341,11 +341,11 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus {
+.is-dark-theme .site a:focus {
 	color: #d1e4dd;
 }
 
-.has-background-dark .site a:focus .meta-nav {
+.is-dark-theme .site a:focus .meta-nav {
 	color: #d1e4dd;
 }
 
@@ -418,7 +418,7 @@ a:hover {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-button__link:focus {
+.is-dark-theme .wp-block-button__link:focus {
 	color: #39414d;
 }
 
@@ -656,12 +656,14 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover h2 {
 		font-size: 3rem;
 	}
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover h2 {
@@ -677,12 +679,14 @@ a:hover {
 	max-width: inherit;
 	text-align: inherit;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover-image h2 {
 		font-size: 3rem;
 	}
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-cover-image h2 {
@@ -875,7 +879,7 @@ a:hover {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-file .wp-block-file__button:focus {
+.is-dark-theme .wp-block-file .wp-block-file__button:focus {
 	color: #39414d;
 }
 
@@ -1480,6 +1484,7 @@ h6 {
 	line-height: 1.3;
 	margin-bottom: 10px;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-latest-posts > li > a {
@@ -1769,6 +1774,7 @@ pre.wp-block-preformatted {
 	line-height: 1.3;
 	margin: 0;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-pullquote p {
@@ -1841,6 +1847,7 @@ pre.wp-block-preformatted {
 .wp-block-pullquote.is-style-solid-color blockquote p {
 	font-size: 2rem;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-pullquote.is-style-solid-color blockquote p {
@@ -1938,6 +1945,7 @@ pre.wp-block-preformatted {
 	font-style: normal;
 	line-height: 1.35;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-large p {
@@ -1950,6 +1958,7 @@ pre.wp-block-preformatted {
 	font-style: normal;
 	line-height: 1.35;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-style-large p {
@@ -1962,6 +1971,7 @@ pre.wp-block-preformatted {
 	line-height: 1.35;
 	left: -25px;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-large:before {
@@ -1974,6 +1984,7 @@ pre.wp-block-preformatted {
 	line-height: 1.35;
 	left: -25px;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-quote.is-style-large:before {
@@ -2118,6 +2129,7 @@ pre.wp-block-preformatted {
 	line-height: 1.3;
 	margin-bottom: 10px;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block-rss .wp-block-rss__item-title > a {
@@ -2286,7 +2298,7 @@ pre.wp-block-preformatted {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-search .wp-block-search__button:focus {
+.is-dark-theme .wp-block-search .wp-block-search__button:focus {
 	color: #39414d;
 }
 
@@ -2612,12 +2624,14 @@ hr[style*="text-align: right"] {
 .wp-block-separator:not(.is-style-dots) {
 	max-width: calc(100vw - 30px);
 }
+
 @media only screen and (min-width: 482px) {
 
 	.wp-block-separator:not(.is-style-dots) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
+
 @media only screen and (min-width: 822px) {
 
 	.wp-block-separator:not(.is-style-dots) {
@@ -2628,12 +2642,14 @@ hr[style*="text-align: right"] {
 hr:not(.is-style-dots) {
 	max-width: calc(100vw - 30px);
 }
+
 @media only screen and (min-width: 482px) {
 
 	hr:not(.is-style-dots) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
+
 @media only screen and (min-width: 822px) {
 
 	hr:not(.is-style-dots) {
@@ -2889,6 +2905,7 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .is-larger-text {
@@ -2900,6 +2917,7 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .has-larger-font-size {
@@ -2911,6 +2929,7 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .is-extra-large-text {
@@ -2922,6 +2941,7 @@ pre.wp-block-verse {
 	font-size: 2.5rem;
 	line-height: 1.3;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .has-extra-large-font-size {
@@ -2934,6 +2954,7 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .is-huge-text {
@@ -2946,6 +2967,7 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .has-huge-font-size {
@@ -2958,6 +2980,7 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .is-gigantic-text {
@@ -2970,6 +2993,7 @@ pre.wp-block-verse {
 	line-height: 1.3;
 	font-weight: 300;
 }
+
 @media only screen and (min-width: 652px) {
 
 	:root .has-gigantic-font-size {
@@ -3007,6 +3031,7 @@ pre.wp-block-verse {
 	font-weight: 300;
 	line-height: 1.1;
 }
+
 @media only screen and (min-width: 652px) {
 
 	.wp-block.editor-post-title__block .editor-post-title__input {
@@ -3094,12 +3119,14 @@ pre.wp-block-verse {
 .wp-block[data-align=wide] {
 	max-width: calc(100vw - 30px);
 }
+
 @media only screen and (min-width: 482px) {
 
 	.wp-block[data-align=wide] {
 		max-width: calc(100vw - 100px);
 	}
 }
+
 @media only screen and (min-width: 822px) {
 
 	.wp-block[data-align=wide] {
@@ -3110,12 +3137,14 @@ pre.wp-block-verse {
 .wp-block.alignwide {
 	max-width: calc(100vw - 30px);
 }
+
 @media only screen and (min-width: 482px) {
 
 	.wp-block.alignwide {
 		max-width: calc(100vw - 100px);
 	}
 }
+
 @media only screen and (min-width: 822px) {
 
 	.wp-block.alignwide {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1711,63 +1711,63 @@ input[type=color]:disabled,
 	opacity: 0.7;
 }
 
-.has-background-dark input[type=text] {
+.is-dark-theme input[type=text] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=email] {
+.is-dark-theme input[type=email] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=url] {
+.is-dark-theme input[type=url] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=password] {
+.is-dark-theme input[type=password] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=search] {
+.is-dark-theme input[type=search] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=number] {
+.is-dark-theme input[type=number] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=tel] {
+.is-dark-theme input[type=tel] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=date] {
+.is-dark-theme input[type=date] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=month] {
+.is-dark-theme input[type=month] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=week] {
+.is-dark-theme input[type=week] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=time] {
+.is-dark-theme input[type=time] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=datetime] {
+.is-dark-theme input[type=datetime] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=datetime-local] {
+.is-dark-theme input[type=datetime-local] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark input[type=color] {
+.is-dark-theme input[type=color] {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site textarea {
+.is-dark-theme .site textarea {
 	background: rgba(255, 255, 255, 0.9);
 }
 
@@ -1775,7 +1775,7 @@ input[type=search]:focus {
 	outline-offset: -7px;
 }
 
-.has-background-dark input[type=search]:focus {
+.is-dark-theme input[type=search]:focus {
 	outline-color: #d1e4dd;
 }
 
@@ -1808,7 +1808,7 @@ select:focus {
 	outline: 2px dotted #39414d;
 }
 
-.has-background-dark select {
+.is-dark-theme select {
 	background: rgba(255, 255, 255, 0.9) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	background-position: right 10px top 60%;
 }
@@ -1855,11 +1855,11 @@ License: MIT.
 		opacity: 0.7;
 	}
 
-	.has-background-dark input[type=checkbox] {
+	.is-dark-theme input[type=checkbox] {
 		background: rgba(255, 255, 255, 0.9);
 	}
 
-	.has-background-dark input[type=radio] {
+	.is-dark-theme input[type=radio] {
 		background: rgba(255, 255, 255, 0.9);
 	}
 
@@ -2160,11 +2160,11 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus {
+.is-dark-theme .site a:focus {
 	color: #d1e4dd;
 }
 
-.has-background-dark .site a:focus .meta-nav {
+.is-dark-theme .site a:focus .meta-nav {
 	color: #d1e4dd;
 }
 
@@ -2346,23 +2346,23 @@ input[type=reset]:focus,
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .site .button:focus {
+.is-dark-theme .site .button:focus {
 	color: #39414d;
 }
 
-.has-background-dark input[type=submit]:focus {
+.is-dark-theme input[type=submit]:focus {
 	color: #39414d;
 }
 
-.has-background-dark input[type=reset]:focus {
+.is-dark-theme input[type=reset]:focus {
 	color: #39414d;
 }
 
-.has-background-dark .wp-block-search__button:focus {
+.is-dark-theme .wp-block-search__button:focus {
 	color: #39414d;
 }
 
-.has-background-dark .wp-block-button .wp-block-button__link:focus {
+.is-dark-theme .wp-block-button .wp-block-button__link:focus {
 	color: #39414d;
 }
 
@@ -3091,7 +3091,7 @@ input[type=reset]:hover {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-file .wp-block-file__button:focus {
+.is-dark-theme .wp-block-file .wp-block-file__button:focus {
 	color: #39414d;
 }
 
@@ -4680,15 +4680,15 @@ pre.wp-block-preformatted {
 	color: #fff;
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover {
 	color: #d1e4dd;
 }
 
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover {
 	color: #d1e4dd;
 }
 
-.has-background-dark .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
 	color: #d1e4dd;
 }
 
@@ -4745,43 +4745,43 @@ pre.wp-block-preformatted {
 	color: #fff;
 }
 
-.has-background-dark .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
 }
 
-.has-background-dark .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
@@ -4818,39 +4818,39 @@ pre.wp-block-preformatted {
 	color: #fff;
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: #d1e4dd;
 	color: #d1e4dd;
 }
 
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: #d1e4dd;
 	color: #d1e4dd;
 }
 
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: #d1e4dd;
 	color: #d1e4dd;
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	color: #fff;
 }
 
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	color: #fff;
 }
 
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	color: #fff;
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: #d1e4dd;
 	color: #d1e4dd;
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	border-color: #d1e4dd;
 	background-color: #d1e4dd;
 	color: #39414d;
@@ -7755,43 +7755,43 @@ footer {
 	max-width: none;
 }
 
-.is-IE.has-background-dark {
+.is-IE.is-dark-theme {
 	color: #fff;
 }
 
-.is-IE.has-background-dark *,
-.is-IE.has-background-dark a,
-.is-IE.has-background-dark .site-description,
-.is-IE.has-background-dark .entry-title,
-.is-IE.has-background-dark .entry-footer,
-.is-IE.has-background-dark .widget-area,
-.is-IE.has-background-dark .post-navigation .meta-nav,
-.is-IE.has-background-dark .footer-navigation-wrapper li a:link,
-.is-IE.has-background-dark .site-footer > .site-info,
-.is-IE.has-background-dark .site-footer > .site-info a,
-.is-IE.has-background-dark .site-footer > .site-info a:visited {
+.is-IE.is-dark-theme *,
+.is-IE.is-dark-theme a,
+.is-IE.is-dark-theme .site-description,
+.is-IE.is-dark-theme .entry-title,
+.is-IE.is-dark-theme .entry-footer,
+.is-IE.is-dark-theme .widget-area,
+.is-IE.is-dark-theme .post-navigation .meta-nav,
+.is-IE.is-dark-theme .footer-navigation-wrapper li a:link,
+.is-IE.is-dark-theme .site-footer > .site-info,
+.is-IE.is-dark-theme .site-footer > .site-info a,
+.is-IE.is-dark-theme .site-footer > .site-info a:visited {
 	color: #fff;
 }
 
-.is-IE.has-background-dark .sub-menu-toggle svg,
-.is-IE.has-background-dark .sub-menu-toggle path,
-.is-IE.has-background-dark .post-navigation .meta-nav svg,
-.is-IE.has-background-dark .post-navigation .meta-nav path {
+.is-IE.is-dark-theme .sub-menu-toggle svg,
+.is-IE.is-dark-theme .sub-menu-toggle path,
+.is-IE.is-dark-theme .post-navigation .meta-nav svg,
+.is-IE.is-dark-theme .post-navigation .meta-nav path {
 	fill: #fff;
 }
 
-.is-IE.has-background-dark .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
+.is-IE.is-dark-theme .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 	background: #000;
 }
 @media only screen and (max-width: 481px) {
 
-	.is-IE.has-background-dark.primary-navigation-open .primary-navigation > .primary-menu-container,
-	.is-IE.has-background-dark.primary-navigation-open .menu-button-container {
+	.is-IE.is-dark-theme.primary-navigation-open .primary-navigation > .primary-menu-container,
+	.is-IE.is-dark-theme.primary-navigation-open .menu-button-container {
 		background-color: #000;
 	}
 }
 
-.is-IE.has-background-dark .skip-link:focus {
+.is-IE.is-dark-theme .skip-link:focus {
 	color: #21759b;
 }
 

--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -1,5 +1,5 @@
 /* OS dark theme preference */
-html.is-dark-mode {
+.is-dark-theme.is-dark-theme {
 	--global--color-background: var(--global--color-dark-gray);
 	--global--color-primary: var(--global--color-light-gray);
 	--global--color-secondary: var(--global--color-light-gray);
@@ -10,15 +10,15 @@ html.is-dark-mode {
 	--button--color-background-active: var(--global--color-background);
 }
 
-html.is-dark-mode body {
+.is-dark-theme.is-dark-theme body {
 	background-color: var(--global--color-background);
 }
 
-html.is-dark-mode .site a:focus {
+.is-dark-theme.is-dark-theme .site a:focus {
 	background: #000;
 }
 
-html.is-dark-mode img {
+.is-dark-theme.is-dark-theme img {
 	filter: brightness(0.85) contrast(1.1);
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -483,8 +483,8 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus,
-.has-background-dark .site a:focus .meta-nav {
+.is-dark-theme .site a:focus,
+.is-dark-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
@@ -554,7 +554,7 @@ a:hover {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-button__link:focus {
+.is-dark-theme .wp-block-button__link:focus {
 	color: var(--button--color-background);
 }
 
@@ -839,7 +839,7 @@ a:hover {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-file .wp-block-file__button:focus {
+.is-dark-theme .wp-block-file .wp-block-file__button:focus {
 	color: var(--button--color-background);
 }
 
@@ -1755,7 +1755,7 @@ pre.wp-block-preformatted {
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-search .wp-block-search__button:focus {
+.is-dark-theme .wp-block-search .wp-block-search__button:focus {
 	color: var(--button--color-background);
 }
 

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -14,12 +14,14 @@
 			// Modify the body class depending on whether this is a dark background or not.
 			if ( isDark ) {
 				document.body.classList.add( 'is-dark-theme' );
+				document.documentElement.classList.add( 'is-dark-theme' );
 			} else {
 				document.body.classList.remove( 'is-dark-theme' );
+				document.documentElement.classList.remove( 'is-dark-theme' );
 			}
 
 			// Toggle the white background class.
-			if ( '#ffffff' === to ) {
+			if ( '#ffffff' === to.toLowerCase() ) {
 				document.body.classList.add( 'has-background-white' );
 			} else {
 				document.body.classList.remove( 'has-background-white' );

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -13,14 +13,9 @@
 
 			// Modify the body class depending on whether this is a dark background or not.
 			if ( isDark ) {
-				if ( ! document.body.classList.contains( 'has-background-dark' ) ) {
-					document.body.classList.add( 'has-background-dark' );
-				}
-				if ( document.documentElement.classList.contains( 'is-dark-mode' ) ) {
-					document.documentElement.classList.remove( 'is-dark-mode' );
-				}
+				document.body.classList.add( 'is-dark-theme' );
 			} else {
-				document.body.classList.remove( 'has-background-dark' );
+				document.body.classList.remove( 'is-dark-theme' );
 			}
 
 			// Toggle the white background class.

--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -4,11 +4,11 @@ function toggleDarkMode() { // eslint-disable-line no-unused-vars
 
 	if ( 'false' === toggler.getAttribute( 'aria-pressed' ) ) {
 		toggler.setAttribute( 'aria-pressed', 'true' );
-		html.classList.add( 'is-dark-mode' );
+		html.classList.add( 'is-dark-theme' );
 		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'yes' );
 	} else {
 		toggler.setAttribute( 'aria-pressed', 'false' );
-		html.classList.remove( 'is-dark-mode' );
+		html.classList.remove( 'is-dark-theme' );
 		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
 	}
 }
@@ -33,9 +33,9 @@ function darkModeInitialLoad() {
 
 	html = document.querySelector( 'html' );
 	if ( isDarkMode ) {
-		html.classList.add( 'is-dark-mode' );
+		html.classList.add( 'is-dark-theme' );
 	} else {
-		html.classList.remove( 'is-dark-mode' );
+		html.classList.remove( 'is-dark-theme' );
 	}
 }
 

--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -1,22 +1,22 @@
 function toggleDarkMode() { // eslint-disable-line no-unused-vars
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
-		html = document.querySelector( 'html' );
 
 	if ( 'false' === toggler.getAttribute( 'aria-pressed' ) ) {
 		toggler.setAttribute( 'aria-pressed', 'true' );
-		html.classList.add( 'is-dark-theme' );
+		document.documentElement.classList.add( 'is-dark-theme' );
+		document.body.classList.add( 'is-dark-theme' );
 		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'yes' );
 	} else {
 		toggler.setAttribute( 'aria-pressed', 'false' );
-		html.classList.remove( 'is-dark-theme' );
+		document.documentElement.classList.remove( 'is-dark-theme' );
+		document.body.classList.remove( 'is-dark-theme' );
 		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
 	}
 }
 
 function darkModeInitialLoad() {
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
-		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches,
-		html;
+		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches;
 
 	if ( 'yes' === window.localStorage.getItem( 'twentytwentyoneDarkMode' ) ) {
 		isDarkMode = true;
@@ -31,12 +31,14 @@ function darkModeInitialLoad() {
 		toggler.setAttribute( 'aria-pressed', 'true' );
 	}
 
-	html = document.querySelector( 'html' );
 	if ( isDarkMode ) {
-		html.classList.add( 'is-dark-theme' );
+		document.documentElement.classList.add( 'is-dark-theme' );
+		document.body.classList.add( 'is-dark-theme' );
 	} else {
-		html.classList.remove( 'is-dark-theme' );
+		document.documentElement.classList.remove( 'is-dark-theme' );
+		document.body.classList.remove( 'is-dark-theme' );
 	}
 }
+console.log('lalalaa');
 
 darkModeInitialLoad();

--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -1,5 +1,5 @@
 function toggleDarkMode() { // eslint-disable-line no-unused-vars
-	var toggler = document.getElementById( 'dark-mode-toggler' ),
+	var toggler = document.getElementById( 'dark-mode-toggler' );
 
 	if ( 'false' === toggler.getAttribute( 'aria-pressed' ) ) {
 		toggler.setAttribute( 'aria-pressed', 'true' );

--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -39,6 +39,5 @@ function darkModeInitialLoad() {
 		document.body.classList.remove( 'is-dark-theme' );
 	}
 }
-console.log('lalalaa');
 
 darkModeInitialLoad();

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -81,13 +81,19 @@ function twentytwentyoneDarkModeEditorToggleEditorStyles() {
 
 	if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
 		document.body.classList.add( 'is-dark-theme' );
+		document.documentElement.classList.add( 'is-dark-theme' );
+		document.querySelector( '.block-editor__typewriter' ).classList.add( 'is-dark-theme' );
 	}
 
 	toggler.addEventListener( 'click', function() {
 		if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
 			document.body.classList.add( 'is-dark-theme' );
+			document.documentElement.classList.add( 'is-dark-theme' );
+			document.querySelector( '.block-editor__typewriter' ).classList.add( 'is-dark-theme' );
 		} else {
 			document.body.classList.remove( 'is-dark-theme' );
+			document.documentElement.classList.remove( 'is-dark-theme' );
+			document.querySelector( '.block-editor__typewriter' ).classList.remove( 'is-dark-theme' );
 		}
 	} );
 }

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -62,7 +62,7 @@
 		outline-offset: -6px;
 		outline: 2px dotted currentColor;
 
-		.has-background-dark & {
+		.is-dark-theme & {
 			color: var(--button--color-background);
 		}
 

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -31,7 +31,7 @@ input[type="color"],
 		opacity: 0.7;
 	}
 
-	.has-background-dark & {
+	.is-dark-theme & {
 		background: var(--global--color-white-90);
 	}
 
@@ -43,7 +43,7 @@ input[type="search"] {
 	&:focus {
 		outline-offset: -7px;
 
-		.has-background-dark & {
+		.is-dark-theme & {
 			outline-color: var(--global--color-background);
 		}
 	}
@@ -77,7 +77,7 @@ select {
 		outline: 2px dotted var(--form--border-color);
 	}
 
-	.has-background-dark & {
+	.is-dark-theme & {
 		background: var(--global--color-white-90) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat; // stylelint-disable-line function-url-quotes
 		background-position: right var(--form--spacing-unit) top 60%;
 	}
@@ -114,7 +114,7 @@ License: MIT.
 			opacity: 0.7;
 		}
 
-		.has-background-dark & {
+		.is-dark-theme & {
 			background: var(--global--color-white-90);
 		}
 	}

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -23,8 +23,8 @@ a:hover {
 	background: rgba(255, 255, 255, .9);
 
 	// Change text color when the body background is dark.
-	.has-background-dark &,
-	.has-background-dark & .meta-nav {
+	.is-dark-theme &,
+	.is-dark-theme & .meta-nav {
 		color: var(--wp--style--color--link, var(--global--color-background));
 	}
 

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -81,7 +81,7 @@
 				border-color: var(--global--color-white);
 				color: var(--global--color-white);
 
-				.has-background-dark & {
+				.is-dark-theme & {
 					color: var(--button--color-text);
 				}
 			}
@@ -102,7 +102,7 @@
 				border-color: var(--form--border-color);
 				color: var(--global--color-white);
 
-				.has-background-dark & {
+				.is-dark-theme & {
 					border-color: var(--button--color-text);
 					background-color: var(--button--color-text);
 					color: var(--button--color-background);
@@ -133,7 +133,7 @@
 					color: var(--global--color-white);
 				}
 
-				.has-background-dark & {
+				.is-dark-theme & {
 					border-color: var(--button--color-text);
 					color: var(--button--color-text);
 
@@ -143,7 +143,7 @@
 				}
 			}
 
-			.has-background-dark & {
+			.is-dark-theme & {
 				border-color: var(--button--color-text);
 				color: var(--button--color-text);
 

--- a/assets/sass/07-utilities/ie.scss
+++ b/assets/sass/07-utilities/ie.scss
@@ -1,6 +1,6 @@
 .is-IE {
 
-	&.has-background-dark {
+	&.is-dark-theme {
 		color: #fff;
 
 		*,

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -1,5 +1,5 @@
 /* OS dark theme preference */
-html.is-dark-mode {
+.is-dark-theme.is-dark-theme {
 	--global--color-background: var(--global--color-dark-gray);
 	--global--color-primary: var(--global--color-light-gray);
 	--global--color-secondary: var(--global--color-light-gray);

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -169,9 +169,9 @@ class Twenty_Twenty_One_Custom_Colors {
 	public function body_class( $classes ) {
 		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
 		if ( 127 > self::get_relative_luminance_from_hex( $background_color ) ) {
-			$classes[] = 'has-background-dark';
+			$classes[] = 'is-dark-theme';
 		} else {
-			$classes[] = 'has-background-light';
+			$classes[] = 'is-light-theme';
 		}
 
 		if ( 'ffffff' === strtolower( $background_color ) ) {

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -65,7 +65,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			// Add Dark Mode variable overrides.
 			wp_add_inline_style(
 				'twenty-twenty-one-custom-color-overrides',
-				'html.is-dark-mode .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); }'
+				'.is-dark-theme.is-dark-theme .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); }'
 			);
 		}
 		wp_enqueue_script(
@@ -328,7 +328,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				.components-editor-notices__pinned ~ .edit-post-visual-editor #dark-mode-toggler {
 					z-index: 20;
 				}
-				html.is-dark-mode #dark-mode-toggler:not(:hover):not(:focus) {
+				.is-dark-theme.is-dark-theme #dark-mode-toggler:not(:hover):not(:focus) {
 					color: var(--global--color-primary);
 				}
 				@media only screen and (max-width: 782px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1257,21 +1257,21 @@ input[type=color]:disabled,
 	opacity: 0.7;
 }
 
-.has-background-dark input[type=text],
-.has-background-dark input[type=email],
-.has-background-dark input[type=url],
-.has-background-dark input[type=password],
-.has-background-dark input[type=search],
-.has-background-dark input[type=number],
-.has-background-dark input[type=tel],
-.has-background-dark input[type=date],
-.has-background-dark input[type=month],
-.has-background-dark input[type=week],
-.has-background-dark input[type=time],
-.has-background-dark input[type=datetime],
-.has-background-dark input[type=datetime-local],
-.has-background-dark input[type=color],
-.has-background-dark .site textarea {
+.is-dark-theme input[type=text],
+.is-dark-theme input[type=email],
+.is-dark-theme input[type=url],
+.is-dark-theme input[type=password],
+.is-dark-theme input[type=search],
+.is-dark-theme input[type=number],
+.is-dark-theme input[type=tel],
+.is-dark-theme input[type=date],
+.is-dark-theme input[type=month],
+.is-dark-theme input[type=week],
+.is-dark-theme input[type=time],
+.is-dark-theme input[type=datetime],
+.is-dark-theme input[type=datetime-local],
+.is-dark-theme input[type=color],
+.is-dark-theme .site textarea {
 	background: var(--global--color-white-90);
 }
 
@@ -1279,7 +1279,7 @@ input[type=search]:focus {
 	outline-offset: -7px;
 }
 
-.has-background-dark input[type=search]:focus {
+.is-dark-theme input[type=search]:focus {
 	outline-color: var(--global--color-background);
 }
 
@@ -1310,7 +1310,7 @@ select:focus {
 	outline: 2px dotted var(--form--border-color);
 }
 
-.has-background-dark select {
+.is-dark-theme select {
 	background: var(--global--color-white-90) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	background-position: left var(--form--spacing-unit) top 60%;
 }
@@ -1348,8 +1348,8 @@ License: MIT.
 		opacity: 0.7;
 	}
 
-	.has-background-dark input[type=checkbox],
-	.has-background-dark input[type=radio] {
+	.is-dark-theme input[type=checkbox],
+	.is-dark-theme input[type=radio] {
 		background: var(--global--color-white-90);
 	}
 
@@ -1623,8 +1623,8 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus,
-.has-background-dark .site a:focus .meta-nav {
+.is-dark-theme .site a:focus,
+.is-dark-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
@@ -1727,11 +1727,11 @@ input[type=reset]:focus,
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .site .button:focus,
-.has-background-dark input[type=submit]:focus,
-.has-background-dark input[type=reset]:focus,
-.has-background-dark .wp-block-search__button:focus,
-.has-background-dark .wp-block-button .wp-block-button__link:focus {
+.is-dark-theme .site .button:focus,
+.is-dark-theme input[type=submit]:focus,
+.is-dark-theme input[type=reset]:focus,
+.is-dark-theme .wp-block-search__button:focus,
+.is-dark-theme .wp-block-button .wp-block-button__link:focus {
 	color: var(--button--color-background);
 }
 
@@ -2149,7 +2149,7 @@ input[type=reset]:hover,
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-file .wp-block-file__button:focus {
+.is-dark-theme .wp-block-file .wp-block-file__button:focus {
 	color: var(--button--color-background);
 }
 
@@ -3311,9 +3311,9 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
 	color: var(--button--color-text);
 }
 
@@ -3340,13 +3340,13 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: var(--button--color-text);
 	background-color: var(--button--color-text);
 	color: var(--button--color-background);
@@ -3369,25 +3369,25 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: var(--button--color-text);
 	color: var(--button--color-text);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: var(--button--color-text);
 	color: var(--button--color-text);
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	border-color: var(--button--color-text);
 	background-color: var(--button--color-text);
 	color: var(--button--color-background);
@@ -5673,43 +5673,43 @@ footer {
 	max-width: none;
 }
 
-.is-IE.has-background-dark {
+.is-IE.is-dark-theme {
 	color: #fff;
 }
 
-.is-IE.has-background-dark *,
-.is-IE.has-background-dark a,
-.is-IE.has-background-dark .site-description,
-.is-IE.has-background-dark .entry-title,
-.is-IE.has-background-dark .entry-footer,
-.is-IE.has-background-dark .widget-area,
-.is-IE.has-background-dark .post-navigation .meta-nav,
-.is-IE.has-background-dark .footer-navigation-wrapper li a:link,
-.is-IE.has-background-dark .site-footer > .site-info,
-.is-IE.has-background-dark .site-footer > .site-info a,
-.is-IE.has-background-dark .site-footer > .site-info a:visited {
+.is-IE.is-dark-theme *,
+.is-IE.is-dark-theme a,
+.is-IE.is-dark-theme .site-description,
+.is-IE.is-dark-theme .entry-title,
+.is-IE.is-dark-theme .entry-footer,
+.is-IE.is-dark-theme .widget-area,
+.is-IE.is-dark-theme .post-navigation .meta-nav,
+.is-IE.is-dark-theme .footer-navigation-wrapper li a:link,
+.is-IE.is-dark-theme .site-footer > .site-info,
+.is-IE.is-dark-theme .site-footer > .site-info a,
+.is-IE.is-dark-theme .site-footer > .site-info a:visited {
 	color: #fff;
 }
 
-.is-IE.has-background-dark .sub-menu-toggle svg,
-.is-IE.has-background-dark .sub-menu-toggle path,
-.is-IE.has-background-dark .post-navigation .meta-nav svg,
-.is-IE.has-background-dark .post-navigation .meta-nav path {
+.is-IE.is-dark-theme .sub-menu-toggle svg,
+.is-IE.is-dark-theme .sub-menu-toggle path,
+.is-IE.is-dark-theme .post-navigation .meta-nav svg,
+.is-IE.is-dark-theme .post-navigation .meta-nav path {
 	fill: #fff;
 }
 
-.is-IE.has-background-dark .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
+.is-IE.is-dark-theme .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 	background: #000;
 }
 @media only screen and (max-width: 481px) {
 
-	.is-IE.has-background-dark.primary-navigation-open .primary-navigation > .primary-menu-container,
-	.is-IE.has-background-dark.primary-navigation-open .menu-button-container {
+	.is-IE.is-dark-theme.primary-navigation-open .primary-navigation > .primary-menu-container,
+	.is-IE.is-dark-theme.primary-navigation-open .menu-button-container {
 		background-color: #000;
 	}
 }
 
-.is-IE.has-background-dark .skip-link:focus {
+.is-IE.is-dark-theme .skip-link:focus {
 	color: #21759b;
 }
 

--- a/style.css
+++ b/style.css
@@ -1265,21 +1265,21 @@ input[type=color]:disabled,
 	opacity: 0.7;
 }
 
-.has-background-dark input[type=text],
-.has-background-dark input[type=email],
-.has-background-dark input[type=url],
-.has-background-dark input[type=password],
-.has-background-dark input[type=search],
-.has-background-dark input[type=number],
-.has-background-dark input[type=tel],
-.has-background-dark input[type=date],
-.has-background-dark input[type=month],
-.has-background-dark input[type=week],
-.has-background-dark input[type=time],
-.has-background-dark input[type=datetime],
-.has-background-dark input[type=datetime-local],
-.has-background-dark input[type=color],
-.has-background-dark .site textarea {
+.is-dark-theme input[type=text],
+.is-dark-theme input[type=email],
+.is-dark-theme input[type=url],
+.is-dark-theme input[type=password],
+.is-dark-theme input[type=search],
+.is-dark-theme input[type=number],
+.is-dark-theme input[type=tel],
+.is-dark-theme input[type=date],
+.is-dark-theme input[type=month],
+.is-dark-theme input[type=week],
+.is-dark-theme input[type=time],
+.is-dark-theme input[type=datetime],
+.is-dark-theme input[type=datetime-local],
+.is-dark-theme input[type=color],
+.is-dark-theme .site textarea {
 	background: var(--global--color-white-90);
 }
 
@@ -1287,7 +1287,7 @@ input[type=search]:focus {
 	outline-offset: -7px;
 }
 
-.has-background-dark input[type=search]:focus {
+.is-dark-theme input[type=search]:focus {
 	outline-color: var(--global--color-background);
 }
 
@@ -1320,7 +1320,7 @@ select:focus {
 	outline: 2px dotted var(--form--border-color);
 }
 
-.has-background-dark select {
+.is-dark-theme select {
 	background: var(--global--color-white-90) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>") no-repeat;
 	background-position: right var(--form--spacing-unit) top 60%;
 }
@@ -1358,8 +1358,8 @@ License: MIT.
 		opacity: 0.7;
 	}
 
-	.has-background-dark input[type=checkbox],
-	.has-background-dark input[type=radio] {
+	.is-dark-theme input[type=checkbox],
+	.is-dark-theme input[type=radio] {
 		background: var(--global--color-white-90);
 	}
 
@@ -1633,8 +1633,8 @@ a:hover {
 	background: rgba(255, 255, 255, 0.9);
 }
 
-.has-background-dark .site a:focus,
-.has-background-dark .site a:focus .meta-nav {
+.is-dark-theme .site a:focus,
+.is-dark-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
@@ -1737,11 +1737,11 @@ input[type=reset]:focus,
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .site .button:focus,
-.has-background-dark input[type=submit]:focus,
-.has-background-dark input[type=reset]:focus,
-.has-background-dark .wp-block-search__button:focus,
-.has-background-dark .wp-block-button .wp-block-button__link:focus {
+.is-dark-theme .site .button:focus,
+.is-dark-theme input[type=submit]:focus,
+.is-dark-theme input[type=reset]:focus,
+.is-dark-theme .wp-block-search__button:focus,
+.is-dark-theme .wp-block-button .wp-block-button__link:focus {
 	color: var(--button--color-background);
 }
 
@@ -2159,7 +2159,7 @@ input[type=reset]:hover,
 	outline: 2px dotted currentColor;
 }
 
-.has-background-dark .wp-block-file .wp-block-file__button:focus {
+.is-dark-theme .wp-block-file .wp-block-file__button:focus {
 	color: var(--button--color-background);
 }
 
@@ -3321,9 +3321,9 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search button.wp-block-search__button:hover {
 	color: var(--button--color-text);
 }
 
@@ -3350,13 +3350,13 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-white-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-green-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-blue-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-purple-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-red-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-orange-background-color .wp-block-search button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-yellow-background-color .wp-block-search button.wp-block-search__button:hover {
 	border-color: var(--button--color-text);
 	background-color: var(--button--color-text);
 	color: var(--button--color-background);
@@ -3379,25 +3379,25 @@ pre.wp-block-preformatted {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: var(--button--color-text);
 	color: var(--button--color-text);
 }
 
-.has-background-dark .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
-.has-background-dark .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .has-background.has-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-dark-gray-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover,
+.is-dark-theme .has-background.has-black-background-color .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	color: var(--global--color-white);
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button {
 	border-color: var(--button--color-text);
 	color: var(--button--color-text);
 }
 
-.has-background-dark .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
+.is-dark-theme .wp-block-search.wp-block-search__button-inside button.wp-block-search__button:hover {
 	border-color: var(--button--color-text);
 	background-color: var(--button--color-text);
 	color: var(--button--color-background);
@@ -5709,43 +5709,43 @@ footer {
 	max-width: none;
 }
 
-.is-IE.has-background-dark {
+.is-IE.is-dark-theme {
 	color: #fff;
 }
 
-.is-IE.has-background-dark *,
-.is-IE.has-background-dark a,
-.is-IE.has-background-dark .site-description,
-.is-IE.has-background-dark .entry-title,
-.is-IE.has-background-dark .entry-footer,
-.is-IE.has-background-dark .widget-area,
-.is-IE.has-background-dark .post-navigation .meta-nav,
-.is-IE.has-background-dark .footer-navigation-wrapper li a:link,
-.is-IE.has-background-dark .site-footer > .site-info,
-.is-IE.has-background-dark .site-footer > .site-info a,
-.is-IE.has-background-dark .site-footer > .site-info a:visited {
+.is-IE.is-dark-theme *,
+.is-IE.is-dark-theme a,
+.is-IE.is-dark-theme .site-description,
+.is-IE.is-dark-theme .entry-title,
+.is-IE.is-dark-theme .entry-footer,
+.is-IE.is-dark-theme .widget-area,
+.is-IE.is-dark-theme .post-navigation .meta-nav,
+.is-IE.is-dark-theme .footer-navigation-wrapper li a:link,
+.is-IE.is-dark-theme .site-footer > .site-info,
+.is-IE.is-dark-theme .site-footer > .site-info a,
+.is-IE.is-dark-theme .site-footer > .site-info a:visited {
 	color: #fff;
 }
 
-.is-IE.has-background-dark .sub-menu-toggle svg,
-.is-IE.has-background-dark .sub-menu-toggle path,
-.is-IE.has-background-dark .post-navigation .meta-nav svg,
-.is-IE.has-background-dark .post-navigation .meta-nav path {
+.is-IE.is-dark-theme .sub-menu-toggle svg,
+.is-IE.is-dark-theme .sub-menu-toggle path,
+.is-IE.is-dark-theme .post-navigation .meta-nav svg,
+.is-IE.is-dark-theme .post-navigation .meta-nav path {
 	fill: #fff;
 }
 
-.is-IE.has-background-dark .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
+.is-IE.is-dark-theme .primary-navigation > div > .menu-wrapper > li > .sub-menu li {
 	background: #000;
 }
 @media only screen and (max-width: 481px) {
 
-	.is-IE.has-background-dark.primary-navigation-open .primary-navigation > .primary-menu-container,
-	.is-IE.has-background-dark.primary-navigation-open .menu-button-container {
+	.is-IE.is-dark-theme.primary-navigation-open .primary-navigation > .primary-menu-container,
+	.is-IE.is-dark-theme.primary-navigation-open .menu-button-container {
 		background-color: #000;
 	}
 }
 
-.is-IE.has-background-dark .skip-link:focus {
+.is-IE.is-dark-theme .skip-link:focus {
 	color: #21759b;
 }
 


### PR DESCRIPTION
The editor already has a `.is-dark-theme` class. This PR updates all other implementations to use the same class. Ensures consistent styling for dark-mode and manually selected dark background-colors.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
