### PR TITLE
Display a caption for featured images if one is set.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -194,7 +194,7 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 				the_post_thumbnail( 'post-thumbnail', array( 'loading' => 'eager' ) );
 				?>
 				<?php if ( wp_get_attachment_caption( get_post_thumbnail_id() ) ) : ?>
-					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption(  get_post_thumbnail_id() ) ); ?></figcaption>
+					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption( get_post_thumbnail_id() ) ); ?></figcaption>
 				<?php endif; ?>
 			</figure><!-- .post-thumbnail -->
 
@@ -205,7 +205,7 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 					<?php the_post_thumbnail( 'post-thumbnail' ); ?>
 				</a>
 				<?php if ( wp_get_attachment_caption( get_post_thumbnail_id() ) ) : ?>
-					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption(  get_post_thumbnail_id() ) ); ?></figcaption>
+					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption( get_post_thumbnail_id() ) ); ?></figcaption>
 				<?php endif; ?>
 			</figure>
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -193,6 +193,9 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 				// Thumbnail is loaded eagerly because it's going to be in the viewport immediately.
 				the_post_thumbnail( 'post-thumbnail', array( 'loading' => 'eager' ) );
 				?>
+				<?php if ( wp_get_attachment_caption( get_post_thumbnail_id() ) ) : ?>
+					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption(  get_post_thumbnail_id() ) ); ?></figcaption>
+				<?php endif; ?>
 			</figure><!-- .post-thumbnail -->
 
 		<?php else : ?>
@@ -201,6 +204,9 @@ if ( ! function_exists( 'twenty_twenty_one_post_thumbnail' ) ) {
 				<a class="post-thumbnail-inner alignwide" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 					<?php the_post_thumbnail( 'post-thumbnail' ); ?>
 				</a>
+				<?php if ( wp_get_attachment_caption( get_post_thumbnail_id() ) ) : ?>
+					<figcaption class="wp-caption-text"><?php echo wp_kses_post( wp_get_attachment_caption(  get_post_thumbnail_id() ) ); ?></figcaption>
+				<?php endif; ?>
 			</figure>
 
 		<?php endif; ?>


### PR DESCRIPTION
Fixes #876.

## Summary
This PR adds a `<figcaption>` element within featured image `<figure>` tags if a caption is set for the image.

## Test instructions

This PR can be tested by following these steps:
1. Upload an image and add a caption.
1. Select the image as the featured image for a post.

## Screenshots

I've made this change on my personal site. here's how it displays.

![Screenshot_2020-11-24 Jonathan Desrosiers](https://user-images.githubusercontent.com/359867/100103383-d2836100-2e32-11eb-82d7-d85c25290ade.jpg)

![Screenshot_2020-11-24 Jonathan Desrosiers](https://user-images.githubusercontent.com/359867/100103445-e8912180-2e32-11eb-9637-8648086d6e09.png)

## Quality assurance
* [X] I have thought about any security implications this code might add.
* [X] I have checked that this code doesn't impact performance (greatly).
* [X] I have tested this code to the best of my abilities
* [X] I have checked that this code does not affect the accessibility negatively
