### PR TITLE
Dark mode: Update the color of the focus outline in the search block 

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -4789,6 +4789,10 @@ pre.wp-block-preformatted {
 	outline-offset: -5px;
 }
 
+.is-dark-theme .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline-color: currentColor;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: 15px 30px;
 }

--- a/assets/sass/05-blocks/search/_style.scss
+++ b/assets/sass/05-blocks/search/_style.scss
@@ -117,6 +117,10 @@
 				&:focus {
 					outline: 2px dotted var(--form--border-color);
 					outline-offset: -5px;
+
+					.is-dark-theme & {
+						outline-color: currentColor;
+					}
 				}
 			}
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3370,6 +3370,10 @@ pre.wp-block-preformatted {
 	outline-offset: -5px;
 }
 
+.is-dark-theme .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline-color: currentColor;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }

--- a/style.css
+++ b/style.css
@@ -3380,6 +3380,10 @@ pre.wp-block-preformatted {
 	outline-offset: -5px;
 }
 
+.is-dark-theme .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input:focus {
+	outline-color: currentColor;
+}
+
 .wp-block-search.wp-block-search__button-inside.wp-block-search__text-button button.wp-block-search__button {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }


### PR DESCRIPTION
<!-- Add reference to the issue this pull-request fixes.-->
Fixes the outline color for the search block with button inside, when dark mode is enabled.

## Summary
<!-- Explain what you changed and why in one or two sentences. -->

## Relevant technical choices:
<!-- Are there any technical choices that affect more than this issue? If so, please explain why you made them.-->

## Test instructions

This PR can be tested by following these steps:
1. Enable dark mode
1. Add a search block. Enable the option "button inside.
1. Save and view the front.
1. Focus on the input field.
1. Confirm that the focus outline for the field is visible.
<!-- Don't forget to test the unhappy-paths! -->

## Screenshots

![image](https://user-images.githubusercontent.com/7422055/100776170-81f89e80-3404-11eb-8384-132cb834a68b.png)


## Quality assurance
* [x] I have thought about any security implications this code might add.
* [x] I have checked that this code doesn't impact performance (greatly).
* [x] I have tested this code to the best of my abilities
* [x] I have checked that this code does not affect the accessibility negatively
