### PR TITLE
Show dark-mode toggler when scrolling to the very bottom of the page

### DIFF
--- a/assets/js/dark-mode-toggler.js
+++ b/assets/js/dark-mode-toggler.js
@@ -46,12 +46,13 @@ function darkModeRepositionTogglerOnScroll() {
 
 		checkScroll = function() {
 			currentScroll = window.scrollY || document.documentElement.scrollTop;
-			if ( currentScroll > prevScroll ) {
-				if ( 250 < currentScroll ) {
-					document.getElementById( 'dark-mode-toggler' ).classList.add( 'hide' );
-				}
-			} else if ( currentScroll < prevScroll ) {
+			if (
+				currentScroll + ( window.innerHeight * 1.5 ) > document.body.clientHeight ||
+				currentScroll < prevScroll
+			) {
 				document.getElementById( 'dark-mode-toggler' ).classList.remove( 'hide' );
+			} else if ( currentScroll > prevScroll && 250 < currentScroll ) {
+				document.getElementById( 'dark-mode-toggler' ).classList.add( 'hide' );
 			}
 			prevScroll = currentScroll;
 		};


### PR DESCRIPTION
Came up in Friday's test-scrub.
When the visitor scrolls-down to the very bottom of the page, the toggler should appear and not require a scroll-up.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
