### PR TITLE
TwentyTwentyOne: Add bottom-border to hover states in pagination links

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7104,6 +7104,7 @@ h1.page-title {
 .navigation a:hover {
 	color: #28303d;
 	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .navigation a:focus {
@@ -7298,8 +7299,8 @@ h1.page-title {
 	text-decoration: underline;
 }
 
-.pagination .nav-links > *:not(.dots):hover,
-.comments-pagination .nav-links > *:not(.dots):hover {
+.pagination .nav-links > *:not(.dots):not(.current):hover,
+.comments-pagination .nav-links > *:not(.dots):not(.current):hover {
 	text-decoration-style: dotted;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7293,24 +7293,14 @@ h1.page-title {
 	margin-right: 13px;
 }
 
-.pagination .nav-links > *.current {
-	border-bottom: 1px solid #28303d;
-	text-decoration: none;
-}
-
-.pagination .nav-links > *:not(.dots):hover {
-	border-bottom: 1px solid #28303d;
-	text-decoration: none;
-}
-
+.pagination .nav-links > *.current,
 .comments-pagination .nav-links > *.current {
-	border-bottom: 1px solid #28303d;
-	text-decoration: none;
+	text-decoration: underline;
 }
 
+.pagination .nav-links > *:not(.dots):hover,
 .comments-pagination .nav-links > *:not(.dots):hover {
-	border-bottom: 1px solid #28303d;
-	text-decoration: none;
+	text-decoration-style: dotted;
 }
 
 .pagination .nav-links > *:first-child,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -7295,10 +7295,22 @@ h1.page-title {
 
 .pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
+	text-decoration: none;
+}
+
+.pagination .nav-links > *:not(.dots):hover {
+	border-bottom: 1px solid #28303d;
+	text-decoration: none;
 }
 
 .comments-pagination .nav-links > *.current {
 	border-bottom: 1px solid #28303d;
+	text-decoration: none;
+}
+
+.comments-pagination .nav-links > *:not(.dots):hover {
+	border-bottom: 1px solid #28303d;
+	text-decoration: none;
 }
 
 .pagination .nav-links > *:first-child,

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -163,8 +163,10 @@
 		margin-left: calc(0.66 * var(--global--spacing-unit));
 		margin-right: calc(0.66 * var(--global--spacing-unit));
 
-		&.current {
+		&.current,
+		&:not(.dots):hover {
 			border-bottom: 1px solid var(--pagination--color-text);
+			text-decoration: none;
 		}
 
 		&:first-child {

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -11,6 +11,7 @@
 		&:hover {
 			color: var(--global--color-primary-hover);
 			text-decoration: underline;
+			text-decoration-style: dotted;
 		}
 
 		&:focus {
@@ -167,7 +168,7 @@
 			text-decoration: underline;
 		}
 
-		&:not(.dots):hover {
+		&:not(.dots):not(.current):hover {
 			text-decoration-style: dotted;
 		}
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -167,7 +167,7 @@
 			text-decoration: underline;
 		}
 
-		&:not(.dots):hover {
+		&:not(.dots):not(.current):hover {
 			text-decoration-style: dotted;
 		}
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -163,10 +163,12 @@
 		margin-left: calc(0.66 * var(--global--spacing-unit));
 		margin-right: calc(0.66 * var(--global--spacing-unit));
 
-		&.current,
+		&.current {
+			text-decoration: underline;
+		}
+
 		&:not(.dots):hover {
-			border-bottom: 1px solid var(--pagination--color-text);
-			text-decoration: none;
+			text-decoration-style: dotted;
 		}
 
 		&:first-child {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5271,11 +5271,13 @@ h1.page-title {
 }
 
 .pagination .nav-links > *.current,
+.comments-pagination .nav-links > *.current {
+	text-decoration: underline;
+}
+
 .pagination .nav-links > *:not(.dots):hover,
-.comments-pagination .nav-links > *.current,
 .comments-pagination .nav-links > *:not(.dots):hover {
-	border-bottom: 1px solid var(--pagination--color-text);
-	text-decoration: none;
+	text-decoration-style: dotted;
 }
 
 .pagination .nav-links > *:first-child,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5119,6 +5119,7 @@ h1.page-title {
 .navigation a:hover {
 	color: var(--global--color-primary-hover);
 	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .navigation a:focus {
@@ -5275,8 +5276,8 @@ h1.page-title {
 	text-decoration: underline;
 }
 
-.pagination .nav-links > *:not(.dots):hover,
-.comments-pagination .nav-links > *:not(.dots):hover {
+.pagination .nav-links > *:not(.dots):not(.current):hover,
+.comments-pagination .nav-links > *:not(.dots):not(.current):hover {
 	text-decoration-style: dotted;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5271,8 +5271,11 @@ h1.page-title {
 }
 
 .pagination .nav-links > *.current,
-.comments-pagination .nav-links > *.current {
+.pagination .nav-links > *:not(.dots):hover,
+.comments-pagination .nav-links > *.current,
+.comments-pagination .nav-links > *:not(.dots):hover {
 	border-bottom: 1px solid var(--pagination--color-text);
+	text-decoration: none;
 }
 
 .pagination .nav-links > *:first-child,

--- a/style.css
+++ b/style.css
@@ -5307,8 +5307,11 @@ h1.page-title {
 }
 
 .pagination .nav-links > *.current,
-.comments-pagination .nav-links > *.current {
+.pagination .nav-links > *:not(.dots):hover,
+.comments-pagination .nav-links > *.current,
+.comments-pagination .nav-links > *:not(.dots):hover {
 	border-bottom: 1px solid var(--pagination--color-text);
+	text-decoration: none;
 }
 
 .pagination .nav-links > *:first-child,

--- a/style.css
+++ b/style.css
@@ -5155,6 +5155,7 @@ h1.page-title {
 .navigation a:hover {
 	color: var(--global--color-primary-hover);
 	text-decoration: underline;
+	text-decoration-style: dotted;
 }
 
 .navigation a:focus {
@@ -5311,8 +5312,8 @@ h1.page-title {
 	text-decoration: underline;
 }
 
-.pagination .nav-links > *:not(.dots):hover,
-.comments-pagination .nav-links > *:not(.dots):hover {
+.pagination .nav-links > *:not(.dots):not(.current):hover,
+.comments-pagination .nav-links > *:not(.dots):not(.current):hover {
 	text-decoration-style: dotted;
 }
 

--- a/style.css
+++ b/style.css
@@ -5307,11 +5307,13 @@ h1.page-title {
 }
 
 .pagination .nav-links > *.current,
+.comments-pagination .nav-links > *.current {
+	text-decoration: underline;
+}
+
 .pagination .nav-links > *:not(.dots):hover,
-.comments-pagination .nav-links > *.current,
 .comments-pagination .nav-links > *:not(.dots):hover {
-	border-bottom: 1px solid var(--pagination--color-text);
-	text-decoration: none;
+	text-decoration-style: dotted;
 }
 
 .pagination .nav-links > *:first-child,


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes: #868

## Summary

This PR simply adds bottom-borders to the hover state on pagination links to make them match the current page bottom-border. 

## Test instructions

This PR can be tested by following these steps:
1. Visit any post archive page (search, category, etc.)
2. Scroll to the bottom and hover over the pagination links.
3. You should see a thin underline beneath the hovered link that matches the bottom-border for the _current_ page text. (see screenshots below)
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before: 
![2020-11-23 16 32 03](https://user-images.githubusercontent.com/709581/100017785-71637b00-2da9-11eb-9fce-823e15dbdf00.gif)

After: 
![2020-11-23 16 30 25](https://user-images.githubusercontent.com/709581/100017667-4416cd00-2da9-11eb-891e-1c5cf35f1d78.gif)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
