### PR TITLE
Social Links Block: Fix focus on default block style

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4997,6 +4997,10 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links a:focus {
+	color: #28303d;
+}
+
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
 	color: #28303d;
 }

--- a/assets/sass/05-blocks/social-icons/_style.scss
+++ b/assets/sass/05-blocks/social-icons/_style.scss
@@ -1,11 +1,18 @@
-.wp-block-social-links.is-style-twentytwentyone-social-icons-color {
+.wp-block-social-links {
 
-	a {
+	a:focus {
 		color: var(--global--color-primary);
 	}
 
-	.wp-social-link {
-		background: none;
-	}
+	&.is-style-twentytwentyone-social-icons-color {
 
+		a {
+			color: var(--global--color-primary);
+		}
+
+		.wp-social-link {
+			background: none;
+		}
+
+	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3504,6 +3504,10 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links a:focus {
+	color: var(--global--color-primary);
+}
+
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
 	color: var(--global--color-primary);
 }

--- a/style.css
+++ b/style.css
@@ -3514,6 +3514,10 @@ hr.wp-block-separator.is-style-dots:before {
 	border-color: currentColor;
 }
 
+.wp-block-social-links a:focus {
+	color: var(--global--color-primary);
+}
+
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color a {
 	color: var(--global--color-primary);
 }


### PR DESCRIPTION
The white focus background on the Social Links block makes the white icons functionally invisible. This PR updates the focus color to `--global--color-primary`, which is dark grey and has contrast against the white background.

## Screenshots

Before:
![Screen Shot 2020-11-24 at 12 30 27 PM](https://user-images.githubusercontent.com/541093/100130569-dd4cee80-2e50-11eb-8095-b340950ed49c.png)

After:
![Screen Shot 2020-11-24 at 12 30 35 PM](https://user-images.githubusercontent.com/541093/100130577-de7e1b80-2e50-11eb-9830-0a6907e492df.png)

(The `li`'s background is slightly visible through the semi-transparent `a:focus` background, but I don't _think_ we need to fix anything there.)

## Test instructions

This PR can be tested by following these steps:
1. Add a Social Links block and fill in some links, either default or "pill" style
2. View the post/page, not in dark mode
3. Tab through to focus on the social links
4. You should be able to see the social icon against the background

Check that there are no regressions with the other styles/dark mode.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
