### PR TITLE
Use black for focused links over a light body background

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -349,12 +349,12 @@ a:hover {
 	color: #d1e4dd;
 }
 
-.has-background-white .site a:focus {
+.is-light-theme .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
 	color: #fff;
 }
 
-.has-background-white .site a:focus .meta-nav {
+.is-light-theme .site a:focus .meta-nav {
 	color: #fff;
 }
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2199,12 +2199,12 @@ a:hover {
 	color: #d1e4dd;
 }
 
-.has-background-white .site a:focus {
+.is-light-theme .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
 	color: #fff;
 }
 
-.has-background-white .site a:focus .meta-nav {
+.is-light-theme .site a:focus .meta-nav {
 	color: #fff;
 }
 
@@ -5612,10 +5612,10 @@ table.wp-calendar-table caption {
 
 a.custom-logo-link {
 	text-decoration: none;
+	background: none;
 }
 
-.has-background-white a.custom-logo-link:focus,
-.is-dark-theme a.custom-logo-link:focus {
+a.custom-logo-link:focus {
 	background: none;
 }
 
@@ -5782,15 +5782,11 @@ a.custom-logo-link {
 	color: #28303d;
 }
 
-.site-footer > .site-info a:focus {
-	color: #28303d;
-}
-
 .is-dark-theme .site-footer > .site-info a:focus {
 	color: #d1e4dd;
 }
 
-.has-background-white .site-footer > .site-info a:focus {
+.is-light-theme .site-footer > .site-info a:focus {
 	color: #fff;
 }
 
@@ -7160,7 +7156,7 @@ h1.page-title {
 	fill: #d1e4dd;
 }
 
-.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+.is-light-theme .footer-navigation-wrapper li a:focus .svg-icon {
 	fill: #fff;
 }
 
@@ -7392,27 +7388,27 @@ h1.page-title {
 	color: #d1e4dd;
 }
 
-.has-background-white .pagination .nav-links a:active {
+.is-light-theme .pagination .nav-links a:active {
 	color: #fff;
 }
 
-.has-background-white .pagination .nav-links a:hover:active {
+.is-light-theme .pagination .nav-links a:hover:active {
 	color: #fff;
 }
 
-.has-background-white .pagination .nav-links a:hover:focus {
+.is-light-theme .pagination .nav-links a:hover:focus {
 	color: #fff;
 }
 
-.has-background-white .comments-pagination .nav-links a:active {
+.is-light-theme .comments-pagination .nav-links a:active {
 	color: #fff;
 }
 
-.has-background-white .comments-pagination .nav-links a:hover:active {
+.is-light-theme .comments-pagination .nav-links a:hover:active {
 	color: #fff;
 }
 
-.has-background-white .comments-pagination .nav-links a:hover:focus {
+.is-light-theme .comments-pagination .nav-links a:hover:focus {
 	color: #fff;
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -488,12 +488,12 @@ a:hover {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .site a:focus {
+.is-light-theme .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
-.has-background-white .site a:focus .meta-nav {
+.is-light-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -16,19 +16,16 @@
 				document.body.classList.add( 'is-dark-theme' );
 				document.documentElement.classList.add( 'is-dark-theme' );
 				document.documentElement.classList.remove( 'respect-color-scheme-preference' );
+				document.body.classList.remove( 'is-light-theme' );
+				document.documentElement.classList.remove( 'is-light-theme' );
 			} else {
+				document.body.classList.add( 'is-light-theme' );
+				document.documentElement.classList.add( 'is-light-theme' );
 				document.body.classList.remove( 'is-dark-theme' );
 				document.documentElement.classList.remove( 'is-dark-theme' );
 				if ( wp.customize( 'respect_user_color_preference' ).get() ) {
 					document.documentElement.classList.add( 'respect-color-scheme-preference' );
 				}
-			}
-
-			// Toggle the white background class.
-			if ( '#ffffff' === to.toLowerCase() ) {
-				document.body.classList.add( 'has-background-white' );
-			} else {
-				document.body.classList.remove( 'has-background-white' );
 			}
 
 			stylesheet = jQuery( '#' + stylesheetID );

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -22,14 +22,17 @@ a:hover {
 
 	background: rgba(255, 255, 255, .9);
 
-	// Change text color when the body background is dark.
+	// The dark and light theme color classes are used to increases the specificity,
+	// to override custom link colors while in focus.
+
+	// Change color when the body background is dark.
 	.is-dark-theme &,
 	.is-dark-theme & .meta-nav {
 		color: var(--wp--style--color--link, var(--global--color-background));
 	}
 
-	// Change colors when the body background is white.
-	.has-background-white & {
+	// Change colors when the body background is light.
+	.is-light-theme & {
 		background: rgba(0, 0, 0, .9);
 		color: var(--wp--style--color--link, var(--global--color-white));
 

--- a/assets/sass/06-components/footer-navigation.scss
+++ b/assets/sass/06-components/footer-navigation.scss
@@ -38,7 +38,7 @@
 			}
 
 			&:focus {
-
+				// Change color when the body background is dark.
 				.is-dark-theme & {
 
 					.svg-icon {
@@ -46,8 +46,8 @@
 					}
 				}
 
-				// Change colors when the body background is white.
-				.has-background-white & {
+				// Change color when the body background is light.
+				.is-light-theme & {
 
 					.svg-icon {
 						fill: var(--wp--style--color--link, var(--global--color-white));

--- a/assets/sass/06-components/footer.scss
+++ b/assets/sass/06-components/footer.scss
@@ -59,14 +59,13 @@
 		}
 
 		&:focus {
-			color: var(--footer--color-link-hover);
-
+			// Change color when the body background is dark.
 			.is-dark-theme & {
 				color: var(--wp--style--color--link, var(--global--color-background));
 			}
 
-			// Change colors when the body background is white.
-			.has-background-white & {
+			// Change color when the body background is light.
+			.is-light-theme & {
 				color: var(--wp--style--color--link, var(--global--color-white));
 			}
 		}

--- a/assets/sass/06-components/header.scss
+++ b/assets/sass/06-components/header.scss
@@ -80,12 +80,11 @@
 a.custom-logo-link {
 	text-decoration: none;
 
+	// Hide link background color.
+	background: none;
+	// Override link color background on focus.
 	&:focus {
-		// Change colors when the body background is white.
-		.has-background-white &,
-		.is-dark-theme & {
-			background: none;
-		}
+		background: none;
 	}
 }
 

--- a/assets/sass/06-components/pagination.scss
+++ b/assets/sass/06-components/pagination.scss
@@ -157,6 +157,7 @@
 			color: var(--pagination--color-link-hover);
 		}
 
+		// Override custom pagination link color when focused.
 		.is-dark-theme & {
 
 			a:active,
@@ -166,7 +167,7 @@
 			}
 		}
 
-		.has-background-white & {
+		.is-light-theme & {
 
 			a:active,
 			a:hover:active,

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -174,10 +174,6 @@ class Twenty_Twenty_One_Custom_Colors {
 			$classes[] = 'is-light-theme';
 		}
 
-		if ( 'ffffff' === strtolower( $background_color ) ) {
-			$classes[] = 'has-background-white';
-		}
-
 		return $classes;
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1659,12 +1659,12 @@ a:hover {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .site a:focus {
+.is-light-theme .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
-.has-background-white .site a:focus .meta-nav {
+.is-light-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -3895,10 +3895,10 @@ table.wp-calendar-table caption {
 
 a.custom-logo-link {
 	text-decoration: none;
+	background: none;
 }
 
-.has-background-white a.custom-logo-link:focus,
-.is-dark-theme a.custom-logo-link:focus {
+a.custom-logo-link:focus {
 	background: none;
 }
 
@@ -4059,15 +4059,11 @@ a.custom-logo-link {
 	color: var(--footer--color-link-hover);
 }
 
-.site-footer > .site-info a:focus {
-	color: var(--footer--color-link-hover);
-}
-
 .is-dark-theme .site-footer > .site-info a:focus {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .site-footer > .site-info a:focus {
+.is-light-theme .site-footer > .site-info a:focus {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -5178,7 +5174,7 @@ h1.page-title {
 	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+.is-light-theme .footer-navigation-wrapper li a:focus .svg-icon {
 	fill: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -5363,12 +5359,12 @@ h1.page-title {
 	color: var(--global--color-background);
 }
 
-.has-background-white .pagination .nav-links a:active,
-.has-background-white .pagination .nav-links a:hover:active,
-.has-background-white .pagination .nav-links a:hover:focus,
-.has-background-white .comments-pagination .nav-links a:active,
-.has-background-white .comments-pagination .nav-links a:hover:active,
-.has-background-white .comments-pagination .nav-links a:hover:focus {
+.is-light-theme .pagination .nav-links a:active,
+.is-light-theme .pagination .nav-links a:hover:active,
+.is-light-theme .pagination .nav-links a:hover:focus,
+.is-light-theme .comments-pagination .nav-links a:active,
+.is-light-theme .comments-pagination .nav-links a:hover:active,
+.is-light-theme .comments-pagination .nav-links a:hover:focus {
 	color: var(--global--color-white);
 }
 

--- a/style.css
+++ b/style.css
@@ -1669,12 +1669,12 @@ a:hover {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .site a:focus {
+.is-light-theme .site a:focus {
 	background: rgba(0, 0, 0, 0.9);
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
-.has-background-white .site a:focus .meta-nav {
+.is-light-theme .site a:focus .meta-nav {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -3915,10 +3915,10 @@ table.wp-calendar-table caption {
 
 a.custom-logo-link {
 	text-decoration: none;
+	background: none;
 }
 
-.has-background-white a.custom-logo-link:focus,
-.is-dark-theme a.custom-logo-link:focus {
+a.custom-logo-link:focus {
 	background: none;
 }
 
@@ -4079,15 +4079,11 @@ a.custom-logo-link {
 	color: var(--footer--color-link-hover);
 }
 
-.site-footer > .site-info a:focus {
-	color: var(--footer--color-link-hover);
-}
-
 .is-dark-theme .site-footer > .site-info a:focus {
 	color: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .site-footer > .site-info a:focus {
+.is-light-theme .site-footer > .site-info a:focus {
 	color: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -5214,7 +5210,7 @@ h1.page-title {
 	fill: var(--wp--style--color--link, var(--global--color-background));
 }
 
-.has-background-white .footer-navigation-wrapper li a:focus .svg-icon {
+.is-light-theme .footer-navigation-wrapper li a:focus .svg-icon {
 	fill: var(--wp--style--color--link, var(--global--color-white));
 }
 
@@ -5399,12 +5395,12 @@ h1.page-title {
 	color: var(--global--color-background);
 }
 
-.has-background-white .pagination .nav-links a:active,
-.has-background-white .pagination .nav-links a:hover:active,
-.has-background-white .pagination .nav-links a:hover:focus,
-.has-background-white .comments-pagination .nav-links a:active,
-.has-background-white .comments-pagination .nav-links a:hover:active,
-.has-background-white .comments-pagination .nav-links a:hover:focus {
+.is-light-theme .pagination .nav-links a:active,
+.is-light-theme .pagination .nav-links a:hover:active,
+.is-light-theme .pagination .nav-links a:hover:focus,
+.is-light-theme .comments-pagination .nav-links a:active,
+.is-light-theme .comments-pagination .nav-links a:hover:active,
+.is-light-theme .comments-pagination .nav-links a:hover:focus {
 	color: var(--global--color-white);
 }
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/873

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Increases the readability of focused links over light body backgrounds, by using a black link background color that has a higher contrast ratio against the body background.

Removes the ` has-background-white ` CSS class and implements the previously unused `is-light-theme` class instead.
`is-dark-theme` is still used for dark backgrounds.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

The theme has CSS variables for link text colors for example for the primary navigation, pagination and footer area.
To override this, the `is-*-theme` body classes are used to increase the specificity.

## Test instructions

This PR can be tested by following these steps:
1. Add a transparent logo.
1. In the Customizer, change the body background color.
1. Focus on a link: Preferably, tab through an entire page and test all links.
1.  Change color and repeat.
1. Confirm that the colors are readable
1. Confirm that the colors do not affect the transparent logo

Also pay attention to footer credit links and social icons in the footer menu.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

After:
![focus-after](https://user-images.githubusercontent.com/7422055/100070185-eaaaae80-2e39-11eb-822d-79ee3fcd01d1.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
