### PR TITLE
Dark Mode: Update border opacity

### DIFF
--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -8,6 +8,7 @@
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
 	--button--color-background-active: var(--global--color-background);
+	--global--color-border: #ffffff8c;
 }
 
 .is-dark-theme.is-dark-theme body {

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -8,6 +8,7 @@
 	--button--color-text-active: var(--global--color-secondary);
 	--button--color-background: var(--global--color-secondary);
 	--button--color-background-active: var(--global--color-background);
+	--global--color-border: #ffffff8c; //55% opacity
 
 	body {
 		background-color: var(--global--color-background);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/620

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Sets the opacity of the global border variable to 55% when dark mode is enabled.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Enabled dark mode
1. View the opacity and contrast of the borders and dividers.
1.

To test a different opacity you can use these codes:
https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4

<!-- Don't forget to test the unhappy-paths! -->


## Screenshots
![footer-border-after](https://user-images.githubusercontent.com/7422055/98432362-b3a86f00-20bd-11eb-803d-1a7d66dc60a7.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
