### PR TITLE
Update Dark Mode link focus style

### DIFF
--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -18,6 +18,7 @@
 .is-dark-theme.is-dark-theme .site a:focus .meta-nav {
 	background: #000;
 	color: #fff;
+	text-decoration: none;
 }
 
 .is-dark-theme.is-dark-theme img {

--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -14,8 +14,10 @@
 	background-color: var(--global--color-background);
 }
 
-.is-dark-theme.is-dark-theme .site a:focus {
+.is-dark-theme.is-dark-theme .site a:focus,
+.is-dark-theme.is-dark-theme .site a:focus .meta-nav {
 	background: #000;
+	color: #fff;
 }
 
 .is-dark-theme.is-dark-theme img {

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -13,8 +13,10 @@
 		background-color: var(--global--color-background);
 	}
 
-	.site a:focus {
+	.site a:focus,
+	.site a:focus .meta-nav {
 		background: #000;
+		color: #fff;
 	}
 
 	img {

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -17,6 +17,7 @@
 	.site a:focus .meta-nav {
 		background: #000;
 		color: #fff;
+		text-decoration: none;
 	}
 
 	img {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/796

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Set the link text color to white.
Set the next and previous post navigation text color to white when in focus.
Removes the link underline on focus

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
-The link underline is removed because the color contrast ratio between the dark body background and 
the black focus background, is not high enough to be used on its own.


## Test instructions

This PR can be tested by following these steps:
1. Enable dark mode
2. Focus on a link
3. See the color
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
![darkmode-focus-after](https://user-images.githubusercontent.com/7422055/98254753-f7e02600-1f7c-11eb-8c98-e5d3ede66fc5.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [ ] I have checked that this code does not affect the accessibility negatively
