### PR TITLE
Decrease range input thumb size on Firefox

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1978,6 +1978,7 @@ input[type=radio] + label {
 		border-radius: 50%;
 		background: #d1e4dd;
 		cursor: pointer;
+		box-sizing: border-box;
 	}
 }
 

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -230,6 +230,7 @@ input[type="radio"] + label {
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
+		box-sizing: border-box;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1462,6 +1462,7 @@ input[type=radio] + label {
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
+		box-sizing: border-box;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -1472,6 +1472,7 @@ input[type=radio] + label {
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
+		box-sizing: border-box;
 	}
 }
 


### PR DESCRIPTION
Fixes #860.

## Summary
This PR sets `box-sizing: border-box` to the range input thumb on Firefox, so it has the same size as Chrome.

## Test instructions

This PR can be tested by following these steps:
1. Create a post and add an HTML block with these contents:
```HTML
<input type="range" min="0" max="100" />
```
2. Save the post and preview the end result in Chrome and Firefox.
3. Verify the thumb has the same size in Firefox and Chrome.

## Screenshots
_Chrome:_
![imatge](https://user-images.githubusercontent.com/3616980/99798987-3a376480-2b32-11eb-8ca1-998f221bffab.png)

_Firefox (before):_
![imatge](https://user-images.githubusercontent.com/3616980/99798904-16741e80-2b32-11eb-8ebd-23f5ee2bc792.png)

_Firefox (after):_
![imatge](https://user-images.githubusercontent.com/3616980/99812971-63162480-2b47-11eb-8d97-43b4d854dc7e.png)

I also tested Gnome Web (which uses WebKit like Safari), and it looks like Chrome. IE11 seems to be between both sizes, so I left it untouched.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
