### PR TITLE
Remove customizer notice

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -1,36 +1,11 @@
-/* global twentytwentyoneGetHexLum, backgroundColorNotice */
+/* global twentytwentyoneGetHexLum */
 
 ( function() {
-	/**
-	 * Add/remove the notice.
-	 *
-	 * @param {boolean} enable - Whether we want to enable or disable the notice.
-	 *
-	 * @return {void}
-	 */
-	function twentytwentyoneBackgroundColorNotice( enable ) {
-		if ( enable ) {
-			wp.customize( 'background_color' ).notifications.add( 'backgroundColorNotice', new wp.customize.Notification( 'backgroundColorNotice', {
-				type: 'info',
-				message: backgroundColorNotice.message
-			} ) );
-		} else {
-			wp.customize( 'background_color' ).notifications.remove( 'backgroundColorNotice' );
-		}
-	}
-
 	// Wait until the customizer has finished loading.
 	wp.customize.bind( 'ready', function() {
-		var supportsDarkMode = ( 127 <= twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) && wp.customize( 'respect_user_color_preference' ).get() );
-
 		// Hide the "respect_user_color_preference" setting if the background-color is dark.
 		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {
 			wp.customize.control( 'respect_user_color_preference' ).deactivate();
-		}
-
-		// Add notice on init if needed.
-		if ( wp.customize( 'respect_user_color_preference' ) ) {
-			twentytwentyoneBackgroundColorNotice( true );
 		}
 
 		// Handle changes to the background-color.
@@ -38,22 +13,8 @@
 			setting.bind( function( value ) {
 				if ( 127 > twentytwentyoneGetHexLum( value ) ) {
 					wp.customize.control( 'respect_user_color_preference' ).deactivate();
-					supportsDarkMode = false;
 				} else {
 					wp.customize.control( 'respect_user_color_preference' ).activate();
-					supportsDarkMode = wp.customize( 'respect_user_color_preference' ).get();
-				}
-			} );
-		} );
-
-		// Handle changes to the "respect_user_color_preference" setting.
-		wp.customize( 'respect_user_color_preference', function( setting ) {
-			setting.bind( function( value ) {
-				supportsDarkMode = value && 127 < twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() );
-				if ( ! supportsDarkMode ) {
-					twentytwentyoneBackgroundColorNotice( false );
-				} else {
-					twentytwentyoneBackgroundColorNotice( true );
 				}
 			} );
 		} );

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -126,14 +126,6 @@ class Twenty_Twenty_One_Dark_Mode {
 			'1.0.0',
 			true
 		);
-
-		wp_localize_script(
-			'twentytwentyone-customize-controls',
-			'backgroundColorNotice',
-			array(
-				'message' => esc_html__( 'Changes will only be visible if Dark Mode is "Off" in the preview.', 'twentytwentyone' ),
-			)
-		);
 	}
 
 	/**
@@ -153,6 +145,11 @@ class Twenty_Twenty_One_Dark_Mode {
 		if ( is_object( $colors_section ) ) {
 			$colors_section->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
 			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+		}
+
+		$background_color_control = $wp_customize->get_control( 'background_color' );
+		if ( is_object( $background_color_control ) ) {
+			$background_color_control->description = esc_html__( 'Selecting a dark background-color will disable the ability to switch between dark and light schemes', 'twentytwentyone' );
 		}
 
 		$wp_customize->add_setting(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -147,11 +147,6 @@ class Twenty_Twenty_One_Dark_Mode {
 			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
 		}
 
-		$background_color_control = $wp_customize->get_control( 'background_color' );
-		if ( is_object( $background_color_control ) ) {
-			$background_color_control->description = esc_html__( 'Selecting a dark background-color will disable the ability to switch between dark and light schemes', 'twentytwentyone' );
-		}
-
 		$wp_customize->add_setting(
 			'respect_user_color_preference',
 			array(


### PR DESCRIPTION
Reported in Friday's test-scrub. The notice was confusing and it wasn't clear what happens when the background-color changes to dark. This PR Removes the notice. Combined with the description that was added to the section earlier today the notice is no longer necessary.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
