### PR TITLE
Quote & Pullquote block: Update symbol position

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -206,6 +206,8 @@ blockquote:before {
 	content: "“";
 	font-size: 1.25rem;
 	line-height: 1.7;
+	position: absolute;
+	left: -12px;
 }
 
 blockquote .wp-block-quote__citation {
@@ -1789,6 +1791,8 @@ pre.wp-block-preformatted {
 	color: currentColor;
 	content: "“";
 	display: block;
+	position: relative;
+	left: 0;
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
@@ -1914,7 +1918,6 @@ pre.wp-block-preformatted {
 	content: "“";
 	font-size: 1.25rem;
 	line-height: 1.7;
-	position: absolute;
 	left: -12px;
 }
 
@@ -3121,9 +3124,6 @@ pre.wp-block-verse {
 	color: #28303d;
 }
 
-/**
- * Spacing Overrides
- */
 [data-block] {
 	margin-top: 30px;
 	margin-bottom: 30px;
@@ -3137,16 +3137,17 @@ pre.wp-block-verse {
 	margin-bottom: 0;
 }
 
-/* Block Alignments */
 .wp-block {
 	max-width: calc(100vw - 30px);
 }
+
 @media only screen and (min-width: 482px) {
 
 	.wp-block {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
+
 @media only screen and (min-width: 822px) {
 
 	.wp-block {
@@ -3230,6 +3231,14 @@ pre.wp-block-verse {
 		max-width: 290px;
 		margin-left: 25px;
 	}
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+	border: none;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote:before {
+	left: 5px;
 }
 
 html {

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1938,9 +1938,15 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote.has-text-align-right:before {
+	display: none;
+}
+
+.wp-block-quote.has-text-align-right p:before {
 	content: "”";
-	left: initial;
-	right: -12px;
+	font-size: 1.25rem;
+	font-weight: normal;
+	line-height: 1.7;
+	margin-right: 5px;
 }
 
 .wp-block-quote.has-text-align-center {
@@ -2015,14 +2021,37 @@ pre.wp-block-preformatted {
 	}
 }
 
-.wp-block-quote.is-large.has-text-align-right:before {
-	left: initial;
-	right: -25px;
+.wp-block-quote.is-large.has-text-align-right:before,
+.wp-block-quote.is-style-large.has-text-align-right:before {
+	display: none;
 }
 
-.wp-block-quote.is-style-large.has-text-align-right:before {
-	left: initial;
-	right: -25px;
+.wp-block-quote.is-large.has-text-align-right p:before {
+	content: "”";
+	font-size: 2.25rem;
+	font-weight: normal;
+	line-height: 1.35;
+	margin-right: 10px;
+}
+@media only screen and (min-width: 652px) {
+
+	.wp-block-quote.is-large.has-text-align-right p:before {
+		font-size: 2.5rem;
+	}
+}
+
+.wp-block-quote.is-style-large.has-text-align-right p:before {
+	content: "”";
+	font-size: 2.25rem;
+	font-weight: normal;
+	line-height: 1.35;
+	margin-right: 10px;
+}
+@media only screen and (min-width: 652px) {
+
+	.wp-block-quote.is-style-large.has-text-align-right p:before {
+		font-size: 2.5rem;
+	}
 }
 @media only screen and (max-width: 481px) {
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4269,9 +4269,15 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote.has-text-align-right:before {
+	display: none;
+}
+
+.wp-block-quote.has-text-align-right p:before {
 	content: "”";
-	left: initial;
-	right: -12px;
+	font-size: 1.25rem;
+	font-weight: normal;
+	line-height: 1.7;
+	margin-right: 5px;
 }
 
 .wp-block-quote.has-text-align-center {
@@ -4348,14 +4354,37 @@ pre.wp-block-preformatted {
 	}
 }
 
-.wp-block-quote.is-large.has-text-align-right:before {
-	left: initial;
-	right: -25px;
+.wp-block-quote.is-large.has-text-align-right:before,
+.wp-block-quote.is-style-large.has-text-align-right:before {
+	display: none;
 }
 
-.wp-block-quote.is-style-large.has-text-align-right:before {
-	left: initial;
-	right: -25px;
+.wp-block-quote.is-large.has-text-align-right p:before {
+	content: "”";
+	font-size: 2.25rem;
+	font-weight: normal;
+	line-height: 1.35;
+	margin-right: 10px;
+}
+@media only screen and (min-width: 652px) {
+
+	.wp-block-quote.is-large.has-text-align-right p:before {
+		font-size: 2.5rem;
+	}
+}
+
+.wp-block-quote.is-style-large.has-text-align-right p:before {
+	content: "”";
+	font-size: 2.25rem;
+	font-weight: normal;
+	line-height: 1.35;
+	margin-right: 10px;
+}
+@media only screen and (min-width: 652px) {
+
+	.wp-block-quote.is-style-large.has-text-align-right p:before {
+		font-size: 2.5rem;
+	}
 }
 
 .wp-block-quote.is-large .wp-block-quote__citation {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1436,6 +1436,8 @@ blockquote:before {
 	content: "“";
 	font-size: 1.25rem;
 	line-height: 1.7;
+	position: absolute;
+	left: -12px;
 }
 
 blockquote .wp-block-quote__citation {
@@ -4103,6 +4105,8 @@ pre.wp-block-preformatted {
 	color: currentColor;
 	content: "“";
 	display: block;
+	position: relative;
+	left: 0;
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
@@ -4251,8 +4255,7 @@ pre.wp-block-preformatted {
 	content: "“";
 	font-size: 1.25rem;
 	line-height: 1.7;
-	position: absolute;
-	left: 13px;
+	left: 8px;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4247,6 +4247,14 @@ pre.wp-block-preformatted {
    */
 }
 
+.wp-block-quote:before {
+	content: "“";
+	font-size: 1.25rem;
+	line-height: 1.7;
+	position: absolute;
+	left: 13px;
+}
+
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4240,6 +4240,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote {
+	border-left: none;
 
 	/**
    * Block Options

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -374,6 +374,8 @@ blockquote:before {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
+	position: absolute;
+	left: calc(-0.5 * var(--global--spacing-horizontal));
 }
 
 blockquote .wp-block-quote__citation,
@@ -1377,6 +1379,8 @@ pre.wp-block-preformatted {
 	color: currentColor;
 	content: "“";
 	display: block;
+	position: relative;
+	left: 0;
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
@@ -1475,7 +1479,6 @@ pre.wp-block-preformatted {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
-	position: absolute;
 	left: calc(-0.5 * var(--global--spacing-horizontal));
 }
 
@@ -2223,9 +2226,6 @@ pre.wp-block-verse {
 	color: var(--global--color-primary);
 }
 
-/**
- * Spacing Overrides
- */
 [data-block] {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
@@ -2239,7 +2239,6 @@ pre.wp-block-verse {
 	margin-bottom: 0;
 }
 
-/* Block Alignments */
 .wp-block {
 	max-width: var(--responsive--aligndefault-width);
 }
@@ -2286,6 +2285,14 @@ pre.wp-block-verse {
 		max-width: 290px;
 		margin-left: var(--global--spacing-horizontal);
 	}
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+	border: none;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote:before {
+	left: 5px;
 }
 
 html {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1499,9 +1499,15 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote.has-text-align-right:before {
+	display: none;
+}
+
+.wp-block-quote.has-text-align-right p:before {
 	content: "”";
-	left: initial;
-	right: calc(-0.5 * var(--global--spacing-horizontal));
+	font-size: var(--quote--font-size);
+	font-weight: normal;
+	line-height: var(--quote--line-height);
+	margin-right: 5px;
 }
 
 .wp-block-quote.has-text-align-center {
@@ -1537,8 +1543,16 @@ pre.wp-block-preformatted {
 
 .wp-block-quote.is-large.has-text-align-right:before,
 .wp-block-quote.is-style-large.has-text-align-right:before {
-	left: initial;
-	right: calc(-1 * var(--global--spacing-horizontal));
+	display: none;
+}
+
+.wp-block-quote.is-large.has-text-align-right p:before,
+.wp-block-quote.is-style-large.has-text-align-right p:before {
+	content: "”";
+	font-size: var(--quote--font-size-large);
+	font-weight: normal;
+	line-height: var(--quote--line-height-large);
+	margin-right: 10px;
 }
 @media only screen and (max-width: 481px) {
 

--- a/assets/sass/04-elements/blockquote.scss
+++ b/assets/sass/04-elements/blockquote.scss
@@ -59,6 +59,8 @@ blockquote {
 		content: "\201C";
 		font-size: var(--quote--font-size);
 		line-height: var(--quote--line-height);
+		position: absolute;
+		left: calc(-0.5 * var(--global--spacing-horizontal));
 	}
 
 	.wp-block-quote__citation,

--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -12,6 +12,8 @@
 		color: currentColor;
 		content: "\201C";
 		display: block;
+		position: relative; // Override the absolute position.
+		left: 0;
 		font-size: 3rem;
 		font-weight: 500;
 		line-height: 1;

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -10,6 +10,8 @@
 		color: currentColor;
 		content: "\201C";
 		display: block;
+		position: relative; // Override the absolute position.
+		left: 0;
 		font-size: 3rem;
 		font-weight: 500;
 		line-height: 1;

--- a/assets/sass/05-blocks/quote/_editor.scss
+++ b/assets/sass/05-blocks/quote/_editor.scss
@@ -19,7 +19,6 @@
 		content: "\201C";
 		font-size: var(--quote--font-size);
 		line-height: var(--quote--line-height);
-		position: absolute;
 		left: calc(-0.5 * var(--global--spacing-horizontal));
 	}
 

--- a/assets/sass/05-blocks/quote/_editor.scss
+++ b/assets/sass/05-blocks/quote/_editor.scss
@@ -41,10 +41,17 @@
 		padding-right: 0;
 		border-right: none;
 
+		// Hide the left aligned quote.
 		&:before {
+			display: none;
+		}
+		// Align the quote left of the text.
+		p:before {
 			content: "\201D";
-			left: initial;
-			right: calc(-0.5 * var(--global--spacing-horizontal));
+			font-size: var(--quote--font-size);
+			font-weight: normal;
+			line-height: var(--quote--line-height);
+			margin-right: 5px;
 		}
 	}
 
@@ -78,10 +85,19 @@
 
 		&.has-text-align-right {
 
+			// Hide the left aligned quote.
 			&:before {
-				left: initial;
-				right: calc(-1 * var(--global--spacing-horizontal));
+				display: none;
 			}
+			// Align the quote left of the text.
+			p:before {
+				content: "\201D";
+				font-size: var(--quote--font-size-large);
+				font-weight: normal;
+				line-height: var(--quote--line-height-large);
+				margin-right: 10px;
+			}
+
 		}
 
 		@include media(mobile-only) {

--- a/assets/sass/05-blocks/quote/_editor.scss
+++ b/assets/sass/05-blocks/quote/_editor.scss
@@ -45,6 +45,7 @@
 		&:before {
 			display: none;
 		}
+
 		// Align the quote left of the text.
 		p:before {
 			content: "\201D";
@@ -89,6 +90,7 @@
 			&:before {
 				display: none;
 			}
+
 			// Align the quote left of the text.
 			p:before {
 				content: "\201D";
@@ -97,7 +99,6 @@
 				line-height: var(--quote--line-height-large);
 				margin-right: 10px;
 			}
-
 		}
 
 		@include media(mobile-only) {

--- a/assets/sass/05-blocks/quote/_style.scss
+++ b/assets/sass/05-blocks/quote/_style.scss
@@ -21,10 +21,18 @@
 		padding-right: 0;
 		border-right: none;
 
+		// Hide the left aligned quote.
 		&:before {
+			display: none;
+		}
+
+		// Align the quote left of the text.
+		p:before {
 			content: "\201D";
-			left: initial;
-			right: calc(-0.5 * var(--global--spacing-horizontal));
+			font-size: var(--quote--font-size);
+			font-weight: normal;
+			line-height: var(--quote--line-height);
+			margin-right: 5px;
 		}
 	}
 
@@ -59,9 +67,18 @@
 
 		&.has-text-align-right {
 
+			// Hide the left aligned quote.
 			&:before {
-				left: initial;
-				right: calc(-1 * var(--global--spacing-horizontal));
+				display: none;
+			}
+
+			// Align the quote left of the text.
+			p:before {
+				content: "\201D";
+				font-size: var(--quote--font-size-large);
+				font-weight: normal;
+				line-height: var(--quote--line-height-large);
+				margin-right: 10px;
 			}
 		}
 

--- a/assets/sass/05-blocks/quote/_style.scss
+++ b/assets/sass/05-blocks/quote/_style.scss
@@ -1,4 +1,5 @@
 .wp-block-quote {
+	border-left: none;
 
 	.wp-block-quote__citation,
 	cite,

--- a/assets/sass/05-blocks/quote/_style.scss
+++ b/assets/sass/05-blocks/quote/_style.scss
@@ -5,7 +5,6 @@
 		content: "\201C";
 		font-size: var(--quote--font-size);
 		line-height: var(--quote--line-height);
-		position: absolute;
 		left: 8px;
 	}
 

--- a/assets/sass/05-blocks/quote/_style.scss
+++ b/assets/sass/05-blocks/quote/_style.scss
@@ -1,6 +1,14 @@
 .wp-block-quote {
 	border-left: none;
 
+	&:before {
+		content: "\201C";
+		font-size: var(--quote--font-size);
+		line-height: var(--quote--line-height);
+		position: absolute;
+		left: 8px;
+	}
+
 	.wp-block-quote__citation,
 	cite,
 	footer {

--- a/assets/sass/05-blocks/utilities/_editor.scss
+++ b/assets/sass/05-blocks/utilities/_editor.scss
@@ -26,7 +26,6 @@
 }
 
 // Gutenberg text color options
-
 .has-primary-color[class] {
 	color: var(--global--color-primary);
 }
@@ -70,10 +69,7 @@
 	color: var(--global--color-primary);
 }
 
-/**
- * Spacing Overrides
- */
-
+// Spacing Overrides
 [data-block] {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
@@ -88,7 +84,7 @@
 	}
 }
 
-/* Block Alignments */
+// Block Alignments
 .wp-block {
 
 	// Gutenberg injects a rule that limits the max width of .wp-block to 580px
@@ -140,4 +136,14 @@
 		max-width: 290px;
 		margin-left: var(--global--spacing-horizontal);
 	}
+}
+
+// Remove the border of blockquotes inside the classic block.
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+	border: none;
+}
+
+// Adjust the position of the quote symbol for blockquotes inside the classic block.
+.wp-block-freeform.block-library-rich-text__tinymce blockquote:before {
+	left: 5px;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3041,9 +3041,15 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote.has-text-align-right:before {
+	display: none;
+}
+
+.wp-block-quote.has-text-align-right p:before {
 	content: "”";
-	right: initial;
-	left: calc(-0.5 * var(--global--spacing-horizontal));
+	font-size: var(--quote--font-size);
+	font-weight: normal;
+	line-height: var(--quote--line-height);
+	margin-left: 5px;
 }
 
 .wp-block-quote.has-text-align-center {
@@ -3080,8 +3086,16 @@ pre.wp-block-preformatted {
 
 .wp-block-quote.is-large.has-text-align-right:before,
 .wp-block-quote.is-style-large.has-text-align-right:before {
-	right: initial;
-	left: calc(-1 * var(--global--spacing-horizontal));
+	display: none;
+}
+
+.wp-block-quote.is-large.has-text-align-right p:before,
+.wp-block-quote.is-style-large.has-text-align-right p:before {
+	content: "”";
+	font-size: var(--quote--font-size-large);
+	font-weight: normal;
+	line-height: var(--quote--line-height-large);
+	margin-left: 10px;
 }
 
 .wp-block-quote.is-large .wp-block-quote__citation,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1174,6 +1174,8 @@ blockquote:before {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
+	position: absolute;
+	right: calc(-0.5 * var(--global--spacing-horizontal));
 }
 
 blockquote .wp-block-quote__citation,
@@ -2931,6 +2933,8 @@ pre.wp-block-preformatted {
 	color: currentColor;
 	content: "“";
 	display: block;
+	position: relative;
+	right: 0;
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
@@ -3023,8 +3027,7 @@ pre.wp-block-preformatted {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
-	position: absolute;
-	right: 13px;
+	right: 8px;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3012,6 +3012,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote {
+	border-right: none;
 
 	/**
    * Block Options

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3019,6 +3019,14 @@ pre.wp-block-preformatted {
    */
 }
 
+.wp-block-quote:before {
+	content: "“";
+	font-size: var(--quote--font-size);
+	line-height: var(--quote--line-height);
+	position: absolute;
+	right: 13px;
+}
+
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,

--- a/style.css
+++ b/style.css
@@ -3029,6 +3029,14 @@ pre.wp-block-preformatted {
    */
 }
 
+.wp-block-quote:before {
+	content: "“";
+	font-size: var(--quote--font-size);
+	line-height: var(--quote--line-height);
+	position: absolute;
+	left: 13px;
+}
+
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,

--- a/style.css
+++ b/style.css
@@ -3022,6 +3022,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote {
+	border-left: none;
 
 	/**
    * Block Options

--- a/style.css
+++ b/style.css
@@ -3051,9 +3051,15 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-quote.has-text-align-right:before {
+	display: none;
+}
+
+.wp-block-quote.has-text-align-right p:before {
 	content: "”";
-	left: initial;
-	right: calc(-0.5 * var(--global--spacing-horizontal));
+	font-size: var(--quote--font-size);
+	font-weight: normal;
+	line-height: var(--quote--line-height);
+	margin-right: 5px;
 }
 
 .wp-block-quote.has-text-align-center {
@@ -3090,8 +3096,16 @@ pre.wp-block-preformatted {
 
 .wp-block-quote.is-large.has-text-align-right:before,
 .wp-block-quote.is-style-large.has-text-align-right:before {
-	left: initial;
-	right: calc(-1 * var(--global--spacing-horizontal));
+	display: none;
+}
+
+.wp-block-quote.is-large.has-text-align-right p:before,
+.wp-block-quote.is-style-large.has-text-align-right p:before {
+	content: "”";
+	font-size: var(--quote--font-size-large);
+	font-weight: normal;
+	line-height: var(--quote--line-height-large);
+	margin-right: 10px;
 }
 
 .wp-block-quote.is-large .wp-block-quote__citation,

--- a/style.css
+++ b/style.css
@@ -1182,6 +1182,8 @@ blockquote:before {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
+	position: absolute;
+	left: calc(-0.5 * var(--global--spacing-horizontal));
 }
 
 blockquote .wp-block-quote__citation,
@@ -2941,6 +2943,8 @@ pre.wp-block-preformatted {
 	color: currentColor;
 	content: "“";
 	display: block;
+	position: relative;
+	left: 0;
 	font-size: 3rem;
 	font-weight: 500;
 	line-height: 1;
@@ -3033,8 +3037,7 @@ pre.wp-block-preformatted {
 	content: "“";
 	font-size: var(--quote--font-size);
 	line-height: var(--quote--line-height);
-	position: absolute;
-	left: 13px;
+	left: 8px;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Partial fix for https://github.com/WordPress/twentytwentyone/issues/549
Fixes https://github.com/WordPress/twentytwentyone/issues/835

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
When the quote block has right aligned text:
Hides the original, left aligned quote symbol.
Places a new quote symbol left of the text itself.
Resets the absolute position for the pullquote block so that the symbol is above the text.

https://github.com/WordPress/twentytwentyone/pull/832/commits/c1bf9a9df209b2bc674755d203ba70f45e37bb45 Fixes the position of the symbol on the front when the text has the default alignment.


Also: Removes the left border that is visible on the default quote on the front.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add two quotes blocks.
1. Align one of quotes to the right.
1. Confirm that the default block and the right aligned block matches, except the text is right aligned.

<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Editor:
Before
![quote-editor](https://user-images.githubusercontent.com/7422055/98809725-58101580-241e-11eb-91fd-f64f6a9bed30.png)

After
![quote-editor-after](https://user-images.githubusercontent.com/7422055/98809711-50507100-241e-11eb-8f69-4bc5c34c13e9.png)

---
Front:
Before
![quote-front](https://user-images.githubusercontent.com/7422055/98813143-05d1f300-2424-11eb-915c-1c78b31dcc95.png)

After:
![quote-front-after](https://user-images.githubusercontent.com/7422055/98813394-5fd2b880-2424-11eb-800e-084d9daee939.png)

----

It does not fix the position of the symbol for "classic" quotes:
![classic-quote-front](https://user-images.githubusercontent.com/7422055/98814172-9bba4d80-2425-11eb-9075-ed0a9c5cbab5.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
