### PR TITLE
CSS: Remove `has-background-background-color` selector

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -374,11 +374,11 @@ a:hover {
 	outline: 2px dotted #28303d;
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a {
+.has-background .has-link-color a {
 	color: #28303d;
 }
 
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background.has-link-color a {
 	color: #28303d;
 }
 
@@ -1979,9 +1979,9 @@ pre.wp-block-preformatted {
 	font-style: normal;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[style*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.has-background .wp-block-quote .wp-block-quote__citation,
+[class*=background-color] .wp-block-quote .wp-block-quote__citation,
+[style*=background-color] .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*=background-image] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
 }
@@ -2801,13 +2801,13 @@ hr.is-style-dots:before {
 	color: #28303d;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-separator,
-[class*=background-color]:not(.has-background-background-color) .wp-block-separator,
-[style*=background-color]:not(.has-background-background-color) .wp-block-separator,
+.has-background .wp-block-separator,
+[class*=background-color] .wp-block-separator,
+[style*=background-color] .wp-block-separator,
 .wp-block-cover[style*=background-image] .wp-block-separator,
-.has-background:not(.has-background-background-color) hr,
-[class*=background-color]:not(.has-background-background-color) hr,
-[style*=background-color]:not(.has-background-background-color) hr,
+.has-background hr,
+[class*=background-color] hr,
+[style*=background-color] hr,
 .wp-block-cover[style*=background-image] hr {
 	border-color: currentColor;
 }
@@ -3145,7 +3145,7 @@ pre.wp-block-verse {
 	color: #39414d;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,
@@ -3313,11 +3313,11 @@ body {
 	text-decoration: none;
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a {
+.has-background .has-link-color a {
 	color: #28303d;
 }
 
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background.has-link-color a {
 	color: #28303d;
 }
 
@@ -3366,7 +3366,7 @@ a {
 	color: #fff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2224,11 +2224,11 @@ a:hover {
 	outline: 2px dotted #28303d;
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a {
+.has-background .has-link-color a {
 	color: #28303d;
 }
 
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background.has-link-color a {
 	color: #28303d;
 }
 
@@ -4275,16 +4275,16 @@ pre.wp-block-preformatted {
 	left: 8px;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.has-background .wp-block-quote .wp-block-quote__citation,
+[class*=background-color] .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*=background-image] .wp-block-quote .wp-block-quote__citation,
-.has-background:not(.has-background-background-color) .wp-block-quote cite,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote cite,
+.has-background .wp-block-quote cite,
+[class*=background-color] .wp-block-quote cite,
 [style*=background-color] .wp-block-quote cite,
 .wp-block-cover[style*=background-image] .wp-block-quote cite,
-.has-background:not(.has-background-background-color) .wp-block-quote footer,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote footer,
+.has-background .wp-block-quote footer,
+[class*=background-color] .wp-block-quote footer,
 [style*=background-color] .wp-block-quote footer,
 .wp-block-cover[style*=background-image] .wp-block-quote footer {
 	color: currentColor;
@@ -4656,8 +4656,8 @@ pre.wp-block-preformatted {
 	border-color: #39414d;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
-[class*=background-color]:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
+.has-background .wp-block-search .wp-block-search__input,
+[class*=background-color] .wp-block-search .wp-block-search__input,
 [style*=background-color] .wp-block-search .wp-block-search__input,
 .wp-block-cover[style*=background-image] .wp-block-search .wp-block-search__input {
 	border-color: currentColor;
@@ -4990,8 +4990,8 @@ hr.wp-block-separator.is-style-dots:before {
 	}
 }
 
-.has-background:not(.has-background-background-color) hr.wp-block-separator,
-[class*=background-color]:not(.has-background-background-color) hr.wp-block-separator,
+.has-background hr.wp-block-separator,
+[class*=background-color] hr.wp-block-separator,
 [style*=background-color] hr.wp-block-separator,
 .wp-block-cover[style*=background-image] hr.wp-block-separator {
 	border-color: currentColor;
@@ -7756,7 +7756,7 @@ h1.page-title {
 	color: #fff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -513,8 +513,8 @@ a:hover {
 	outline: 2px dotted var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a,
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background .has-link-color a,
+.has-background.has-link-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
@@ -1537,9 +1537,9 @@ pre.wp-block-preformatted {
 	font-style: var(--quote--font-style-cite);
 }
 
-.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[style*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.has-background .wp-block-quote .wp-block-quote__citation,
+[class*=background-color] .wp-block-quote .wp-block-quote__citation,
+[style*=background-color] .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*=background-image] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
 }
@@ -2049,13 +2049,13 @@ hr.is-style-dots:before {
 	color: var(--separator--border-color);
 }
 
-.has-background:not(.has-background-background-color) .wp-block-separator,
-[class*=background-color]:not(.has-background-background-color) .wp-block-separator,
-[style*=background-color]:not(.has-background-background-color) .wp-block-separator,
+.has-background .wp-block-separator,
+[class*=background-color] .wp-block-separator,
+[style*=background-color] .wp-block-separator,
 .wp-block-cover[style*=background-image] .wp-block-separator,
-.has-background:not(.has-background-background-color) hr,
-[class*=background-color]:not(.has-background-background-color) hr,
-[style*=background-color]:not(.has-background-background-color) hr,
+.has-background hr,
+[class*=background-color] hr,
+[style*=background-color] hr,
 .wp-block-cover[style*=background-image] hr {
 	border-color: currentColor;
 }
@@ -2244,7 +2244,7 @@ pre.wp-block-verse {
 	color: var(--global--color-secondary);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,
@@ -2365,8 +2365,8 @@ body {
 	text-decoration: none;
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a,
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background .has-link-color a,
+.has-background.has-link-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
@@ -2415,7 +2415,7 @@ a {
 	color: var(--global--color-white);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,

--- a/assets/sass/04-elements/links.scss
+++ b/assets/sass/04-elements/links.scss
@@ -57,7 +57,7 @@ a:hover {
 
 // Enforce the custom link color even if a custom background color has been set.
 // The extra specificity here is required to override the background color styles.
-.has-background:not(.has-background-background-color) {
+.has-background {
 	// Target both current level and nested block.
 	.has-link-color a,
 	&.has-link-color a {

--- a/assets/sass/05-blocks/quote/_editor.scss
+++ b/assets/sass/05-blocks/quote/_editor.scss
@@ -27,9 +27,9 @@
 		font-size: var(--global--font-size-xs);
 		font-style: var(--quote--font-style-cite);
 
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
-		[style*="background-color"]:not(.has-background-background-color) &,
+		.has-background &,
+		[class*="background-color"] &,
+		[style*="background-color"] &,
 		.wp-block-cover[style*="background-image"] & {
 			color: currentColor;
 		}

--- a/assets/sass/05-blocks/quote/_style.scss
+++ b/assets/sass/05-blocks/quote/_style.scss
@@ -12,8 +12,8 @@
 	cite,
 	footer {
 
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
+		.has-background &,
+		[class*="background-color"] &,
 		[style*="background-color"] &,
 		.wp-block-cover[style*="background-image"] & {
 			color: currentColor;

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -35,8 +35,8 @@
 			border-color: var(--form--border-color);
 		}
 
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
+		.has-background &,
+		[class*="background-color"] &,
 		[style*="background-color"] &,
 		.wp-block-cover[style*="background-image"] & {
 			border-color: currentColor;

--- a/assets/sass/05-blocks/separator/_editor.scss
+++ b/assets/sass/05-blocks/separator/_editor.scss
@@ -39,9 +39,9 @@ hr {
 		}
 	}
 
-	.has-background:not(.has-background-background-color) &,
-	[class*="background-color"]:not(.has-background-background-color) &,
-	[style*="background-color"]:not(.has-background-background-color) &,
+	.has-background &,
+	[class*="background-color"] &,
+	[style*="background-color"] &,
 	.wp-block-cover[style*="background-image"] & {
 		border-color: currentColor;
 	}

--- a/assets/sass/05-blocks/separator/_style.scss
+++ b/assets/sass/05-blocks/separator/_style.scss
@@ -50,8 +50,8 @@ hr {
 			}
 		}
 
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
+		.has-background &,
+		[class*="background-color"] &,
 		[style*="background-color"] &,
 		.wp-block-cover[style*="background-image"] & {
 			border-color: currentColor;

--- a/assets/sass/05-blocks/utilities/_editor.scss
+++ b/assets/sass/05-blocks/utilities/_editor.scss
@@ -37,7 +37,7 @@
 // Gutenberg background-color options
 .has-background {
 
-	&:not(.has-background-background-color) a:not(.wp-block-button__link),
+	a,
 	p,
 	h1,
 	h2,

--- a/assets/sass/06-components/editor.scss
+++ b/assets/sass/06-components/editor.scss
@@ -30,7 +30,7 @@ body {
 
 // Enforce the custom link color even if a custom background color has been set.
 // The extra specificity here is required to override the background color styles.
-.has-background:not(.has-background-background-color) {
+.has-background {
 	// Target both current level and nested block.
 	.has-link-color a,
 	&.has-link-color a {

--- a/assets/sass/07-utilities/color-palette.scss
+++ b/assets/sass/07-utilities/color-palette.scss
@@ -43,7 +43,7 @@
 // Gutenberg background-color options
 .has-background {
 
-	&:not(.has-background-background-color) a:not(.wp-block-button__link),
+	a,
 	p,
 	h1,
 	h2,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1684,8 +1684,8 @@ a:hover {
 	outline: 2px dotted var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a,
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background .has-link-color a,
+.has-background.has-link-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
@@ -3044,16 +3044,16 @@ pre.wp-block-preformatted {
 	right: 8px;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.has-background .wp-block-quote .wp-block-quote__citation,
+[class*=background-color] .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*=background-image] .wp-block-quote .wp-block-quote__citation,
-.has-background:not(.has-background-background-color) .wp-block-quote cite,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote cite,
+.has-background .wp-block-quote cite,
+[class*=background-color] .wp-block-quote cite,
 [style*=background-color] .wp-block-quote cite,
 .wp-block-cover[style*=background-image] .wp-block-quote cite,
-.has-background:not(.has-background-background-color) .wp-block-quote footer,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote footer,
+.has-background .wp-block-quote footer,
+[class*=background-color] .wp-block-quote footer,
 [style*=background-color] .wp-block-quote footer,
 .wp-block-cover[style*=background-image] .wp-block-quote footer {
 	color: currentColor;
@@ -3311,8 +3311,8 @@ pre.wp-block-preformatted {
 	border-color: var(--form--border-color);
 }
 
-.has-background:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
-[class*=background-color]:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
+.has-background .wp-block-search .wp-block-search__input,
+[class*=background-color] .wp-block-search .wp-block-search__input,
 [style*=background-color] .wp-block-search .wp-block-search__input,
 .wp-block-cover[style*=background-image] .wp-block-search .wp-block-search__input {
 	border-color: currentColor;
@@ -3497,8 +3497,8 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-right: var(--global--font-size-sm);
 }
 
-.has-background:not(.has-background-background-color) hr.wp-block-separator,
-[class*=background-color]:not(.has-background-background-color) hr.wp-block-separator,
+.has-background hr.wp-block-separator,
+[class*=background-color] hr.wp-block-separator,
 [style*=background-color] hr.wp-block-separator,
 .wp-block-cover[style*=background-image] hr.wp-block-separator {
 	border-color: currentColor;
@@ -5677,7 +5677,7 @@ h1.page-title {
 	color: var(--global--color-white);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,

--- a/style.css
+++ b/style.css
@@ -1694,8 +1694,8 @@ a:hover {
 	outline: 2px dotted var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.has-background:not(.has-background-background-color) .has-link-color a,
-.has-background:not(.has-background-background-color).has-link-color a {
+.has-background .has-link-color a,
+.has-background.has-link-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
@@ -3054,16 +3054,16 @@ pre.wp-block-preformatted {
 	left: 8px;
 }
 
-.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.has-background .wp-block-quote .wp-block-quote__citation,
+[class*=background-color] .wp-block-quote .wp-block-quote__citation,
 [style*=background-color] .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*=background-image] .wp-block-quote .wp-block-quote__citation,
-.has-background:not(.has-background-background-color) .wp-block-quote cite,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote cite,
+.has-background .wp-block-quote cite,
+[class*=background-color] .wp-block-quote cite,
 [style*=background-color] .wp-block-quote cite,
 .wp-block-cover[style*=background-image] .wp-block-quote cite,
-.has-background:not(.has-background-background-color) .wp-block-quote footer,
-[class*=background-color]:not(.has-background-background-color) .wp-block-quote footer,
+.has-background .wp-block-quote footer,
+[class*=background-color] .wp-block-quote footer,
 [style*=background-color] .wp-block-quote footer,
 .wp-block-cover[style*=background-image] .wp-block-quote footer {
 	color: currentColor;
@@ -3321,8 +3321,8 @@ pre.wp-block-preformatted {
 	border-color: var(--form--border-color);
 }
 
-.has-background:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
-[class*=background-color]:not(.has-background-background-color) .wp-block-search .wp-block-search__input,
+.has-background .wp-block-search .wp-block-search__input,
+[class*=background-color] .wp-block-search .wp-block-search__input,
 [style*=background-color] .wp-block-search .wp-block-search__input,
 .wp-block-cover[style*=background-image] .wp-block-search .wp-block-search__input {
 	border-color: currentColor;
@@ -3507,8 +3507,8 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-left: var(--global--font-size-sm);
 }
 
-.has-background:not(.has-background-background-color) hr.wp-block-separator,
-[class*=background-color]:not(.has-background-background-color) hr.wp-block-separator,
+.has-background hr.wp-block-separator,
+[class*=background-color] hr.wp-block-separator,
 [style*=background-color] hr.wp-block-separator,
 .wp-block-cover[style*=background-image] hr.wp-block-separator {
 	border-color: currentColor;
@@ -5713,7 +5713,7 @@ h1.page-title {
 	color: var(--global--color-white);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
+.has-background a,
 .has-background p,
 .has-background h1,
 .has-background h2,


### PR DESCRIPTION
The `has-background-background-color` is leftover from the original theme, which had [a color called `background`](https://github.com/Automattic/themes/blob/e878ddb802a713e66660b9ae4d1eddb48a59489d/seedlet/functions.php#L187-L191) in the palette. This rule was intended to exclude any block with that background color, but this color doesn't exist in Twenty Twenty-One, so this class is never applied anywhere. It should be safe to remove, with no effect on the theme.

## Test instructions

This PR can be tested by following these steps:
1. Make sure blocks with background colors look correct — there should be no visual changes between this branch & trunk.

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
