### PR TITLE
Fix separator width & opacity

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4912,18 +4912,18 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
 	max-width: calc(100vw - 30px);
 }
 @media only screen and (min-width: 482px) {
 
-	hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+	hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
 @media only screen and (min-width: 822px) {
 
-	hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+	hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
 		max-width: min(calc(100vw - 200px), 610px);
 	}
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4912,23 +4912,39 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
+hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 	max-width: calc(100vw - 30px);
 }
 @media only screen and (min-width: 482px) {
 
-	hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
+	hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 		max-width: min(calc(100vw - 100px), 610px);
 	}
 }
 @media only screen and (min-width: 822px) {
 
-	hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
+	hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 		max-width: min(calc(100vw - 200px), 610px);
 	}
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
+hr.wp-block-separator:not(.is-style-dots).alignwide {
+	max-width: calc(100vw - 30px);
+}
+@media only screen and (min-width: 482px) {
+
+	hr.wp-block-separator:not(.is-style-dots).alignwide {
+		max-width: calc(100vw - 100px);
+	}
+}
+@media only screen and (min-width: 822px) {
+
+	hr.wp-block-separator:not(.is-style-dots).alignwide {
+		max-width: min(calc(100vw - 200px), 1240px);
+	}
+}
+
+hr.wp-block-separator:not(.is-style-dots).alignfull {
 	max-width: 100%;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4905,6 +4905,7 @@ hr {
 
 hr.wp-block-separator {
 	border-bottom: 1px solid #28303d;
+	opacity: 1;
 
 	/**
    * Block Options

--- a/assets/sass/05-blocks/separator/_style.scss
+++ b/assets/sass/05-blocks/separator/_style.scss
@@ -9,8 +9,15 @@ hr {
 		border-bottom: var(--separator--height) solid var(--separator--border-color);
 		opacity: 1;
 
-		&:not(.is-style-dots):not(.alignwide) {
+		&:not(.is-style-dots):not(.is-style-wide) {
 			max-width: var(--responsive--aligndefault-width);
+		}
+
+		&:not(.is-style-dots) {
+
+			&.alignwide {
+				max-width: var(--responsive--alignwide-width);
+			}
 
 			&.alignfull {
 				max-width: var(--responsive--alignfull-width);

--- a/assets/sass/05-blocks/separator/_style.scss
+++ b/assets/sass/05-blocks/separator/_style.scss
@@ -9,7 +9,7 @@ hr {
 		border-bottom: var(--separator--height) solid var(--separator--border-color);
 		opacity: 1;
 
-		&:not(.is-style-dots):not(.is-style-wide) {
+		&:not(.is-style-dots):not(.alignwide) {
 			max-width: var(--responsive--aligndefault-width);
 		}
 

--- a/assets/sass/05-blocks/separator/_style.scss
+++ b/assets/sass/05-blocks/separator/_style.scss
@@ -7,6 +7,7 @@ hr {
 
 	&.wp-block-separator {
 		border-bottom: var(--separator--height) solid var(--separator--border-color);
+		opacity: 1;
 
 		&:not(.is-style-dots):not(.alignwide) {
 			max-width: var(--responsive--aligndefault-width);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3452,7 +3452,7 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
 	max-width: var(--responsive--aligndefault-width);
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3445,6 +3445,7 @@ hr {
 
 hr.wp-block-separator {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);
+	opacity: 1;
 
 	/**
    * Block Options

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3452,11 +3452,15 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
+hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 	max-width: var(--responsive--aligndefault-width);
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
+hr.wp-block-separator:not(.is-style-dots).alignwide {
+	max-width: var(--responsive--alignwide-width);
+}
+
+hr.wp-block-separator:not(.is-style-dots).alignfull {
 	max-width: var(--responsive--alignfull-width);
 }
 

--- a/style.css
+++ b/style.css
@@ -3455,6 +3455,7 @@ hr {
 
 hr.wp-block-separator {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);
+	opacity: 1;
 
 	/**
    * Block Options

--- a/style.css
+++ b/style.css
@@ -3462,11 +3462,15 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
+hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 	max-width: var(--responsive--aligndefault-width);
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.alignwide).alignfull {
+hr.wp-block-separator:not(.is-style-dots).alignwide {
+	max-width: var(--responsive--alignwide-width);
+}
+
+hr.wp-block-separator:not(.is-style-dots).alignfull {
 	max-width: var(--responsive--alignfull-width);
 }
 

--- a/style.css
+++ b/style.css
@@ -3462,7 +3462,7 @@ hr.wp-block-separator {
    */
 }
 
-hr.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+hr.wp-block-separator:not(.is-style-dots):not(.alignwide) {
 	max-width: var(--responsive--aligndefault-width);
 }
 


### PR DESCRIPTION
I'm not sure when these broke, but in the front end, running Gutenberg 9.4.1, I'm seeing all separators show an incorrect opacity. Wide separators are also only being shown at 100px wide. This PR should fix the issue. 

Before: 

![Screen Shot 2020-11-20 at 2 49 37 PM](https://user-images.githubusercontent.com/1202812/99845141-2d227180-2b42-11eb-84f2-58c9e5cae160.png)
![Screen Shot 2020-11-20 at 3 06 59 PM](https://user-images.githubusercontent.com/1202812/99845139-2d227180-2b42-11eb-9040-9e9008b8fb3e.png)

After: 

![Screen Shot 2020-11-20 at 2 51 08 PM](https://user-images.githubusercontent.com/1202812/99845205-41ff0500-2b42-11eb-8b0b-728f15ba332f.png)
![Screen Shot 2020-11-20 at 3 06 31 PM](https://user-images.githubusercontent.com/1202812/99845207-41ff0500-2b42-11eb-930b-8e523e7fa69a.png)
