### PR TITLE
Make the solid pullquote block readable and match in the editor and front

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -1892,6 +1892,14 @@ pre.wp-block-preformatted {
 	padding: 0 40px;
 }
 
+.wp-block[data-align=left] .wp-block-pullquote.is-style-solid-color {
+	padding: 20px;
+}
+
+.wp-block[data-align=right] .wp-block-pullquote.is-style-solid-color {
+	padding: 20px;
+}
+
 .wp-block-quote {
 	position: relative;
 	border-left: none;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4156,8 +4156,8 @@ pre.wp-block-preformatted {
 	background: none;
 }
 
-.wp-block-pullquote.alignleft blockquote:before,
-.wp-block-pullquote.alignleft cite {
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) blockquote:before,
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) cite {
 	text-align: center;
 }
 
@@ -4237,6 +4237,19 @@ pre.wp-block-preformatted {
 .wp-block-pullquote.is-style-solid-color cite,
 .wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft {
+	padding: 20px;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignright {
+	padding: 20px;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft blockquote,
+.wp-block-pullquote.is-style-solid-color.alignright blockquote {
+	max-width: initial;
 }
 
 .wp-block-quote {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4220,6 +4220,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
+	margin: 0;
 	max-width: inherit;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -1453,6 +1453,11 @@ pre.wp-block-preformatted {
 	padding: 0 calc(2 * var(--global--spacing-unit));
 }
 
+.wp-block[data-align=left] .wp-block-pullquote.is-style-solid-color,
+.wp-block[data-align=right] .wp-block-pullquote.is-style-solid-color {
+	padding: var(--global--spacing-unit);
+}
+
 .wp-block-quote {
 	position: relative;
 	border-left: none;

--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -94,3 +94,10 @@
 		}
 	}
 }
+
+.wp-block[data-align="left"],
+.wp-block[data-align="right"] {
+	.wp-block-pullquote.is-style-solid-color {
+		padding: var(--global--spacing-unit);
+	}
+}

--- a/assets/sass/05-blocks/pullquote/_editor.scss
+++ b/assets/sass/05-blocks/pullquote/_editor.scss
@@ -97,6 +97,7 @@
 
 .wp-block[data-align="left"],
 .wp-block[data-align="right"] {
+
 	.wp-block-pullquote.is-style-solid-color {
 		padding: var(--global--spacing-unit);
 	}

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -47,6 +47,7 @@
 	}
 
 	&.alignleft:not(.is-style-solid-color) {
+
 		blockquote:before,
 		cite {
 			text-align: center;

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -80,6 +80,7 @@
 		}
 
 		blockquote {
+			margin: 0;
 			max-width: inherit;
 
 			p {

--- a/assets/sass/05-blocks/pullquote/_style.scss
+++ b/assets/sass/05-blocks/pullquote/_style.scss
@@ -46,8 +46,7 @@
 		background: none;
 	}
 
-	&.alignleft {
-
+	&.alignleft:not(.is-style-solid-color) {
 		blockquote:before,
 		cite {
 			text-align: center;
@@ -57,7 +56,6 @@
 	&.alignwide > p,
 	&.alignwide blockquote {
 		max-width: var(--responsive--alignwide-width);
-
 	}
 
 	&.alignfull:not(.is-style-solid-color) > p,
@@ -72,7 +70,7 @@
 		border-style: solid;
 		border-color: var(--pullquote--border-color);
 
-		@media ( min-width: 600px ) {
+		@media (min-width: 600px) {
 			padding: calc(5 * var(--global--spacing-unit));
 		}
 
@@ -92,6 +90,15 @@
 		cite,
 		footer {
 			color: currentColor;
+		}
+
+		&.alignleft,
+		&.alignright {
+			padding: var(--global--spacing-unit);
+
+			blockquote {
+				max-width: initial;
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"homepage": "https://github.com/wordpress/twentytwentyone",
 	"devDependencies": {
 		"@wordpress/browserslist-config": "^2.2.2",
+		"@wordpress/env": "^2.1.0",
 		"@wordpress/eslint-plugin": "^7.3.0",
 		"autoprefixer": "^9.5.1",
 		"chokidar-cli": "^2.1.0",
@@ -64,6 +65,7 @@
 		"lint:scss": "stylelint **/*.scss",
 		"lint:js": "eslint assets/js",
 		"lint-fix:scss": "stylelint **/*.scss --fix",
-		"lint-fix:js": "eslint assets/js --fix"
+		"lint-fix:js": "eslint assets/js --fix",
+		"wp-env": "wp-env"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 	"homepage": "https://github.com/wordpress/twentytwentyone",
 	"devDependencies": {
 		"@wordpress/browserslist-config": "^2.2.2",
-		"@wordpress/env": "^2.1.0",
 		"@wordpress/eslint-plugin": "^7.3.0",
 		"autoprefixer": "^9.5.1",
 		"chokidar-cli": "^2.1.0",
@@ -65,7 +64,6 @@
 		"lint:scss": "stylelint **/*.scss",
 		"lint:js": "eslint assets/js",
 		"lint-fix:scss": "stylelint **/*.scss --fix",
-		"lint-fix:js": "eslint assets/js --fix",
-		"wp-env": "wp-env"
+		"lint-fix:js": "eslint assets/js --fix"
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2998,6 +2998,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
+	margin: 0;
 	max-width: inherit;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2964,8 +2964,8 @@ pre.wp-block-preformatted {
 	background: none;
 }
 
-.wp-block-pullquote.alignleft blockquote:before,
-.wp-block-pullquote.alignleft cite {
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) blockquote:before,
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) cite {
 	text-align: center;
 }
 
@@ -3009,6 +3009,16 @@ pre.wp-block-preformatted {
 .wp-block-pullquote.is-style-solid-color cite,
 .wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft,
+.wp-block-pullquote.is-style-solid-color.alignright {
+	padding: var(--global--spacing-unit);
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft blockquote,
+.wp-block-pullquote.is-style-solid-color.alignright blockquote {
+	max-width: initial;
 }
 
 .wp-block-quote {

--- a/style.css
+++ b/style.css
@@ -2974,8 +2974,8 @@ pre.wp-block-preformatted {
 	background: none;
 }
 
-.wp-block-pullquote.alignleft blockquote:before,
-.wp-block-pullquote.alignleft cite {
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) blockquote:before,
+.wp-block-pullquote.alignleft:not(.is-style-solid-color) cite {
 	text-align: center;
 }
 
@@ -3019,6 +3019,16 @@ pre.wp-block-preformatted {
 .wp-block-pullquote.is-style-solid-color cite,
 .wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft,
+.wp-block-pullquote.is-style-solid-color.alignright {
+	padding: var(--global--spacing-unit);
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft blockquote,
+.wp-block-pullquote.is-style-solid-color.alignright blockquote {
+	max-width: initial;
 }
 
 .wp-block-quote {

--- a/style.css
+++ b/style.css
@@ -3008,6 +3008,7 @@ pre.wp-block-preformatted {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
+	margin: 0;
 	max-width: inherit;
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes #841.
 
## Summary
Make the solid pullquote block readable and match in the editor and front.
What has been done: 
- When the pullquote block has solid style and is left or right aligned, the padding of the block has been reduced to `var(--global--spacing-unit)` in the editor and in front. In front `max-width: initial` has been added to increase the block width.

## Relevant technical choices:
No

## Test instructions

This PR can be tested by following these steps:
- Add a pullquote block and select the solid style.
- Align the block to left or right.
- The block should look the same in the editor and in front


## Screenshots
Pullquote solid right block editor (Before)
![pullquote-solid-right-editor-before](https://user-images.githubusercontent.com/33403964/99638025-f5360400-2a45-11eb-9e0b-361169fcf0b9.png)

Pullquote solid right block editor (After)
![pullquote-solid-right-editor-after](https://user-images.githubusercontent.com/33403964/99638086-0bdc5b00-2a46-11eb-8a56-d79af3bce2d5.png)

Pullquote solid right block front (Before)
![pullquote-solid-right-front-before](https://user-images.githubusercontent.com/33403964/99638137-1991e080-2a46-11eb-90ef-e9689b1231cd.png)

Pullquote solid right block front (After)
![pullquote-solid-right-front-after](https://user-images.githubusercontent.com/33403964/99638160-21518500-2a46-11eb-9a73-8eb54381a62c.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
