### PR TITLE
Fix link focus color on white background

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7151,6 +7151,10 @@ h1.page-title {
 	fill: #d1e4dd;
 }
 
+.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: #fff;
+}
+
 .footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
 	fill: #28303d;

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5614,6 +5614,10 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
+.has-background-white a.custom-logo-link:focus {
+	background: none;
+}
+
 .site-title > a {
 	text-decoration-color: #39414d;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5614,7 +5614,8 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
-.has-background-white a.custom-logo-link:focus {
+.has-background-white a.custom-logo-link:focus,
+.is-dark-theme a.custom-logo-link:focus {
 	background: none;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -5785,6 +5785,10 @@ a.custom-logo-link {
 	color: #d1e4dd;
 }
 
+.has-background-white .site-footer > .site-info a:focus {
+	color: #fff;
+}
+
 .singular .entry-header {
 	border-bottom: 3px solid #28303d;
 	padding-bottom: 60px;

--- a/assets/sass/06-components/footer-navigation.scss
+++ b/assets/sass/06-components/footer-navigation.scss
@@ -45,6 +45,14 @@
 						fill: var(--wp--style--color--link, var(--global--color-background));
 					}
 				}
+
+				// Change colors when the body background is white.
+				.has-background-white & {
+
+					.svg-icon {
+						fill: var(--wp--style--color--link, var(--global--color-white));
+					}
+				}
 			}
 		}
 

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -64,6 +64,11 @@
 			.is-dark-theme & {
 				color: var(--wp--style--color--link, var(--global--color-background));
 			}
+
+			// Change colors when the body background is white.
+			.has-background-white & {
+				color: var(--wp--style--color--link, var(--global--color-white));
+			}
 		}
 	}
 }

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -82,7 +82,8 @@ a.custom-logo-link {
 
 	&:focus {
 		// Change colors when the body background is white.
-		.has-background-white & {
+		.has-background-white &,
+		.is-dark-theme & {
 			background: none;
 		}
 	}
@@ -93,7 +94,6 @@ a.custom-logo-link {
 }
 
 // Site logo
-
 .site-logo {
 
 	margin: calc(var(--global--spacing-vertical) / 2) 0;

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -79,6 +79,13 @@
 
 a.custom-logo-link {
 	text-decoration: none;
+
+	&:focus {
+		// Change colors when the body background is white.
+		.has-background-white & {
+			background: none;
+		}
+	}
 }
 
 .site-title > a {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5169,6 +5169,10 @@ h1.page-title {
 	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
+.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: var(--wp--style--color--link, var(--global--color-white));
+}
+
 .footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
 	fill: var(--footer--color-link);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4062,6 +4062,10 @@ a.custom-logo-link {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
+.has-background-white .site-footer > .site-info a:focus {
+	color: var(--wp--style--color--link, var(--global--color-white));
+}
+
 .singular .entry-header {
 	border-bottom: 3px solid var(--global--color-border);
 	padding-bottom: calc(2 * var(--global--spacing-vertical));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3897,6 +3897,10 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
+.has-background-white a.custom-logo-link:focus {
+	background: none;
+}
+
 .site-title > a {
 	text-decoration-color: var(--global--color-secondary);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3897,7 +3897,8 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
-.has-background-white a.custom-logo-link:focus {
+.has-background-white a.custom-logo-link:focus,
+.is-dark-theme a.custom-logo-link:focus {
 	background: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -4082,6 +4082,10 @@ a.custom-logo-link {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
+.has-background-white .site-footer > .site-info a:focus {
+	color: var(--wp--style--color--link, var(--global--color-white));
+}
+
 .singular .entry-header {
 	border-bottom: 3px solid var(--global--color-border);
 	padding-bottom: calc(2 * var(--global--spacing-vertical));

--- a/style.css
+++ b/style.css
@@ -3917,7 +3917,8 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
-.has-background-white a.custom-logo-link:focus {
+.has-background-white a.custom-logo-link:focus,
+.is-dark-theme a.custom-logo-link:focus {
 	background: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -5205,6 +5205,10 @@ h1.page-title {
 	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
+.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+	fill: var(--wp--style--color--link, var(--global--color-white));
+}
+
 .footer-navigation-wrapper li .svg-icon {
 	vertical-align: middle;
 	fill: var(--footer--color-link);

--- a/style.css
+++ b/style.css
@@ -3917,6 +3917,10 @@ a.custom-logo-link {
 	text-decoration: none;
 }
 
+.has-background-white a.custom-logo-link:focus {
+	background: none;
+}
+
 .site-title > a {
 	text-decoration-color: var(--global--color-secondary);
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Partial fix for https://github.com/WordPress/twentytwentyone/issues/864

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
On focus:
Change the link text color to white over the black background.
Change the fill color of the social icons over the black background
Remove the background color for custom logos.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Set the body background color to white.
1. Add a transparent logo.  Focus on the logo to confirm that the background is not black.
1. Add social links to the footer menu. Focus on the menu items to confirm that the background is black but the icon color is white.
1. Focus on the site info links. Confirm that the background is black and that the text color is white.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Footer menu:
![footer-menu](https://user-images.githubusercontent.com/7422055/99938109-70115e80-2d67-11eb-9551-10191f709f78.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
