### PR TITLE
Update menu callback and container to false

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -28,11 +28,11 @@
 						array(
 							'theme_location' => 'footer',
 							'items_wrap'     => '%3$s',
-							'container'      => 'false',
+							'container'      => false,
 							'depth'          => 1,
 							'link_before'    => '<span>',
 							'link_after'     => '</span>',
-							'fallback_cb'    => 'false',
+							'fallback_cb'    => false,
 						)
 					);
 					?>

--- a/template-parts/header/site-nav.php
+++ b/template-parts/header/site-nav.php
@@ -28,7 +28,7 @@
 				'menu_class'      => 'menu-wrapper',
 				'container_class' => 'primary-menu-container',
 				'items_wrap'      => '<ul id="primary-menu-list" class="%2$s">%3$s</ul>',
-				'fallback_cb'     => 'false',
+				'fallback_cb'     => false,
 			)
 		);
 		?>


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/pull/771#issuecomment-724166454

props @sabernhardt

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Change `'false'` to `false`

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add menus to the primary and secondary locations
1. Confirm that the menus still work
1.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
