### PR TITLE
Update pagination colors when the background is dark or white

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7355,6 +7355,54 @@ h1.page-title {
 	color: #28303d;
 }
 
+.is-dark-theme .pagination .nav-links a:active {
+	color: #d1e4dd;
+}
+
+.is-dark-theme .pagination .nav-links a:hover:active {
+	color: #d1e4dd;
+}
+
+.is-dark-theme .pagination .nav-links a:hover:focus {
+	color: #d1e4dd;
+}
+
+.is-dark-theme .comments-pagination .nav-links a:active {
+	color: #d1e4dd;
+}
+
+.is-dark-theme .comments-pagination .nav-links a:hover:active {
+	color: #d1e4dd;
+}
+
+.is-dark-theme .comments-pagination .nav-links a:hover:focus {
+	color: #d1e4dd;
+}
+
+.has-background-white .pagination .nav-links a:active {
+	color: #fff;
+}
+
+.has-background-white .pagination .nav-links a:hover:active {
+	color: #fff;
+}
+
+.has-background-white .pagination .nav-links a:hover:focus {
+	color: #fff;
+}
+
+.has-background-white .comments-pagination .nav-links a:active {
+	color: #fff;
+}
+
+.has-background-white .comments-pagination .nav-links a:hover:active {
+	color: #fff;
+}
+
+.has-background-white .comments-pagination .nav-links a:hover:focus {
+	color: #fff;
+}
+
 .pagination .nav-links > * {
 	color: #28303d;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -157,6 +157,23 @@
 			color: var(--pagination--color-link-hover);
 		}
 
+		.is-dark-theme & {
+
+			a:active,
+			a:hover:active,
+			a:hover:focus {
+				color: var(--global--color-background);
+			}
+		}
+
+		.has-background-white & {
+
+			a:active,
+			a:hover:active,
+			a:hover:focus {
+				color: var(--global--color-white);
+			}
+		}
 	}
 
 	.nav-links > * {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5341,6 +5341,24 @@ h1.page-title {
 	color: var(--pagination--color-link-hover);
 }
 
+.is-dark-theme .pagination .nav-links a:active,
+.is-dark-theme .pagination .nav-links a:hover:active,
+.is-dark-theme .pagination .nav-links a:hover:focus,
+.is-dark-theme .comments-pagination .nav-links a:active,
+.is-dark-theme .comments-pagination .nav-links a:hover:active,
+.is-dark-theme .comments-pagination .nav-links a:hover:focus {
+	color: var(--global--color-background);
+}
+
+.has-background-white .pagination .nav-links a:active,
+.has-background-white .pagination .nav-links a:hover:active,
+.has-background-white .pagination .nav-links a:hover:focus,
+.has-background-white .comments-pagination .nav-links a:active,
+.has-background-white .comments-pagination .nav-links a:hover:active,
+.has-background-white .comments-pagination .nav-links a:hover:focus {
+	color: var(--global--color-white);
+}
+
 .pagination .nav-links > *,
 .comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);

--- a/style.css
+++ b/style.css
@@ -5377,6 +5377,24 @@ h1.page-title {
 	color: var(--pagination--color-link-hover);
 }
 
+.is-dark-theme .pagination .nav-links a:active,
+.is-dark-theme .pagination .nav-links a:hover:active,
+.is-dark-theme .pagination .nav-links a:hover:focus,
+.is-dark-theme .comments-pagination .nav-links a:active,
+.is-dark-theme .comments-pagination .nav-links a:hover:active,
+.is-dark-theme .comments-pagination .nav-links a:hover:focus {
+	color: var(--global--color-background);
+}
+
+.has-background-white .pagination .nav-links a:active,
+.has-background-white .pagination .nav-links a:hover:active,
+.has-background-white .pagination .nav-links a:hover:focus,
+.has-background-white .comments-pagination .nav-links a:active,
+.has-background-white .comments-pagination .nav-links a:hover:active,
+.has-background-white .comments-pagination .nav-links a:hover:focus {
+	color: var(--global--color-white);
+}
+
 .pagination .nav-links > *,
 .comments-pagination .nav-links > * {
 	color: var(--pagination--color-text);


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Partial fix for  #864

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

When the background is dark:
Mark sure that pagination links with white backgrounds has dark text.

When the background is white:
Make sure that pagination links with dark backgrounds has white text.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Set the bodu background to white.
1. Click on the older/newer posts link or numbers
1. confirm that the text is always readable
1. Set the body background to black and repeat the test.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before, when a link was clicked:
![pagination-link-before-white](https://user-images.githubusercontent.com/7422055/99940524-9b4a7c80-2d6c-11eb-8341-c85048fc50b6.png)
![pagination-link-before](https://user-images.githubusercontent.com/7422055/99940528-9be31300-2d6c-11eb-9bb0-c739abac6b13.png)

After:
![pagination-link-after-white](https://user-images.githubusercontent.com/7422055/99940599-c339e000-2d6c-11eb-955d-70edf516e6c8.png)

![pagination-link-after-black](https://user-images.githubusercontent.com/7422055/99940688-faa88c80-2d6c-11eb-8963-9440128c7a44.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
