### PR TITLE
don't enlarge images

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5918,23 +5918,10 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 .post-thumbnail .wp-post-image {
 	display: block;
 	width: auto;
-	min-width: calc(100vw - 30px);
 	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 60px;
-}
-@media only screen and (min-width: 482px) {
-
-	.post-thumbnail .wp-post-image {
-		min-width: min(calc(100vw - 100px), 610px);
-	}
-}
-@media only screen and (min-width: 822px) {
-
-	.post-thumbnail .wp-post-image {
-		min-width: min(calc(100vw - 200px), 610px);
-	}
 }
 
 /**

--- a/assets/sass/06-components/entry.scss
+++ b/assets/sass/06-components/entry.scss
@@ -161,7 +161,6 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 	.wp-post-image {
 		display: block;
 		width: auto;
-		min-width: var(--responsive--aligndefault-width);
 		max-width: 100%;
 		margin-left: auto;
 		margin-right: auto;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -449,7 +449,7 @@ function twenty_twenty_one_get_attachment_image_attributes( $attr, $attachment, 
 
 		// Add style.
 		$attr['style'] = isset( $attr['style'] ) ? $attr['style'] : '';
-		$attr['style'] = 'width:100%;height:' . round( 100 * $height / $width, 2 ) . '%;' . $attr['style'];
+		$attr['style'] = 'width:100%;height:' . round( 100 * $height / $width, 2 ) . '%;max-width:' . $width . 'px;' . $attr['style'];
 	}
 
 	return $attr;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4177,7 +4177,6 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 .post-thumbnail .wp-post-image {
 	display: block;
 	width: auto;
-	min-width: var(--responsive--aligndefault-width);
 	max-width: 100%;
 	margin-right: auto;
 	margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -4197,7 +4197,6 @@ body:not(.single) .site-main > article:last-of-type .entry-footer {
 .post-thumbnail .wp-post-image {
 	display: block;
 	width: auto;
-	min-width: var(--responsive--aligndefault-width);
 	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
Fixes #563

If the image is small this PR doesn't force it to be the width of its container and instead it keeps its original size.

![Screenshot_2020-11-06 My Blog – Just another WordPress site](https://user-images.githubusercontent.com/588688/98349221-64613080-2022-11eb-9555-6a2c4fa85240.png)


![Screenshot_2020-11-06 My Blog – Page 3 – Just another WordPress site](https://user-images.githubusercontent.com/588688/98349236-6925e480-2022-11eb-922d-9c4e6d0ce2e1.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
