### PR TITLE
Actions: Intentionally set the node version on lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,11 @@ jobs:
               with:
                 php-version: 7.4
 
+            - name: Set up Node.js
+              uses: actions/setup-node@v1
+              with:
+                node-version: 12.x
+
             - name: Get composer cache directory
               id: composer-cache
               run: |


### PR DESCRIPTION
This should prevent the linter check from erroring out. I'm sure we're moving off github soon, so to keep things functioning this just sets the node version to 12.x, rather than fixing whatever the issue is with node 14.x.