### PR TITLE
Rename theme support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -333,7 +333,7 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 		add_theme_support( 'experimental-link-color' );
 
 		// Add support for experimental cover block spacing.
-		add_theme_support( 'experimental-custom-spacing' );
+		add_theme_support( 'custom-spacing' );
 
 		// Add support for custom units.
 		// This was removed in WordPress 5.6 but is still required to properly support WP 5.5.


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/639

## Summary
Renames `add_theme_support( 'experimental-custom-spacing' );` to `add_theme_support( 'custom-spacing' );`

## Test instructions

This PR can be tested by following these steps:
1. NOTE: This can not be tested without the development version of Gutenberg (master)
1. With the development version active, add a cover block 
1. In block settings sidebar, scroll down below the color settings and locate the padding controls.
1. Test the padding controls, save and view the front
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

![experimental-spacing](https://user-images.githubusercontent.com/7422055/100362624-f514a600-2ffb-11eb-8d6f-d1b4e2726faa.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
