### PR TITLE
Fix outline button background color

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -484,23 +484,13 @@ a:hover {
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link.has-background {
-	background: transparent !important;
+	border-color: #39414d;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:active {
-	color: #39414d;
-	outline-offset: -7px;
-	background: transparent;
-	outline: 2px dotted currentColor;
-	border: 3px solid currentColor;
-}
-
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
 .wp-block-button.is-style-outline .wp-block-button__link.has-background:hover {
-	color: #39414d;
 	outline-offset: -7px;
-	background: transparent;
 	outline: 2px dotted currentColor;
-	border: 3px solid currentColor;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link.has-text-color:active {
@@ -517,6 +507,17 @@ a:hover {
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: 3px solid currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color {
+	border-color: currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:hover {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+	border-color: currentColor;
 }
 
 .wp-block-button.is-style-squared {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2488,11 +2488,15 @@ input[type=reset]:hover {
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link {
-	background: transparent;
 	padding: 15px 30px;
 }
 
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
+	background: transparent;
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color) {
+	background: transparent;
 	color: #39414d;
 	border: 3px solid currentColor;
 }
@@ -2516,54 +2520,48 @@ input[type=reset]:hover {
 	color: #39414d;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background {
-	border: 3px solid currentColor;
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
-	border: 3px solid currentColor;
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:active {
-	outline-offset: -7px;
-	background: transparent;
-	outline: 2px dotted currentColor;
-	border: 3px solid currentColor;
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover {
-	outline-offset: -7px;
-	background: transparent;
-	outline: 2px dotted currentColor;
-	border: 3px solid currentColor;
-}
-
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
 .wp-block-button.is-style-outline .wp-block-button__link.has-background:focus {
 	outline-offset: -7px;
-	background: transparent;
 	outline: 2px dotted currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background) {
 	border: 3px solid currentColor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:active {
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):active {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: 3px solid currentColor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:hover {
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):hover {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: 3px solid currentColor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:focus {
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: 3px solid currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color {
+	border-color: currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:focus {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+	border-color: currentColor;
 }
 
 .wp-block-button .is-style-squared .wp-block-button__link {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -615,11 +615,15 @@ a:hover {
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link.has-background {
-	background: transparent !important;
+	border-color: var(--button--color-background);
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link.has-text-color:active,
 .wp-block-button.is-style-outline .wp-block-button__link.has-text-color:hover {
 	color: var(--button--color-background);
@@ -627,6 +631,17 @@ a:hover {
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: var(--button--border-width) solid currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color {
+	border-color: currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:hover {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+	border-color: currentColor;
 }
 
 .wp-block-button.is-style-squared {

--- a/assets/sass/05-blocks/button/_editor.scss
+++ b/assets/sass/05-blocks/button/_editor.scss
@@ -72,12 +72,16 @@
 				border: var(--button--border-width) solid var(--button--color-background);
 			}
 
-			// Override the editors inline background color for the outline button.
 			&.has-background {
-				background: transparent !important;
+				border-color: var(--button--color-background);
+
+				&:active,
+				&:hover {
+					outline-offset: -7px;
+					outline: 2px dotted currentColor;
+				}
 			}
 
-			&.has-background,
 			&.has-text-color {
 
 				&:active,
@@ -87,6 +91,17 @@
 					background: transparent;
 					outline: 2px dotted currentColor;
 					border: var(--button--border-width) solid currentColor;
+				}
+			}
+
+			&.has-background.has-text-color {
+				border-color: currentColor;
+
+				&:active,
+				&:hover {
+					outline-offset: -7px;
+					outline: 2px dotted currentColor;
+					border-color: currentColor;
 				}
 			}
 		}

--- a/assets/sass/05-blocks/button/_style.scss
+++ b/assets/sass/05-blocks/button/_style.scss
@@ -68,10 +68,14 @@ input[type="reset"],
 	&.is-style-outline {
 
 		.wp-block-button__link {
-			background: transparent;
 			padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
+			&:not(.has-background) {
+				background: transparent;
+			}
+
 			&:not(.has-background):not(.has-text-color) {
+				background: transparent;
 				color: var(--button--color-background);
 				border: var(--button--border-width) solid currentColor;
 
@@ -91,8 +95,17 @@ input[type="reset"],
 
 			}
 
-			&.has-background,
-			&.has-text-color {
+			&.has-background {
+
+				&:active,
+				&:hover,
+				&:focus {
+					outline-offset: -7px;
+					outline: 2px dotted currentColor;
+				}
+			}
+
+			&.has-text-color:not(.has-background) {
 				border: var(--button--border-width) solid currentColor;
 
 				&:active,
@@ -102,6 +115,18 @@ input[type="reset"],
 					background: transparent;
 					outline: 2px dotted currentColor;
 					border: var(--button--border-width) solid currentColor;
+				}
+			}
+
+			&.has-background.has-text-color {
+				border-color: currentColor;
+
+				&:active,
+				&:hover,
+				&:focus {
+					outline-offset: -7px;
+					outline: 2px dotted currentColor;
+					border-color: currentColor;
 				}
 			}
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1793,11 +1793,15 @@ input[type=reset]:hover,
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link {
-	background: transparent;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
+	background: transparent;
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color) {
+	background: transparent;
 	color: var(--button--color-background);
 	border: var(--button--border-width) solid currentColor;
 }
@@ -1816,21 +1820,36 @@ input[type=reset]:hover,
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:focus {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background) {
 	border: var(--button--border-width) solid currentColor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:focus,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:active,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:hover,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:focus {
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: var(--button--border-width) solid currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color {
+	border-color: currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:focus {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+	border-color: currentColor;
 }
 
 .wp-block-button .is-style-squared .wp-block-button__link {

--- a/style.css
+++ b/style.css
@@ -1803,11 +1803,15 @@ input[type=reset]:hover,
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link {
-	background: transparent;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
+	background: transparent;
+}
+
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color) {
+	background: transparent;
 	color: var(--button--color-background);
 	border: var(--button--border-width) solid currentColor;
 }
@@ -1826,21 +1830,36 @@ input[type=reset]:hover,
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background:focus {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background) {
 	border: var(--button--border-width) solid currentColor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:active,
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:hover,
-.wp-block-button.is-style-outline .wp-block-button__link.has-background:focus,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:active,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:hover,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:focus {
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color:not(.has-background):focus {
 	outline-offset: -7px;
 	background: transparent;
 	outline: 2px dotted currentColor;
 	border: var(--button--border-width) solid currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color {
+	border-color: currentColor;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:active,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:hover,
+.wp-block-button.is-style-outline .wp-block-button__link.has-background.has-text-color:focus {
+	outline-offset: -7px;
+	outline: 2px dotted currentColor;
+	border-color: currentColor;
 }
 
 .wp-block-button .is-style-squared .wp-block-button__link {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/804

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Assures that the custom background colors are visible depending on the block settings.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a button block.
1. Set the style to outline.
1. Add a background color.
1. Duplicate the button and add a text color and background color.
1. View the buttons colors in the editor. Test the default state and the hover.
1. Got to the front and view the buttons colors. Test the default state and the hover.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

![buttons](https://user-images.githubusercontent.com/7422055/98394199-ae660880-205a-11eb-84aa-e00b58771bed.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
