### PR TITLE
Add padding-bottom for mobile menus

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6698,6 +6698,10 @@ h1.page-title {
 }
 @media only screen and (max-width: 481px) {
 
+	.primary-navigation > div > .menu-wrapper {
+		padding-bottom: 100px;
+	}
+
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-left: 0;
 	}

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -206,6 +206,7 @@
 		position: relative;
 
 		@include media(mobile-only) {
+			padding-bottom: 100px;
 
 			ul {
 				padding-left: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4771,6 +4771,10 @@ h1.page-title {
 }
 @media only screen and (max-width: 481px) {
 
+	.primary-navigation > div > .menu-wrapper {
+		padding-bottom: 100px;
+	}
+
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-right: 0;
 	}

--- a/style.css
+++ b/style.css
@@ -4791,6 +4791,10 @@ h1.page-title {
 }
 @media only screen and (max-width: 481px) {
 
+	.primary-navigation > div > .menu-wrapper {
+		padding-bottom: 100px;
+	}
+
 	.primary-navigation > div > .menu-wrapper ul {
 		padding-left: 0;
 	}


### PR DESCRIPTION
Fixes #821 

This PR adds a `100px` bottom padding to the menu wrapper on mobiles. This is to take into account the height of bottom navbars that mobile devices have. Most are around 80px, so 100 seems like a reasonable value to use and avoid issues across all devices.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
