### PR TITLE
Try: Use luminance of color to check for "white" background

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -15,17 +15,21 @@
 			if ( isDark ) {
 				document.body.classList.add( 'is-dark-theme' );
 				document.documentElement.classList.add( 'is-dark-theme' );
+				document.body.classList.remove( 'is-light-theme' );
+				document.documentElement.classList.remove( 'is-light-theme' );
 				document.documentElement.classList.remove( 'respect-color-scheme-preference' );
 			} else {
 				document.body.classList.remove( 'is-dark-theme' );
 				document.documentElement.classList.remove( 'is-dark-theme' );
+				document.body.classList.add( 'is-light-theme' );
+				document.documentElement.classList.add( 'is-light-theme' );
 				if ( wp.customize( 'respect_user_color_preference' ).get() ) {
 					document.documentElement.classList.add( 'respect-color-scheme-preference' );
 				}
 			}
 
 			// Toggle the white background class.
-			if ( '#ffffff' === to.toLowerCase() ) {
+			if ( 225 <= lum ) {
 				document.body.classList.add( 'has-background-white' );
 			} else {
 				document.body.classList.remove( 'has-background-white' );

--- a/classes/class-twenty-twenty-one-custom-colors.php
+++ b/classes/class-twenty-twenty-one-custom-colors.php
@@ -168,13 +168,15 @@ class Twenty_Twenty_One_Custom_Colors {
 	 */
 	public function body_class( $classes ) {
 		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
-		if ( 127 > self::get_relative_luminance_from_hex( $background_color ) ) {
+		$luminance        = self::get_relative_luminance_from_hex( $background_color );
+
+		if ( 127 > $luminance ) {
 			$classes[] = 'is-dark-theme';
 		} else {
 			$classes[] = 'is-light-theme';
 		}
 
-		if ( 'ffffff' === strtolower( $background_color ) ) {
+		if ( 225 <= $luminance ) {
 			$classes[] = 'has-background-white';
 		}
 


### PR DESCRIPTION
This PR is an alternate solution to #873 (other solution is #877). This expands what colors are considered "white" for the higher-contrast black focus state.

This addresses @melchoyce's comment,

> Is there any way to keep the white focus styles in the colorful schemes?

Fixes #873

## Summary
Instead of checking for exactly `#ffffff`, this checks whether the luminance of the color is greater than 225. This ensures most of the default background colors have a white focus color, while custom light-grey (like `#eee`) will trigger the black focus style. The default yellow color also has a high-enough luminance that it triggers the black focus.

## Relevant technical choices:

In the interest of not changing the CSS, I'm sticking with the class name `has-background-white`; I'm on the fence about whether it's too unclear though.

## Test instructions

This PR can be tested by following these steps:
1. Play with a number of background colors. The focus style should be visible.

## Screenshots

I've got a lot of screenshots, each one the same page with the title focused.

<details>
<summary>View screenshots</summary>

![black](https://user-images.githubusercontent.com/541093/100133588-f6f03500-2e54-11eb-815d-49cb1c7a55f5.png)

![grey](https://user-images.githubusercontent.com/541093/100133598-f8b9f880-2e54-11eb-9571-ecd101225ca3.png)

![blue](https://user-images.githubusercontent.com/541093/100133592-f788cb80-2e54-11eb-8414-170b7c12e5d6.png)

![red](https://user-images.githubusercontent.com/541093/100133600-f9528f00-2e54-11eb-8c1e-3a92542553de.png)

![yellow](https://user-images.githubusercontent.com/541093/100133604-f9eb2580-2e54-11eb-9027-69f3ca4a379d.png)

![white](https://user-images.githubusercontent.com/541093/100133601-f9528f00-2e54-11eb-9f62-8e33fba111fd.png)

Dark Mode:
![dark-mode](https://user-images.githubusercontent.com/541093/100133597-f8b9f880-2e54-11eb-842a-01914d784b1c.png)

Custom color: `#eeeeee`
![custom-eee](https://user-images.githubusercontent.com/541093/100133594-f8216200-2e54-11eb-8c10-69d55fcb6062.png)

Custom color: `#eef4d7`
![custom-eef4d7](https://user-images.githubusercontent.com/541093/100133596-f8216200-2e54-11eb-9642-1af3ea05601f.png)

</details>

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
