### PR TITLE
Hide the toggler while in the editor.

### DIFF
--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -46,9 +46,7 @@
 }
 
 .wp-admin #dark-mode-toggler {
-	z-index: 99999;
-
-	/* Necessary for the editor. */
+	display: none;
 }
 
 #dark-mode-toggler.fixed-bottom {

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -51,12 +51,6 @@ function twentytwentyoneDarkModeEditorToggle() {
 			// Inject the toggle.
 			document.querySelector( selector ).insertAdjacentHTML( 'afterbegin', this.response );
 
-			// Re-position the toggle.
-			twentytwentyoneDarkModeEditorTogglePosition();
-
-			// Add an observer so the toggle gets re-positioned when the sidebar opens/closes.
-			twentytwentyoneDarkModeEditorTogglePositionObserver();
-
 			// Run toggler script.
 			darkModeInitialLoad();
 
@@ -84,74 +78,4 @@ function twentytwentyoneDarkModeEditorToggleEditorStyles() {
 		document.documentElement.classList.add( 'is-dark-theme' );
 		document.querySelector( '.block-editor__typewriter' ).classList.add( 'is-dark-theme' );
 	}
-
-	toggler.addEventListener( 'click', function() {
-		if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
-			document.body.classList.add( 'is-dark-theme' );
-			document.documentElement.classList.add( 'is-dark-theme' );
-			document.querySelector( '.block-editor__typewriter' ).classList.add( 'is-dark-theme' );
-		} else {
-			document.body.classList.remove( 'is-dark-theme' );
-			document.documentElement.classList.remove( 'is-dark-theme' );
-			document.querySelector( '.block-editor__typewriter' ).classList.remove( 'is-dark-theme' );
-		}
-	} );
-}
-
-/**
- * Reposition the toggle inside the editor wrapper.
- *
- * @since 1.0.0
- *
- * @return {void}
- */
-function twentytwentyoneDarkModeEditorTogglePosition() {
-	var toggle = document.getElementById( 'dark-mode-toggler' ),
-		toggleWidth,
-		workSpace,
-		workSpaceWidth,
-		attempt = 0,
-		attemptDelay = 25,
-		maxAttempts = 10;
-
-	if ( null === toggle ) {
-		// Try again.
-		if ( attempt < maxAttempts ) {
-			setTimeout( function() {
-				twentytwentyoneDarkModeEditorTogglePosition();
-			}, attemptDelay );
-
-			attempt++;
-			attemptDelay *= 2;
-		}
-		return;
-	}
-
-	toggleWidth = window.getComputedStyle( document.getElementById( 'dark-mode-toggler' ) ).width;
-	workSpace = document.querySelector( '.editor-styles-wrapper,.edit-post-visual-editor' );
-	workSpaceWidth = window.getComputedStyle( workSpace ).width;
-
-	// Add styles to reposition toggle.
-	toggle.style.position = 'fixed';
-	toggle.style.bottom = '30px';
-	if ( document.body.classList.contains( 'is-fullscreen-mode' ) ) {
-		toggle.style.left = 'calc(' + workSpaceWidth + ' - ' + toggleWidth + ' - 5px)';
-	} else {
-		toggle.style.left = 'calc(' + workSpaceWidth + ' - ' + toggleWidth + ' + 155px)';
-	}
-}
-
-/**
- * Add a ResizeObserver to the editor wrapper
- * and trigger the toggle repositioning when needed.
- *
- * @since 1.0.0
- *
- * @return {void}
- */
-function twentytwentyoneDarkModeEditorTogglePositionObserver() {
-	var observer = new ResizeObserver( function() {
-		twentytwentyoneDarkModeEditorTogglePosition();
-	} );
-	observer.observe( document.querySelector( '.editor-styles-wrapper,.edit-post-visual-editor' ) );
 }

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, XMLHttpRequest, ResizeObserver, darkModeInitialLoad, setTimeout */
+/* global ajaxurl, XMLHttpRequest, darkModeInitialLoad, setTimeout */
 
 // Check the body class to determine if we want to add the toggler and handle dark-mode or not.
 if ( document.body.classList.contains( 'twentytwentyone-supports-dark-theme' ) ) {

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -45,7 +45,7 @@
 	}
 
 	.wp-admin & {
-		z-index: 99999; /* Necessary for the editor. */
+		display: none;
 	}
 
 	&.fixed-bottom {


### PR DESCRIPTION
This is for a suggestion in https://github.com/WordPress/twentytwentyone/issues/784#issuecomment-722367594
Hides the toggler in the editor and simply respects the user's preferences from the frontend.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
