### PR TITLE
Fix JavaScript error when the responsive menu is toggled

### DIFF
--- a/assets/js/primary-navigation.js
+++ b/assets/js/primary-navigation.js
@@ -41,10 +41,19 @@ function twentytwentyoneCollapseMenuOnClickOutside( event ) {
  */
 function twentytwentyoneSubmenuPosition( li ) {
 	var subMenu = li.querySelector( 'ul.sub-menu' ),
-		rect = subMenu.getBoundingClientRect(),
-		right = Math.round( rect.right ),
-		left = Math.round( rect.left ),
-		windowWidth = Math.round( window.innerWidth );
+		rect,
+		right,
+		left,
+		windowWidth;
+
+	if ( ! subMenu ) {
+		return;
+	}
+
+	rect = subMenu.getBoundingClientRect();
+	right = Math.round( rect.right );
+	left = Math.round( rect.left );
+	windowWidth = Math.round( window.innerWidth );
 
 	if ( right > windowWidth ) {
 		subMenu.classList.add( 'submenu-reposition-right' );


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/900

## Summary
<!-- Explain what you changed and why in one or two sentences. -->
Check if subMenu exists before using it.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a menu with sub menus.  Place the sub-menus last and make the menu item text long.
1. View the front.
1. Confirm that sub menus do not go off screen horizontally ( We test this because the code that solved this problem was changed in this PR).
1.  Reduce the window width
1. Toggle the sub menu.
1. Confirm that there are no JS errors.
<!-- Don't forget to test the unhappy-paths! -->


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
