### PR TITLE
Add custom notice pseudo-control

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -6,6 +6,7 @@
 		// Hide the "respect_user_color_preference" setting if the background-color is dark.
 		if ( 127 > twentytwentyoneGetHexLum( wp.customize( 'background_color' ).get() ) ) {
 			wp.customize.control( 'respect_user_color_preference' ).deactivate();
+			wp.customize.control( 'respect_user_color_preference_notice' ).deactivate();
 		}
 
 		// Handle changes to the background-color.
@@ -13,8 +14,10 @@
 			setting.bind( function( value ) {
 				if ( 127 > twentytwentyoneGetHexLum( value ) ) {
 					wp.customize.control( 'respect_user_color_preference' ).deactivate();
+					wp.customize.control( 'respect_user_color_preference_notice' ).activate();
 				} else {
 					wp.customize.control( 'respect_user_color_preference' ).activate();
+					wp.customize.control( 'respect_user_color_preference_notice' ).deactivate();
 				}
 			} );
 		} );

--- a/classes/class-twenty-twenty-one-customize-notice-control.php
+++ b/classes/class-twenty-twenty-one-customize-notice-control.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Customize API: Twenty_Twenty_One_Customize_Notice_Control class
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_One
+ * @since 1.0.0
+ */
+
+/**
+ * Customize Notice Control class.
+ *
+ * @since 1.0.0
+ *
+ * @see WP_Customize_Control
+ */
+class Twenty_Twenty_One_Customize_Notice_Control extends WP_Customize_Control {
+	/**
+	 * The control type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public $type = 'twenty-twenty-one-notice';
+
+	/**
+	 * Renders the control content.
+	 *
+	 * This simply prints the notice we need.
+	 *
+	 * @access public
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function render_content() {
+		?>
+		<div class="notice notice-info">
+			<p><?php esc_html_e( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ); ?></p>
+			<p><a href="https://wordpress.org/support/article/twenty-twenty-one/">
+				<?php esc_html_e( 'Learn more about Dark Mode.', 'twentytwentyone' ); ?>
+			</a></p>
+		</div>
+		<?php
+	}
+}

--- a/classes/class-twenty-twenty-one-customize-notice-control.php
+++ b/classes/class-twenty-twenty-one-customize-notice-control.php
@@ -37,7 +37,7 @@ class Twenty_Twenty_One_Customize_Notice_Control extends WP_Customize_Control {
 	 */
 	public function render_content() {
 		?>
-		<div class="notice notice-info">
+		<div class="notice notice-warning">
 			<p><?php esc_html_e( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ); ?></p>
 			<p><a href="https://wordpress.org/support/article/twenty-twenty-one/">
 				<?php esc_html_e( 'Learn more about Dark Mode.', 'twentytwentyone' ); ?>

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,13 +182,10 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
-		$description  = __( 'Respect visitor&#8217;s device dark mode settings.', 'twentytwentyone' );
-		$description .= '<br>';
-		$description .= __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.', 'twentytwentyone' );
-		$description .= '<br><br>';
-		$description .= __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' );
-		$description .= '<br>';
-		$description .= '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+		$description  = __( 'Respect visitor&#8217;s device dark mode settings.', 'twentytwentyone' ) . '<br>';
+		$description .= __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.', 'twentytwentyone' ) . '<br>';
+		$description .= '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>' . '<br><br>';
+		$description .= __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '<br>';
 
 
 		$wp_customize->add_control(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -142,9 +142,31 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		$colors_section = $wp_customize->get_section( 'colors' );
 		if ( is_object( $colors_section ) ) {
-			$colors_section->title       = __( 'Colors & Dark Mode', 'twentytwentyone' );
-			$colors_section->description = __( 'To access the Dark Mode settings, select a light background color.', 'twentytwentyone' ) . '<br><a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+			$colors_section->title = __( 'Colors & Dark Mode', 'twentytwentyone' );
 		}
+
+		// Custom notice control.
+		include_once get_theme_file_path( 'classes/class-twenty-twenty-one-customize-notice-control.php' ); // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
+
+		$wp_customize->add_setting(
+			'respect_user_color_preference_notice',
+			array(
+				'capability'        => 'edit_theme_options',
+				'default'           => '',
+				'sanitize_callback' => '__return_empty_string',
+			)
+		);
+
+		$wp_customize->add_control(
+			new Twenty_Twenty_One_Customize_Notice_Control(
+				$wp_customize,
+				'respect_user_color_preference_notice',
+				array(
+					'section'  => 'colors',
+					'priority' => 100,
+				)
+			)
+		);
 
 		$wp_customize->add_setting(
 			'respect_user_color_preference',
@@ -163,6 +185,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				'type'            => 'checkbox',
 				'section'         => 'colors',
 				'label'           => esc_html__( 'Dark Mode support', 'twentytwentyone' ),
+				'priority'        => 110,
 				'description'     => __( 'Respect visitor&#8217;s device dark mode settings.<br>Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.<br><br>Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ),
 				'active_callback' => function( $value ) {
 					return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -164,6 +164,9 @@ class Twenty_Twenty_One_Dark_Mode {
 				array(
 					'section'  => 'colors',
 					'priority' => 100,
+					'active_callback' => function() {
+						return 127 >= Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
+					},
 				)
 			)
 		);

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,10 +182,8 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
-		$description  = __( 'Respect visitor&#8217;s device dark mode settings.', 'twentytwentyone' ) . '<br>';
-		$description .= __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.', 'twentytwentyone' ) . '<br>';
-		$description .= '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>' . '<br><br>';
-		$description .= __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '<br>';
+		$description  = '<p>' . __( 'Respect visitor\'s device dark mode settings. Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
+		$description .= '<p>' . __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '</p>';
 
 
 		$wp_customize->add_control(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,6 +182,15 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
+		$description  = __( 'Respect visitor&#8217;s device dark mode settings.', 'twentytwentyone' );
+		$description .= '<br>';
+		$description .= __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.', 'twentytwentyone' );
+		$description .= '<br><br>';
+		$description .= __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' );
+		$description .= '<br>';
+		$description .= '<a href="https://wordpress.org/support/article/twenty-twenty-one/">' . __( 'Learn more about Dark Mode.', 'twentytwentyone' ) . '</a>';
+
+
 		$wp_customize->add_control(
 			'respect_user_color_preference',
 			array(
@@ -189,7 +198,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				'section'         => 'colors',
 				'label'           => esc_html__( 'Dark Mode support', 'twentytwentyone' ),
 				'priority'        => 110,
-				'description'     => __( 'Respect visitor&#8217;s device dark mode settings.<br>Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text.<br><br>Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ),
+				'description'     => $description,
 				'active_callback' => function( $value ) {
 					return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 				},

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,7 +182,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
-		$description  = '<p>' . __( 'Respect visitor\'s device dark mode settings. Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
+		$description  = '<p>' . __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
 		$description .= '<p>' . __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '</p>';
 
 

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -162,8 +162,8 @@ class Twenty_Twenty_One_Dark_Mode {
 				$wp_customize,
 				'respect_user_color_preference_notice',
 				array(
-					'section'  => 'colors',
-					'priority' => 100,
+					'section'         => 'colors',
+					'priority'        => 100,
 					'active_callback' => function() {
 						return 127 >= Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 					},


### PR DESCRIPTION
This is an alternative to https://github.com/WordPress/twentytwentyone/pull/838

## Summary
* Adds a notice between the colorpicker and checkbox
* Removes the section description

## Relevant technical choices:
In WP notices are always above their controls. Since we want to keep the checkbox dependency (we don't want it always shown) we can't add the notice to that control (it will be hidden when the checkbox is also hidden). As a result, a new control-type had to be introduced. This PR adds a new `Twenty_Twenty_One_Customize_Notice_Control` class which just prints a notice with our hardcoded message. For the purposes of this theme and an one-off control there's no point in abstracting the logic.

![Peek 2020-11-16 16-59](https://user-images.githubusercontent.com/588688/99268514-ef65d600-282d-11eb-8a6e-d8686cbef31d.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
