### PR TITLE
Update sub menu toggle position

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6812,7 +6812,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 1px solid #28303d;
+	outline: 2px solid #28303d;
 }
 @media only screen and (max-width: 481px) {
 

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -6812,7 +6812,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 2px solid #28303d;
+	outline: 1px solid #28303d;
 }
 @media only screen and (max-width: 481px) {
 
@@ -6969,7 +6969,7 @@ h1.page-title {
 	}
 
 	.primary-navigation .primary-menu-container > ul > .menu-item > a + .sub-menu-toggle {
-		margin-left: -13px;
+		margin-left: -8px;
 	}
 }
 

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -241,7 +241,7 @@
 			border: none;
 
 			&:focus {
-				outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+				outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
 			}
 
 			@include media(mobile-only) {
@@ -374,7 +374,7 @@
 					padding-right: var(--primary-nav--padding);
 
 					+ .sub-menu-toggle {
-						margin-left: calc(0px - var(--primary-nav--padding));
+						margin-left: calc(5px - var(--primary-nav--padding));
 					}
 				}
 			}

--- a/assets/sass/06-components/navigation.scss
+++ b/assets/sass/06-components/navigation.scss
@@ -241,7 +241,7 @@
 			border: none;
 
 			&:focus {
-				outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
+				outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 			}
 
 			@include media(mobile-only) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4885,7 +4885,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+	outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
 }
 @media only screen and (max-width: 481px) {
 
@@ -4999,7 +4999,7 @@ h1.page-title {
 	}
 
 	.primary-navigation .primary-menu-container > ul > .menu-item > a + .sub-menu-toggle {
-		margin-right: calc(0px - var(--primary-nav--padding));
+		margin-right: calc(5px - var(--primary-nav--padding));
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4885,7 +4885,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
+	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 }
 @media only screen and (max-width: 481px) {
 

--- a/style.css
+++ b/style.css
@@ -4905,7 +4905,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
+	outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
 }
 @media only screen and (max-width: 481px) {
 
@@ -5035,7 +5035,7 @@ h1.page-title {
 	}
 
 	.primary-navigation .primary-menu-container > ul > .menu-item > a + .sub-menu-toggle {
-		margin-left: calc(0px - var(--primary-nav--padding));
+		margin-left: calc(5px - var(--primary-nav--padding));
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -4905,7 +4905,7 @@ h1.page-title {
 }
 
 .primary-navigation > div > .menu-wrapper .sub-menu-toggle:focus {
-	outline: 1px solid var(--wp--style--color--link, var(--global--color-primary));
+	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 }
 @media only screen and (max-width: 481px) {
 


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/898

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Moves the button 5px to the right.
Reduces the outline thickness from 2 to 1px.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a menu with sub menus to the primary menu location
1. focus on the sub menu toggle button
1. click on the sub menu toggle button
1. Confirm that the text is readable
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots
Before:
![submenu-toggle](https://user-images.githubusercontent.com/7422055/100580727-c55ceb00-32e6-11eb-987f-08090ccd8096.png)



After
![toggle-after3](https://user-images.githubusercontent.com/7422055/100580646-9fcfe180-32e6-11eb-912c-4538b3687090.png)
![toggle-after2](https://user-images.githubusercontent.com/7422055/100580651-a1010e80-32e6-11eb-9379-c0417bcb3839.png)
![toggle-after](https://user-images.githubusercontent.com/7422055/100580653-a1010e80-32e6-11eb-8d7f-70549734bee3.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
