### PR TITLE
Increase range input thumb size

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -1966,8 +1966,8 @@ input[type=radio] + label {
 	input[type=range]::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		border: 3px solid #39414d;
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: #d1e4dd;
 		cursor: pointer;
@@ -1975,8 +1975,8 @@ input[type=radio] + label {
 
 	input[type=range]::-moz-range-thumb {
 		border: 3px solid #39414d;
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: #d1e4dd;
 		cursor: pointer;
@@ -2007,8 +2007,8 @@ input[type=range]::-ms-fill-lower {
 
 input[type=range]::-ms-thumb {
 	border: 3px solid #39414d;
-	height: 25px;
-	width: 25px;
+	height: 44px;
+	width: 44px;
 	border-radius: 50%;
 	background: #d1e4dd;
 	cursor: pointer;

--- a/assets/sass/04-elements/forms.scss
+++ b/assets/sass/04-elements/forms.scss
@@ -34,7 +34,6 @@ input[type="color"],
 	.is-dark-theme & {
 		background: var(--global--color-white-90);
 	}
-
 }
 
 // Reset the negative offset from normalize to make the thicker "border" work on focus.
@@ -216,8 +215,8 @@ input[type="radio"] + label {
 	input[type="range"]::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -225,8 +224,8 @@ input[type="radio"] + label {
 
 	input[type="range"]::-moz-range-thumb {
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -257,8 +256,8 @@ input[type="range"]::-ms-fill-lower {
 
 input[type="range"]::-ms-thumb {
 	border: 3px solid var(--form--color-ranged);
-	height: 25px;
-	width: 25px;
+	height: 44px;
+	width: 44px;
 	border-radius: 50%;
 	background: var(--global--color-background);
 	cursor: pointer;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1450,8 +1450,8 @@ input[type=radio] + label {
 	input[type=range]::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -1459,8 +1459,8 @@ input[type=radio] + label {
 
 	input[type=range]::-moz-range-thumb {
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -1491,8 +1491,8 @@ input[type=range]::-ms-fill-lower {
 
 input[type=range]::-ms-thumb {
 	border: 3px solid var(--form--color-ranged);
-	height: 25px;
-	width: 25px;
+	height: 44px;
+	width: 44px;
 	border-radius: 50%;
 	background: var(--global--color-background);
 	cursor: pointer;

--- a/style.css
+++ b/style.css
@@ -1460,8 +1460,8 @@ input[type=radio] + label {
 	input[type=range]::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -1469,8 +1469,8 @@ input[type=radio] + label {
 
 	input[type=range]::-moz-range-thumb {
 		border: 3px solid var(--form--color-ranged);
-		height: 25px;
-		width: 25px;
+		height: 44px;
+		width: 44px;
 		border-radius: 50%;
 		background: var(--global--color-background);
 		cursor: pointer;
@@ -1501,8 +1501,8 @@ input[type=range]::-ms-fill-lower {
 
 input[type=range]::-ms-thumb {
 	border: 3px solid var(--form--color-ranged);
-	height: 25px;
-	width: 25px;
+	height: 44px;
+	width: 44px;
 	border-radius: 50%;
 	background: var(--global--color-background);
 	cursor: pointer;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/pull/861#issuecomment-731628911

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Increases the clickable size of the thumb in range input elements to the minimum size 44x44px.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. In the editor, add a range input element:
```
<!-- wp:html -->
<input type="range">
<!-- /wp:html -->

```
1. View the element on the front.
1. Test to make sure that the size is correct in different browsers.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Top: Chrome
Bottom: Firefox
![range](https://user-images.githubusercontent.com/7422055/99953942-4dd90a00-2d82-11eb-845e-c609efb4257f.png)



## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
