### PR TITLE
Try: Add a dotted underline to focused links

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -338,6 +338,8 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
 

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -338,7 +338,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -338,7 +338,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2188,7 +2188,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2188,7 +2188,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
@@ -7018,6 +7018,7 @@ h1.page-title {
 	position: relative;
 	z-index: 99999;
 	outline-offset: 0;
+	text-decoration-thickness: 2px;
 }
 
 .primary-navigation .current-menu-item > a:first-child,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2188,6 +2188,8 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
 

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -480,7 +480,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -480,7 +480,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -480,6 +480,8 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
 

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -20,7 +20,7 @@ a:hover {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, .9);
 

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -20,6 +20,8 @@ a:hover {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, .9);
 
 	// Change text color when the body background is dark.

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -20,7 +20,7 @@ a:hover {
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, .9);
 

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -416,6 +416,7 @@
 			position: relative;
 			z-index: 99999; // Ensure focus styles appear above absolute positioned elements
 			outline-offset: 0;
+			text-decoration-thickness: 2px;
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1651,7 +1651,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1651,7 +1651,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
@@ -5042,6 +5042,7 @@ h1.page-title {
 	position: relative;
 	z-index: 99999;
 	outline-offset: 0;
+	text-decoration-thickness: 2px;
 }
 
 .primary-navigation .current-menu-item > a:first-child,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1651,6 +1651,8 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
 

--- a/style.css
+++ b/style.css
@@ -1661,6 +1661,8 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+	text-decoration-style: dotted;
+	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
 

--- a/style.css
+++ b/style.css
@@ -1661,7 +1661,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration: underline dotted currentColor;
+	text-decoration: underline 1px dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }
@@ -5078,6 +5078,7 @@ h1.page-title {
 	position: relative;
 	z-index: 99999;
 	outline-offset: 0;
+	text-decoration-thickness: 2px;
 }
 
 .primary-navigation .current-menu-item > a:first-child,

--- a/style.css
+++ b/style.css
@@ -1661,7 +1661,7 @@ a:hover {
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
-	text-decoration-style: dotted;
+	text-decoration: underline dotted currentColor;
 	text-decoration-skip-ink: none;
 	background: rgba(255, 255, 255, 0.9);
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Follow up on https://github.com/WordPress/twentytwentyone/issues/873

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

Adds the dotted underline (which is already used on hover) to focused links.
This _additional_ text decoration change does not rely on color, so the contrast ratio between the body light background and the white link focus background is less important.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. View the front of the site
1. Place focus on links for example using tab.
1. See the dotted underline.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Before:
![before-solid](https://user-images.githubusercontent.com/7422055/100245421-52472380-2f38-11eb-87b1-7cafc79a8f4c.png)

After:
![dotted](https://user-images.githubusercontent.com/7422055/100245157-07c5a700-2f38-11eb-9b5e-389c8891653c.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
