### PR TITLE
Fix button cursor by removing the crop-text mixin

### DIFF
--- a/assets/css/ie-editor.css
+++ b/assets/css/ie-editor.css
@@ -396,22 +396,6 @@ a:hover {
 	padding: 15px 30px;
 }
 
-.wp-block-button__link:before,
-.wp-block-button__link:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
-}
-
 .wp-block-button__link:focus {
 	background: transparent;
 	outline-offset: -6px;
@@ -917,22 +901,6 @@ a:hover {
 	text-decoration: none;
 	padding: 15px 30px;
 	display: inline-block;
-}
-
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {
@@ -2380,22 +2348,6 @@ pre.wp-block-preformatted {
 	margin-left: 0;
 	background-color: transparent;
 	color: #39414d;
-}
-
-.wp-block-search .wp-block-search__button:before,
-.wp-block-search .wp-block-search__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
 }
 
 .wp-block-search .wp-block-search__button:focus {

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -2311,62 +2311,6 @@ input[type=reset] {
 	padding: 15px 30px;
 }
 
-.site .button:before,
-.site .button:after,
-input[type=submit]:before,
-input[type=submit]:after,
-input[type=reset]:before,
-input[type=reset]:after,
-.wp-block-search__button:before,
-.wp-block-search__button:after,
-.wp-block-button .wp-block-button__link:before,
-.wp-block-button .wp-block-button__link:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.site .button:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-input[type=submit]:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-input[type=reset]:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-search__button:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.site .button:after {
-	margin-top: -calc(1em - 0);
-}
-
-input[type=submit]:after {
-	margin-top: -calc(1em - 0);
-}
-
-input[type=reset]:after {
-	margin-top: -calc(1em - 0);
-}
-
-.wp-block-search__button:after {
-	margin-top: -calc(1em - 0);
-}
-
-.wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(1em - 0);
-}
-
 .site .button:focus,
 input[type=submit]:focus,
 input[type=reset]:focus,
@@ -3092,22 +3036,6 @@ input[type=reset]:hover {
 	text-decoration: none;
 	padding: 15px 30px;
 	display: inline-block;
-}
-
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(1em - 0);
-}
-
-.wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(1em - 0);
 }
 
 .wp-block-file .wp-block-file__button:focus {

--- a/assets/css/style-editor.css
+++ b/assets/css/style-editor.css
@@ -532,22 +532,6 @@ a:hover {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.wp-block-button__link:before,
-.wp-block-button__link:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-button__link:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.wp-block-button__link:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
-}
-
 .wp-block-button__link:focus {
 	background: transparent;
 	outline-offset: -6px;
@@ -871,22 +855,6 @@ a:hover {
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 	display: inline-block;
-}
-
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
 .wp-block-file .wp-block-file__button:focus {
@@ -1821,22 +1789,6 @@ pre.wp-block-preformatted {
 	margin-left: 0;
 	background-color: transparent;
 	color: var(--button--color-text-hover);
-}
-
-.wp-block-search .wp-block-search__button:before,
-.wp-block-search .wp-block-search__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-search .wp-block-search__button:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.wp-block-search .wp-block-search__button:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
 .wp-block-search .wp-block-search__button:focus {

--- a/assets/sass/02-tools/mixins.scss
+++ b/assets/sass/02-tools/mixins.scss
@@ -17,35 +17,10 @@
 	}
 }
 
-// Crop Text Boundry
-// - Sets a fixed-width on content within alignwide and alignfull blocks
-@mixin crop-text($inset-line-height: 1) {
-
-	line-height: $inset-line-height;
-	$offset-top: calc(.5em * #{$inset-line-height} + -.38);
-	$offset-bottom: calc(.5em * #{$inset-line-height} + -.39);
-
-	&:before,
-	&:after {
-		content: "";
-		display: block;
-		height: 0;
-		width: 0;
-	}
-
-	&:before {
-		margin-bottom: -($offset-top);
-	}
-
-	&:after {
-		margin-top: -($offset-bottom);
-	}
-}
-
 // Button style
 // - Applies button styles to blocks and elements that share them.
 @mixin button-style() {
-	@include crop-text(var(--button--line-height));
+	line-height: var(--button--line-height);
 	color: var(--button--color-text);
 	cursor: pointer;
 	font-weight: var(--button--font-weight);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1716,38 +1716,6 @@ input[type=reset],
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.site .button:before,
-.site .button:after,
-input[type=submit]:before,
-input[type=submit]:after,
-input[type=reset]:before,
-input[type=reset]:after,
-.wp-block-search__button:before,
-.wp-block-search__button:after,
-.wp-block-button .wp-block-button__link:before,
-.wp-block-button .wp-block-button__link:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.site .button:before,
-input[type=submit]:before,
-input[type=reset]:before,
-.wp-block-search__button:before,
-.wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.site .button:after,
-input[type=submit]:after,
-input[type=reset]:after,
-.wp-block-search__button:after,
-.wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
-}
-
 .site .button:focus,
 input[type=submit]:focus,
 input[type=reset]:focus,
@@ -2168,22 +2136,6 @@ input[type=reset]:hover,
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 	display: inline-block;
-}
-
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
 .wp-block-file .wp-block-file__button:focus {

--- a/style.css
+++ b/style.css
@@ -1726,38 +1726,6 @@ input[type=reset],
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.site .button:before,
-.site .button:after,
-input[type=submit]:before,
-input[type=submit]:after,
-input[type=reset]:before,
-input[type=reset]:after,
-.wp-block-search__button:before,
-.wp-block-search__button:after,
-.wp-block-button .wp-block-button__link:before,
-.wp-block-button .wp-block-button__link:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.site .button:before,
-input[type=submit]:before,
-input[type=reset]:before,
-.wp-block-search__button:before,
-.wp-block-button .wp-block-button__link:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.site .button:after,
-input[type=submit]:after,
-input[type=reset]:after,
-.wp-block-search__button:after,
-.wp-block-button .wp-block-button__link:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
-}
-
 .site .button:focus,
 input[type=submit]:focus,
 input[type=reset]:focus,
@@ -2178,22 +2146,6 @@ input[type=reset]:hover,
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 	display: inline-block;
-}
-
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
-	content: "";
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.wp-block-file .wp-block-file__button:before {
-	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
-}
-
-.wp-block-file .wp-block-file__button:after {
-	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
 .wp-block-file .wp-block-file__button:focus {


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/878

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
When a button block is added, the cursor needs to be visible to indicate that you can start entering the button text. 

If my understanding is correct, the crop-text mixin sets the content width to 0, and it means that the cursor is not visible.
https://github.com/WordPress/twentytwentyone/blob/trunk/assets/sass/02-tools/mixins.scss#L33

The crop-text mixin is only used for the buttons block.
The code comment does not seem to be accurate, or may have been accurate in a previous version of the theme:
"- Sets a fixed-width on content **within alignwide and alignfull blocks**"

I do not see any unexpected side effects in 5.5.3 or 5.6 RC when removing the mixin.
Other options would be:
**-Change the width of the content from 0 so that the cursor is shown correctly. I was not able to determine if this was viable because I do not know what problem the mixin is meant to solve.
-Only apply the mixin on the front, not the editor.**

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a button block
1. Confirm that the cursor is visible immediately.
1.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
![cursor](https://user-images.githubusercontent.com/7422055/100454138-9bc07b80-30bc-11eb-98f8-7501e47f2ddf.gif)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
