### PR TITLE
Fix the casing of "Dark Mode."

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5653,6 +5653,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: 180px;
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: 30px;
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: 30px;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7395,7 +7395,7 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 
 	.widget-area {
-		margin-top: 30px;
+		margin-top: 90px;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5656,7 +5656,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: 30px;
+		margin-top: 90px;
 	}
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7388,6 +7388,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: 30px;
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -12,7 +12,7 @@
 	@include media(mobile-only) {
 
 		.no-widgets & {
-			margin-top: var(--global--spacing-vertical);
+			margin-top: calc(3 * var(--global--spacing-vertical));
 		}
 	}
 }

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -8,6 +8,13 @@
 	.no-widgets & {
 		margin-top: calc(6 * var(--global--spacing-vertical));
 	}
+
+	@include media(mobile-only) {
+
+		.no-widgets & {
+			margin-top: var(--global--spacing-vertical);
+		}
+	}
 }
 
 // Footer Branding

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -17,7 +17,7 @@
 	}
 
 	@include media(mobile-only) {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 
 	ul {

--- a/assets/sass/06-components/widgets.scss
+++ b/assets/sass/06-components/widgets.scss
@@ -16,6 +16,10 @@
 		grid-template-columns: repeat(3, 1fr);
 	}
 
+	@include media(mobile-only) {
+		margin-top: var(--global--spacing-vertical);
+	}
+
 	ul {
 		list-style-type: none;
 		padding: 0;

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,7 +182,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
-		$description  = '<p>' . __( 'Dark mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
+		$description  = '<p>' . __( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
 		$description .= '<p>' . __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '</p>';
 
 		$wp_customize->add_control(

--- a/classes/class-twenty-twenty-one-dark-mode.php
+++ b/classes/class-twenty-twenty-one-dark-mode.php
@@ -182,7 +182,13 @@ class Twenty_Twenty_One_Dark_Mode {
 			)
 		);
 
-		$description  = '<p>' . __( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="https://wordpress.org/support/article/twenty-twenty-one/">Learn more about Dark Mode.</a>', 'twentytwentyone' ) . '</p>';
+		$description  = '<p>';
+		$description .= sprintf(
+			// translators: %s is the wordpress.org Twenty Twenty-One support article URL.
+			__( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="%s">Learn more about Dark Mode.</a>', 'twentytwentyone' ),
+			__( 'https://wordpress.org/support/article/twenty-twenty-one/', 'twentytwentyone' )
+		);
+		$description .= '</p>';
 		$description .= '<p>' . __( 'Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page.', 'twentytwentyone' ) . '</p>';
 
 		$wp_customize->add_control(

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3948,6 +3948,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: calc(6 * var(--global--spacing-vertical));
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: var(--global--spacing-vertical);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5399,7 +5399,7 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 
 	.widget-area {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3951,7 +3951,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5359,6 +5359,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;

--- a/style.css
+++ b/style.css
@@ -3968,6 +3968,12 @@ a.custom-logo-link {
 .no-widgets .site-footer {
 	margin-top: calc(6 * var(--global--spacing-vertical));
 }
+@media only screen and (max-width: 481px) {
+
+	.no-widgets .site-footer {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .site-footer > .site-info {
 	padding-top: var(--global--spacing-vertical);

--- a/style.css
+++ b/style.css
@@ -3971,7 +3971,7 @@ a.custom-logo-link {
 @media only screen and (max-width: 481px) {
 
 	.no-widgets .site-footer {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 
@@ -5404,7 +5404,7 @@ h1.page-title {
 @media only screen and (max-width: 481px) {
 
 	.widget-area {
-		margin-top: var(--global--spacing-vertical);
+		margin-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -5395,6 +5395,12 @@ h1.page-title {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+@media only screen and (max-width: 481px) {
+
+	.widget-area {
+		margin-top: var(--global--spacing-vertical);
+	}
+}
 
 .widget-area ul {
 	list-style-type: none;


### PR DESCRIPTION
Looks like "Dark Mode" is consistently used throughout the theme. Let's change this instance. This change was included in the latest sync in WordPress `trunk`.

It also feels like the link does not belong within the translation string. I know that support documentation can have localized URLs, but I'm not sure the best practice for this. 

The [internationalization best practices say](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#best-practices-for-writing-strings):
```
- Do not put unnecessary HTML markup into the translated string
- Do not leave URLs for translation, unless they could have a version in another language.
```

Defer to the team's interpretation and experience here (I know there are polyglots here), but wanted to raise this!