### PR TITLE
Update Dark Mode customizer text and instructions

### DIFF
--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -150,7 +150,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function customizer_controls( $wp_customize ) {
 
 		$colors_section = $wp_customize->get_section( 'colors' );
-		if ( null !== $colors_section ) {
+		if ( is_object( $colors_section ) ) {
 			$colors_section->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
 			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
 		}

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -149,9 +149,11 @@ class Twenty_Twenty_One_Dark_Mode {
 	 */
 	public function customizer_controls( $wp_customize ) {
 
-		$wp_customize->get_section( 'colors' )->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
-		$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
-
+		$colors_section = $wp_customize->get_section( 'colors' );
+		if ( $colors_section ) {
+			$wp_customize->get_section( 'colors' )->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
+			$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+		}
 
 		$wp_customize->add_setting(
 			'respect_user_color_preference',

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -150,7 +150,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function customizer_controls( $wp_customize ) {
 
 		$colors_section = $wp_customize->get_section( 'colors' );
-		if ( $colors_section ) {
+		if ( null !== $colors_section ) {
 			$colors_section->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
 			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
 		}

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -150,7 +150,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function customizer_controls( $wp_customize ) {
 
 		$wp_customize->get_section( 'colors' )->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
-		$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br>' . '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+		$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
 
 
 		$wp_customize->add_setting(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -151,8 +151,8 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		$colors_section = $wp_customize->get_section( 'colors' );
 		if ( $colors_section ) {
-			$wp_customize->get_section( 'colors' )->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
-			$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+			$colors_section->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
+			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
 		}
 
 		$wp_customize->add_setting(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -148,6 +148,11 @@ class Twenty_Twenty_One_Dark_Mode {
 	 * @return void
 	 */
 	public function customizer_controls( $wp_customize ) {
+
+		$wp_customize->get_section( 'colors' )->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
+		$wp_customize->get_section( 'colors' )->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br>' . '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+
+
 		$wp_customize->add_setting(
 			'respect_user_color_preference',
 			array(
@@ -165,8 +170,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				'type'            => 'checkbox',
 				'section'         => 'colors',
 				'label'           => esc_html__( 'Dark Mode Support', 'twentytwentyone' ),
-				'description'     => __( 'Respect visitor\'s device dark mode settings. <br>Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.<br><br>Dark Mode can also be turned on and off with a button.<br><br><a href="
-https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ),
+				'description'     => __( 'Respect visitor\'s device dark mode settings.<br>Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.<br><br>Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ),
 				'active_callback' => function( $value ) {
 					return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 				},


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
## Summary
<!-- Explain what you changed and why in one or two sentences. -->
The text is updated with the goal of:

1. Making the Dark Mode settings easier to find by renaming the color sections to Colors & Dark Mode.
1. Clarifying where the toggle button is placed (bottom right corner)
1. Clarifying that to use the Dark Mode settings, users can select a light body background color.
1.  Moves the link to the support page to the section description so that it is always available.

Also solves a PHPCS issue.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Visit the customizer.
1.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
![default-background](https://user-images.githubusercontent.com/7422055/98513938-ff4b4c00-2268-11eb-8e14-a3c26e13c6ab.png)


![dark-background](https://user-images.githubusercontent.com/7422055/98513836-cca15380-2268-11eb-8abf-4079ae87aec7.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
