### PR TITLE
Hide "Posts" in post pagination on small screens

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7342,6 +7342,13 @@ h1.page-title {
 		flex: 0 1 auto;
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.pagination .nav-short,
+	.comments-pagination .nav-short {
+		display: none;
+	}
+}
 
 .comments-pagination {
 	padding-top: 20px;

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -206,6 +206,13 @@
 			}
 		}
 	}
+
+	@include media(mobile-only) {
+
+		.nav-short {
+			display: none;
+		}
+	}
 }
 
 // Comments pagination

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -225,11 +225,11 @@ if ( ! function_exists( 'twenty_twenty_one_the_posts_navigation' ) ) {
 				'prev_text'          => sprintf(
 					'%s <span class="nav-prev-text">%s</span>',
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ),
-					esc_html__( 'Newer posts', 'twentytwentyone' )
+					__( 'Newer <span class="nav-short">Posts</span>', 'twentytwentyone' )
 				),
 				'next_text'          => sprintf(
 					'<span class="nav-next-text">%s</span> %s',
-					esc_html__( 'Older posts', 'twentytwentyone' ),
+					__( 'Older <span class="nav-short">Posts</span>', 'twentytwentyone' ),
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
 				),
 			)

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -217,6 +217,17 @@ if ( ! function_exists( 'twenty_twenty_one_the_posts_navigation' ) ) {
 	 * @return void
 	 */
 	function twenty_twenty_one_the_posts_navigation() {
+		$post_type      = get_post_type_object( get_post_type() );
+		$post_type_name = '';
+		if (
+			is_object( $post_type ) &&
+			property_exists( $post_type, 'labels' ) &&
+			is_object( $post_type->labels ) &&
+			property_exists( $post_type->labels, 'name' )
+		) {
+			$post_type_name = $post_type->labels->name;
+		}
+
 		the_posts_pagination(
 			array(
 				/* translators: There is a space after page. */
@@ -225,11 +236,19 @@ if ( ! function_exists( 'twenty_twenty_one_the_posts_navigation' ) ) {
 				'prev_text'          => sprintf(
 					'%s <span class="nav-prev-text">%s</span>',
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ),
-					__( 'Newer <span class="nav-short">Posts</span>', 'twentytwentyone' )
+					sprintf(
+						/* translators: %s: The post-type name. */
+						esc_html__( 'Newer %s', 'twentytwentyone' ),
+						'<span class="nav-short">' . esc_html( $post_type_name ) . '</span>'
+					)
 				),
 				'next_text'          => sprintf(
 					'<span class="nav-next-text">%s</span> %s',
-					__( 'Older <span class="nav-short">Posts</span>', 'twentytwentyone' ),
+					sprintf(
+						/* translators: %s: The post-type name. */
+						esc_html__( 'Older %s', 'twentytwentyone' ),
+						'<span class="nav-short">' . esc_html( $post_type_name ) . '</span>'
+					),
 					is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' )
 				),
 			)

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5346,6 +5346,13 @@ h1.page-title {
 		flex: 0 1 auto;
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.pagination .nav-short,
+	.comments-pagination .nav-short {
+		display: none;
+	}
+}
 
 .comments-pagination {
 	padding-top: calc(0.66 * var(--global--spacing-vertical));

--- a/style.css
+++ b/style.css
@@ -5382,6 +5382,13 @@ h1.page-title {
 		flex: 0 1 auto;
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.pagination .nav-short,
+	.comments-pagination .nav-short {
+		display: none;
+	}
+}
 
 .comments-pagination {
 	padding-top: calc(0.66 * var(--global--spacing-vertical));


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/541

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Places to word "Posts" inside a `<span>`, and hides the content of the span on `mobile-only`

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->
Unfortunately this means that the translation will include HTML.

_All the credit to Twenty Twenty 🎉_ 

## Test instructions

This PR can be tested by following these steps:
1. View an archive page with pagination
1. Reduce the screen width
1. See that the word "Posts" is hidden.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

If this is a visual change please include screenshots of the change at various screen sizes.

Browser window resize from small to larger:

![mobile-post-pagination](https://user-images.githubusercontent.com/7422055/98802394-8e946300-2413-11eb-9cdf-c6ffca6e5dfa.gif)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
