### PR TITLE
Hide dark-mode toggler on scroll

### DIFF
--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -55,6 +55,11 @@
 	position: fixed;
 	bottom: 5px;
 	right: 5px;
+	transition: bottom 0.5s;
+}
+
+#dark-mode-toggler.fixed-bottom.hide {
+	bottom: -80px;
 }
 
 #dark-mode-toggler.relative {

--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -40,4 +40,23 @@ function darkModeInitialLoad() {
 	}
 }
 
+function darkModeRepositionTogglerOnScroll() {
+	var prevScroll = window.scrollY || document.documentElement.scrollTop,
+		currentScroll,
+
+		checkScroll = function() {
+			currentScroll = window.scrollY || document.documentElement.scrollTop;
+			if ( currentScroll > prevScroll ) {
+				if ( 250 < currentScroll ) {
+					document.getElementById( 'dark-mode-toggler' ).classList.add( 'hide' );
+				}
+			} else if ( currentScroll < prevScroll ) {
+				document.getElementById( 'dark-mode-toggler' ).classList.remove( 'hide' );
+			}
+			prevScroll = currentScroll;
+		};
+	window.addEventListener( 'scroll', checkScroll );
+}
+
 darkModeInitialLoad();
+darkModeRepositionTogglerOnScroll();

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -52,6 +52,11 @@
 		position: fixed;
 		bottom: 5px;
 		right: 5px;
+		transition: bottom 0.5s;
+
+		&.hide {
+			bottom: -80px;
+		}
 	}
 
 	&.relative {


### PR DESCRIPTION
Hides the dark-mode toggler on scroll-down, reveals it on scroll-up.
See https://github.com/WordPress/twentytwentyone/issues/784#issuecomment-722364092

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
