### PR TITLE
Remove is_singular() from single.php

### DIFF
--- a/single.php
+++ b/single.php
@@ -17,7 +17,7 @@ while ( have_posts() ) :
 
 	get_template_part( 'template-parts/content/content-single' );
 
-	if ( is_singular( 'attachment' ) ) {
+	if ( is_attachment() ) {
 		// Parent post navigation.
 		the_post_navigation(
 			array(
@@ -32,35 +32,32 @@ while ( have_posts() ) :
 		comments_template();
 	}
 
-	if ( is_singular() ) {
-		// Previous/next post navigation.
-		$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
-		$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
+	// Previous/next post navigation.
+	$twentytwentyone_next = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' );
+	$twentytwentyone_prev = is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' );
 
-		$twentytwentyone_post_type      = get_post_type_object( get_post_type() );
-		$twentytwentyone_post_type_name = '';
-		if (
-			is_object( $twentytwentyone_post_type ) &&
-			property_exists( $twentytwentyone_post_type, 'labels' ) &&
-			is_object( $twentytwentyone_post_type->labels ) &&
-			property_exists( $twentytwentyone_post_type->labels, 'singular_name' )
-		) {
-			$twentytwentyone_post_type_name = $twentytwentyone_post_type->labels->singular_name;
-		}
-
-		/* translators: %s: The post-type singlular name (example: Post, Page etc) */
-		$twentytwentyone_next_label = sprintf( esc_html__( 'Next %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
-		/* translators: %s: The post-type singlular name (example: Post, Page etc) */
-		$twentytwentyone_previous_label = sprintf( esc_html__( 'Previous %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
-
-		the_post_navigation(
-			array(
-				'next_text' => '<p class="meta-nav">' . $twentytwentyone_next_label . $twentytwentyone_next . '</p><p class="post-title">%title</p>',
-				'prev_text' => '<p class="meta-nav">' . $twentytwentyone_prev . $twentytwentyone_previous_label . '</p><p class="post-title">%title</p>',
-			)
-		);
+	$twentytwentyone_post_type      = get_post_type_object( get_post_type() );
+	$twentytwentyone_post_type_name = '';
+	if (
+		is_object( $twentytwentyone_post_type ) &&
+		property_exists( $twentytwentyone_post_type, 'labels' ) &&
+		is_object( $twentytwentyone_post_type->labels ) &&
+		property_exists( $twentytwentyone_post_type->labels, 'singular_name' )
+	) {
+		$twentytwentyone_post_type_name = $twentytwentyone_post_type->labels->singular_name;
 	}
 
+	/* translators: %s: The post-type singlular name (example: Post, Page etc) */
+	$twentytwentyone_next_label = sprintf( esc_html__( 'Next %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
+	/* translators: %s: The post-type singlular name (example: Post, Page etc) */
+	$twentytwentyone_previous_label = sprintf( esc_html__( 'Previous %s', 'twentytwentyone' ), $twentytwentyone_post_type_name );
+
+	the_post_navigation(
+		array(
+			'next_text' => '<p class="meta-nav">' . $twentytwentyone_next_label . $twentytwentyone_next . '</p><p class="post-title">%title</p>',
+			'prev_text' => '<p class="meta-nav">' . $twentytwentyone_prev . $twentytwentyone_previous_label . '</p><p class="post-title">%title</p>',
+		)
+	);
 endwhile; // End of the loop.
 
 get_footer();


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->

Fixes https://github.com/WordPress/twentytwentyone/commit/296f25d7dbbb6314c8e19b12d6535e0d0a37f754#r43839910
props @joyously

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Removes is_singular() from single.php

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View a single post and confirm that the navigation still works
1. View an attachment page and confirm that _Published in_ is present if the attachment is part of a gallery
1.
<!-- Don't forget to test the unhappy-paths! -->

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
