### PR TITLE
Use a solid color for borders when a dark background is used

### DIFF
--- a/assets/css/style-dark-mode-rtl.css
+++ b/assets/css/style-dark-mode-rtl.css
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #9a9a9a;
+		--global--color-border: #9ea1a7;
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus,

--- a/assets/css/style-dark-mode-rtl.css
+++ b/assets/css/style-dark-mode-rtl.css
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #ffffff8c;
+		--global--color-border: #9a9a9a;
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus,

--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #9a9a9a;
+		--global--color-border: #9ea1a7;
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus,

--- a/assets/css/style-dark-mode.css
+++ b/assets/css/style-dark-mode.css
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #ffffff8c;
+		--global--color-border: #9a9a9a;
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus,

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #9a9a9a;
+		--global--color-border: #9ea1a7;
 
 		.site a:focus,
 		.site a:focus .meta-nav {

--- a/assets/sass/style-dark-mode.scss
+++ b/assets/sass/style-dark-mode.scss
@@ -10,7 +10,7 @@
 		--button--color-text-active: var(--global--color-secondary);
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
-		--global--color-border: #ffffff8c; //55% opacity
+		--global--color-border: #9a9a9a;
 
 		.site a:focus,
 		.site a:focus .meta-nav {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/834

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Replaces the white border that had a 55% opacity with a solid color: `#9a9a9a`.

This was the best I could do. _I was not able to change the border so that it is outside the cover image instead of on top of it._
Open to other other pull requests to replace this one if someone can get it to work.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Change the body background to dark or enable Dark Mode.
1. Add a cover block with an image. Select the border style
1. Add an image block. Select the border style.
1. Compare the two borders. Confirm that the borders match.

<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
