### PR TITLE
Editor: Remove padding when columns are placed inside groups

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -975,6 +975,17 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block[data-align=full] .wp-block-group .wp-block-columns p:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h1:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h2:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h3:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h4:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h5:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h6:not(.has-background) {
+	padding-left: 0;
+	padding-right: 0;
+}
+
 .wp-block-group .wp-block-group.has-background > .block-editor-block-list__layout > [data-align=full] {
 	margin: 0;
 	width: 100%;

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -929,6 +929,17 @@ a:hover {
 	margin-bottom: 0;
 }
 
+.wp-block[data-align=full] .wp-block-group .wp-block-columns p:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h1:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h2:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h3:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h4:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h5:not(.has-background),
+.wp-block[data-align=full] .wp-block-group .wp-block-columns h6:not(.has-background) {
+	padding-left: 0;
+	padding-right: 0;
+}
+
 .wp-block-group .wp-block-group.has-background > .block-editor-block-list__layout > [data-align=full] {
 	margin: 0;
 	width: 100%;

--- a/assets/sass/05-blocks/group/_editor.scss
+++ b/assets/sass/05-blocks/group/_editor.scss
@@ -39,6 +39,23 @@
 	.wp-block-group__inner-container > *:last-child {
 		margin-bottom: 0;
 	}
+
+	.wp-block[data-align="full"] & {
+
+		.wp-block-columns {
+
+			p:not(.has-background),
+			h1:not(.has-background),
+			h2:not(.has-background),
+			h3:not(.has-background),
+			h4:not(.has-background),
+			h5:not(.has-background),
+			h6:not(.has-background) {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
 }
 
 .wp-block-group .wp-block-group.has-background > .block-editor-block-list__layout > [data-align="full"] {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Partial fix for https://github.com/WordPress/twentytwentyone/issues/865

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
I tried several different ways to limit the padding in the columns editor style.
But because `.wp-block[data-align="full"]` can wrap any block and not only the nested column block, 
I was not able to make it work.

Because of that, I added an exception to the group block style instead. I'm not really happy about it, but it does remove the padding. Feel free to improve it.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Copy the test content from the issue.
1. View it in the editor.
1. Confirm that there is no padding for the text that is inside the columns that are place in the group block.

1. Add a column outside the group block, and set it to full width.
1. Add text content.
1. Confirm that there is still padding around the text, which prevents the text from going up to the edge of the browser window, keeping it readable.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

After:
![columns-after](https://user-images.githubusercontent.com/7422055/99950446-d359bb80-2d7c-11eb-80c1-640fbe04b908.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
