### PR TITLE
Change implementation for customizer conditions

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -3,18 +3,22 @@
 ( function() {
 	// Wait until the customizer has finished loading.
 	wp.customize.bind( 'ready', function() {
-		// Hide the "respect_user_color_preference" setting if the background-color is dark.
+		// Get the checkbox element.
+		var input = wp.customize.control( 'respect_user_color_preference' ).container.find( 'input' )[0];
+		// Disable the "respect_user_color_preference" checkbox if the background-color is dark.
 		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {
-			wp.customize.control( 'respect_user_color_preference' ).deactivate();
+			input.setAttribute( 'disabled', 'disabled' );
 		}
 
 		// Handle changes to the background-color.
 		wp.customize( 'background_color', function( setting ) {
 			setting.bind( function( value ) {
 				if ( 127 > twentytwentyoneGetHexLum( value ) ) {
-					wp.customize.control( 'respect_user_color_preference' ).deactivate();
+					// Disable the checkbox if the background-color is dark.
+					input.setAttribute( 'disabled', 'disabled' );
 				} else {
-					wp.customize.control( 'respect_user_color_preference' ).activate();
+					// Enable the checkbox if the background-color is dark.
+					input.removeAttribute( 'disabled' );
 				}
 			} );
 		} );

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -118,9 +118,6 @@ class Twenty_Twenty_One_Dark_Mode {
 	 * @return void
 	 */
 	public function customize_controls_enqueue_scripts() {
-		if ( ! $this->switch_should_render() ) {
-			return;
-		}
 		wp_enqueue_script(
 			'twentytwentyone-customize-controls',
 			get_template_directory_uri() . '/assets/js/customize.js',
@@ -167,9 +164,6 @@ class Twenty_Twenty_One_Dark_Mode {
 				'section'         => 'colors',
 				'label'           => esc_html__( 'Dark Mode Support', 'twentytwentyone' ),
 				'description'     => __( 'Respect visitor\'s device dark mode settings.<br>Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.<br><br>Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ),
-				'active_callback' => function( $value ) {
-					return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
-				},
 			)
 		);
 


### PR DESCRIPTION
See https://github.com/WordPress/twentytwentyone/issues/833

This PR changes the behavior of control dependencies.
Now the checkbox is always shown, BUT if the background color is dark then the checkbox is disabled.

![demo31](https://user-images.githubusercontent.com/588688/98916148-797f0900-24d3-11eb-905e-ad58752c711d.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
