### PR TITLE
Update footer link colors on dark backgrounds

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5706,6 +5706,10 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
+.is-dark-theme .site-footer > .site-info a:focus {
+	color: #d1e4dd;
+}
+
 .singular .entry-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;
@@ -7075,6 +7079,10 @@ h1.page-title {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 	color: #28303d;
+}
+
+.is-dark-theme .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: #d1e4dd;
 }
 
 .footer-navigation-wrapper li .svg-icon {

--- a/assets/sass/06-components/footer-navigation.scss
+++ b/assets/sass/06-components/footer-navigation.scss
@@ -36,6 +36,16 @@
 				text-decoration-skip-ink: none;
 				color: var(--footer--color-link-hover);
 			}
+
+			&:focus {
+
+				.is-dark-theme & {
+
+					.svg-icon {
+						fill: var(--wp--style--color--link, var(--global--color-background));
+					}
+				}
+			}
 		}
 
 		.svg-icon {

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -47,9 +47,16 @@
 			color: var(--footer--color-link);
 		}
 
-		&:hover,
+		&:hover {
+			color: var(--footer--color-link-hover);
+		}
+
 		&:focus {
 			color: var(--footer--color-link-hover);
+
+			.is-dark-theme & {
+				color: var(--wp--style--color--link, var(--global--color-background));
+			}
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3987,9 +3987,16 @@ a.custom-logo-link {
 	color: var(--footer--color-link);
 }
 
-.site-footer > .site-info a:hover,
+.site-footer > .site-info a:hover {
+	color: var(--footer--color-link-hover);
+}
+
 .site-footer > .site-info a:focus {
 	color: var(--footer--color-link-hover);
+}
+
+.is-dark-theme .site-footer > .site-info a:focus {
+	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .singular .entry-header {
@@ -5090,6 +5097,10 @@ h1.page-title {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 	color: var(--footer--color-link-hover);
+}
+
+.is-dark-theme .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .footer-navigation-wrapper li .svg-icon {

--- a/style.css
+++ b/style.css
@@ -4007,9 +4007,16 @@ a.custom-logo-link {
 	color: var(--footer--color-link);
 }
 
-.site-footer > .site-info a:hover,
+.site-footer > .site-info a:hover {
+	color: var(--footer--color-link-hover);
+}
+
 .site-footer > .site-info a:focus {
 	color: var(--footer--color-link-hover);
+}
+
+.is-dark-theme .site-footer > .site-info a:focus {
+	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .singular .entry-header {
@@ -5126,6 +5133,10 @@ h1.page-title {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 	color: var(--footer--color-link-hover);
+}
+
+.is-dark-theme .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
 .footer-navigation-wrapper li .svg-icon {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/801

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Updates the text and icon color for focused links when a dark background is used. Does not affect dark mode.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Make sure that Dark Mode is off.
1. In the customizer, select a dark body background from the palette or with the color picker.
1. Add a menu with social media links to the footer menu.
1. View a page where the site title in the footer is linked, so not the front page.
1. Place focus on the social links
1. Place focus on the footer site title and credit links
1. Confirm that the text is readable
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before
![footer](https://user-images.githubusercontent.com/7422055/98356474-ed2c9c00-2023-11eb-990e-6e8875509e45.png)
After:
![footer-after](https://user-images.githubusercontent.com/7422055/98356471-ec940580-2023-11eb-855a-c53485916aa8.png)



## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
