### PR TITLE
Gradients: Add position values to gradients

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -272,42 +272,42 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 			array(
 				array(
 					'name'     => esc_html__( 'Purple to yellow', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $purple . ', ' . $yellow . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $purple . ' 0%, ' . $yellow . ' 100%)',
 					'slug'     => 'purple-to-yellow',
 				),
 				array(
 					'name'     => esc_html__( 'Yellow to purple', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $purple . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $yellow . ' 0%, ' . $purple . ' 100%)',
 					'slug'     => 'yellow-to-purple',
 				),
 				array(
 					'name'     => esc_html__( 'Green to yellow', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $green . ', ' . $yellow . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $green . ' 0%, ' . $yellow . ' 100%)',
 					'slug'     => 'green-to-yellow',
 				),
 				array(
 					'name'     => esc_html__( 'Yellow to green', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $green . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $yellow . ' 0%, ' . $green . ' 100%)',
 					'slug'     => 'yellow-to-green',
 				),
 				array(
 					'name'     => esc_html__( 'Red to yellow', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $red . ', ' . $yellow . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $red . ' 0%, ' . $yellow . ' 100%)',
 					'slug'     => 'red-to-yellow',
 				),
 				array(
 					'name'     => esc_html__( 'Yellow to red', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $red . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $yellow . ' 0%, ' . $red . ' 100%)',
 					'slug'     => 'yellow-to-red',
 				),
 				array(
 					'name'     => esc_html__( 'Purple to red', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $purple . ', ' . $red . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $purple . ' 0%, ' . $red . ' 100%)',
 					'slug'     => 'purple-to-red',
 				),
 				array(
 					'name'     => esc_html__( 'Red to purple', 'twentytwentyone' ),
-					'gradient' => 'linear-gradient(160deg, ' . $red . ', ' . $purple . ')',
+					'gradient' => 'linear-gradient(160deg, ' . $red . ' 0%, ' . $purple . ' 100%)',
 					'slug'     => 'red-to-purple',
 				),
 			)


### PR DESCRIPTION
While not required by CSS, the editor uses the position values in `linear-gradient` to set the control points in the gradient picker. This PR adds the default control points (0%, 100%) explicitly, so that the editor doesn't crash trying to use them. 

(an upstream fix could be made to understand these implicit defaults, but it wouldn't ship in 5.6.)

Fixes #903.

## Test instructions

This PR can be tested by following these steps:
1. Add any block that supports gradient background colors (for example, Group)
2. Set a gradient background
3. Try editing the gradient- move a control point, add another, change the angle…
4. You should be able to do all of the above without the block crashing

## Screenshots

| Before (no control points) | After (gradient editor highlighted) |
|---------------------------|--------------------|
| ![Screen Shot 2020-11-30 at 11 27 17 AM](https://user-images.githubusercontent.com/541093/100635841-02cd7280-32ff-11eb-9164-54ba1bae276e.png) | ![Screen Shot 2020-11-30 at 11 24 15 AM](https://user-images.githubusercontent.com/541093/100635679-cbf75c80-32fe-11eb-9ef5-28c0db7ee115.png) |

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
