### PR TITLE
Only apply column text margins to full-width columns blocks

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -828,37 +828,37 @@ a:hover {
 	}
 }
 
-.wp-block[data-align=full] .wp-block-columns p:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns p:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h1:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h1:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h2:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h2:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h3:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h3:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h4:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h4:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h5:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h5:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }
 
-.wp-block[data-align=full] .wp-block-columns h6:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns h6:not(.has-background) {
 	padding-left: 20px;
 	padding-right: 20px;
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -806,13 +806,13 @@ a:hover {
 	}
 }
 
-.wp-block[data-align=full] .wp-block-columns p:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h1:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h2:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h3:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h4:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h5:not(.has-background),
-.wp-block[data-align=full] .wp-block-columns h6:not(.has-background) {
+.wp-block[data-align=full] > .wp-block-columns p:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h1:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h2:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h3:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h4:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h5:not(.has-background),
+.wp-block[data-align=full] > .wp-block-columns h6:not(.has-background) {
 	padding-left: var(--global--spacing-unit);
 	padding-right: var(--global--spacing-unit);
 }

--- a/assets/sass/05-blocks/columns/_editor.scss
+++ b/assets/sass/05-blocks/columns/_editor.scss
@@ -50,7 +50,7 @@
 		}
 	}
 
-	.wp-block[data-align="full"] & {
+	.wp-block[data-align="full"] > & {
 
 		p:not(.has-background),
 		h1:not(.has-background),


### PR DESCRIPTION
Partially fixes #865. Replaces #870.

This PR removes the unnecessary padding assigned to column block text-based children when they're located inside of other full-width blocks. 

The issue was just specificity: the rule was set to apply to these children when _any_ parent is full width. But it's supposed to only apply when the columns block itself is full-width.

Before|After
---|---
![Screen Shot 2020-11-23 at 3 25 34 PM](https://user-images.githubusercontent.com/1202812/100011741-2abd5300-2da0-11eb-87a9-a5ba5839da84.png)|![Screen Shot 2020-11-23 at 3 25 11 PM](https://user-images.githubusercontent.com/1202812/100011745-2b55e980-2da0-11eb-9b37-494fcb33b2bf.png)

