### PR TITLE
Button Block: Tidy up buttons block margins in the editor

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -435,6 +435,19 @@ a:hover {
 /**
  * Block Options
  */
+.wp-block.wp-block-buttons {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.wp-block.wp-block-buttons .wp-block-button:first-child {
+	margin-top: 30px;
+}
+
+.wp-block.wp-block-buttons .wp-block-button:last-child {
+	margin-bottom: 30px;
+}
+
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background):not(.has-text-color):active {
 	color: #39414d;
 	background-color: #d1e4dd;
@@ -556,8 +569,8 @@ a:hover {
 	clear: both;
 }
 
-[data-align="full"] .wp-block-cover, [data-align="full"]
-.wp-block-cover-image {
+[data-align=full] .wp-block-cover,
+[data-align=full] .wp-block-cover-image {
 	margin-top: 0;
 	margin-bottom: 0;
 }
@@ -1669,7 +1682,7 @@ dt {
 	font-weight: bold;
 }
 
-[data-align="full"] .wp-block-media-text {
+[data-align=full] .wp-block-media-text {
 	margin-top: 0;
 	margin-bottom: 0;
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -435,16 +435,16 @@ a:hover {
 /**
  * Block Options
  */
-.wp-block.wp-block-buttons {
+[data-block].wp-block-buttons {
 	margin-top: 0;
 	margin-bottom: 0;
 }
 
-.wp-block.wp-block-buttons .wp-block-button:first-child {
+[data-block].wp-block-buttons .wp-block-button:first-child {
 	margin-top: 30px;
 }
 
-.wp-block.wp-block-buttons .wp-block-button:last-child {
+[data-block].wp-block-buttons .wp-block-button:last-child {
 	margin-bottom: 30px;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -571,6 +571,19 @@ a:hover {
 /**
  * Block Options
  */
+.wp-block.wp-block-buttons {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.wp-block.wp-block-buttons .wp-block-button:first-child {
+	margin-top: var(--global--spacing-vertical);
+}
+
+.wp-block.wp-block-buttons .wp-block-button:last-child {
+	margin-bottom: var(--global--spacing-vertical);
+}
+
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background):not(.has-text-color):active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
@@ -660,8 +673,8 @@ a:hover {
 	clear: both;
 }
 
-[data-align="full"] .wp-block-cover, [data-align="full"]
-.wp-block-cover-image {
+[data-align=full] .wp-block-cover,
+[data-align=full] .wp-block-cover-image {
 	margin-top: 0;
 	margin-bottom: 0;
 }
@@ -1270,7 +1283,7 @@ dt {
 	font-weight: bold;
 }
 
-[data-align="full"] .wp-block-media-text {
+[data-align=full] .wp-block-media-text {
 	margin-top: 0;
 	margin-bottom: 0;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -571,16 +571,16 @@ a:hover {
 /**
  * Block Options
  */
-.wp-block.wp-block-buttons {
+[data-block].wp-block-buttons {
 	margin-top: 0;
 	margin-bottom: 0;
 }
 
-.wp-block.wp-block-buttons .wp-block-button:first-child {
+[data-block].wp-block-buttons .wp-block-button:first-child {
 	margin-top: var(--global--spacing-vertical);
 }
 
-.wp-block.wp-block-buttons .wp-block-button:last-child {
+[data-block].wp-block-buttons .wp-block-button:last-child {
 	margin-bottom: var(--global--spacing-vertical);
 }
 

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -7,8 +7,8 @@
  * Block Options
  */
 
-// The parent container does not need outer margins applied. 
-// The children should all have top and bottom margins. 
+// The parent container does not need outer margins applied.
+// The children should all have top and bottom margins.
 .wp-block.wp-block-buttons {
 	margin-top: 0;
 	margin-bottom: 0;

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -6,6 +6,22 @@
 /**
  * Block Options
  */
+
+// The parent container does not need outer margins applied. 
+// The children should all have top and bottom margins. 
+.wp-block.wp-block-buttons {
+	margin-top: 0;
+	margin-bottom: 0;
+
+	.wp-block-button:first-child {
+		margin-top: var(--global--spacing-vertical);
+	}
+
+	.wp-block-button:last-child {
+		margin-bottom: var(--global--spacing-vertical);
+	}
+}
+
 .wp-block-button {
 
 	// Target the default and filled button states.

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -9,7 +9,7 @@
 
 // The parent container does not need outer margins applied.
 // The children should all have top and bottom margins.
-.wp-block.wp-block-buttons {
+[data-block].wp-block-buttons {
 	margin-top: 0;
 	margin-bottom: 0;
 


### PR DESCRIPTION
This PR cleans up block margins in the editor so that they match the front-end. It removes the theme's outer margin from the parent `wp-block-buttons` block, and ensures that the top and bottom margins of all children are present. 

Editor Before|Editor After|Front End (Unchanged in this PR)
---|---|---
<img width="687" alt="Screen Shot 2020-11-05 at 8 44 37 AM" src="https://user-images.githubusercontent.com/1202812/98248778-67d1ba80-1f43-11eb-9aee-0f15bdb2514a.png">|<img width="662" alt="Screen Shot 2020-11-05 at 8 42 33 AM" src="https://user-images.githubusercontent.com/1202812/98248795-6c966e80-1f43-11eb-9645-49880b0b1501.png">|![Screen Shot 2020-11-05 at 8 19 52 AM](https://user-images.githubusercontent.com/1202812/98248772-64d6ca00-1f43-11eb-829d-4961c1416212.png)
