### PR TITLE
Update the privacy policy content

### DIFF
--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom Colors Class
+ * Dark Mode Class
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_One
@@ -8,7 +8,7 @@
  */
 
 /**
- * This class is in charge of color customization via the Customizer.
+ * This class is in charge of Dark Mode.
  */
 class Twenty_Twenty_One_Dark_Mode {
 
@@ -44,6 +44,9 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		// Add the switch in the editor.
 		add_action( 'wp_ajax_tt1_dark_mode_editor_switch', array( $this, 'editor_ajax_callback' ) );
+
+		// Add the privacy policy content.
+		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
 	}
 
 	/**
@@ -385,4 +388,24 @@ class Twenty_Twenty_One_Dark_Mode {
 		$this->the_styles();
 		wp_die();
 	}
+
+	/**
+	 * Adds information to the privacy policy.
+	 *
+	 * @access public
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function add_privacy_policy_content() {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+		$content = '<p class="privacy-policy-tutorial">' . __( 'Twenty Twenty-One uses LocalStorage when Dark Mode support is enabled.', 'twentytwentyone' ) . '</p>'
+				. '<strong class="privacy-policy-tutorial">' . __( 'Suggested Text:', 'twentytwentyone' ) . '</strong> '
+				. __( 'This website uses LocalStorage to save the setting when Dark Mode support is turned on or off.<br> LocalStorage is necessary for the setting to work and is only used when a user clicks on the Dark Mode button.<br> No data is saved in the database or transferred.', 'twentytwentyone' );
+		wp_add_privacy_policy_content( 'Twenty Twenty-One', wp_kses_post( wpautop( $content, false ) ) );
+	}
+
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/820

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Adds information about LocalStorage to the privacy policy guide,

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
I placed this in _twentytwentyone\classes\class-twenty-twenty-one-dark-mode.php_  to keep the Dark Mode functionality in the same file.

## Test instructions

This PR can be tested by following these steps:
1. In the WordPress admin, open the Privacy page  from the Settings menu.
1. Click on the link "Check out our guide".
1. Scroll down to the headline with the theme name.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
![Privacy Policy guide](https://user-images.githubusercontent.com/7422055/98650909-d941ac80-2339-11eb-9bd5-a436eb3a4e77.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
