### PR TITLE
Update search block focus style

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4778,6 +4778,11 @@ pre.wp-block-preformatted {
 	color: #39414d;
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline: 2px dotted #39414d;
+	outline-offset: -5px;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: 15px 30px;
 }

--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4778,6 +4778,10 @@ pre.wp-block-preformatted {
 	color: #39414d;
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+	margin-right: 0;
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
 	outline: 2px dotted #39414d;
 	outline-offset: -5px;

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -113,6 +113,11 @@
 
 	&.wp-block-search__button-inside {
 
+		.wp-block-search__inside-wrapper .wp-block-search__input:focus {
+			outline: 2px dotted var(--form--border-color);
+			outline-offset: -5px;
+		}
+
 		&.wp-block-search__text-button {
 
 			button.wp-block-search__button {

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -113,9 +113,13 @@
 
 	&.wp-block-search__button-inside {
 
-		.wp-block-search__inside-wrapper .wp-block-search__input:focus {
-			outline: 2px dotted var(--form--border-color);
-			outline-offset: -5px;
+		.wp-block-search__inside-wrapper .wp-block-search__input {
+			margin-right: 0;
+
+			&:focus {
+				outline: 2px dotted var(--form--border-color);
+				outline-offset: -5px;
+			}
 		}
 
 		&.wp-block-search__text-button {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3359,6 +3359,10 @@ pre.wp-block-preformatted {
 	color: var(--button--color-background);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+	margin-left: 0;
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
 	outline: 2px dotted var(--form--border-color);
 	outline-offset: -5px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3359,6 +3359,11 @@ pre.wp-block-preformatted {
 	color: var(--button--color-background);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline: 2px dotted var(--form--border-color);
+	outline-offset: -5px;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }

--- a/style.css
+++ b/style.css
@@ -3369,6 +3369,11 @@ pre.wp-block-preformatted {
 	color: var(--button--color-background);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline: 2px dotted var(--form--border-color);
+	outline-offset: -5px;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }

--- a/style.css
+++ b/style.css
@@ -3369,6 +3369,10 @@ pre.wp-block-preformatted {
 	color: var(--button--color-background);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+	margin-right: 0;
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
 	outline: 2px dotted var(--form--border-color);
 	outline-offset: -5px;


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes https://github.com/WordPress/twentytwentyone/issues/908

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

When the button is placed inside:
Overrides the `outline: none`. Adjusts the offset from 7 to 5 so that it matches the button, and takes the border change in 
https://github.com/WordPress/twentytwentyone/pull/886 in consideration.

The padding(?) here makes this style less than ideal ( **OK, its really ugly** ), but there needs to be a visible focus indicator.

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Add a default search block. Duplicate it.
1. Select the button inside option
1. Duplicate the block and select the icon only, button inside options.
1. Go to the front.
1. Place focus on the blocks. Compare the focus style for the 3 blocks.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

Top: Default, with focus styles. 
Bottom: Button inside, with focus styles.

Both the input and the button is in focus here using browser dev tools, to show how the dotted outline aligns.

![search-focus-indicator-after gif](https://user-images.githubusercontent.com/7422055/100749839-7e095400-33e5-11eb-91d1-c93a65e1701b.png)

## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
